### PR TITLE
Added: Cleaned Data for Visualization

### DIFF
--- a/data/preprocessed/clean_data.csv
+++ b/data/preprocessed/clean_data.csv
@@ -1,0 +1,10841 @@
+App,Category,Rating,Reviews,Size,Installs,Type,Price,Content Rating,Genres
+Photo Editor & Candy Camera & Grid & ScrapBook,ART_AND_DESIGN,4.1,159,19M,10000,Free,0,Everyone,Art & Design
+Coloring book moana,ART_AND_DESIGN,3.9,967,14M,500000,Free,0,Everyone,Art & Design;Pretend Play
+"U Launcher Lite – FREE Live Cool Themes, Hide Apps",ART_AND_DESIGN,4.7,87510,8.7M,5000000,Free,0,Everyone,Art & Design
+Sketch - Draw & Paint,ART_AND_DESIGN,4.5,215644,25M,50000000,Free,0,Teen,Art & Design
+Pixel Draw - Number Art Coloring Book,ART_AND_DESIGN,4.3,967,2.8M,100000,Free,0,Everyone,Art & Design;Creativity
+Paper flowers instructions,ART_AND_DESIGN,4.4,167,5.6M,50000,Free,0,Everyone,Art & Design
+Smoke Effect Photo Maker - Smoke Editor,ART_AND_DESIGN,3.8,178,19M,50000,Free,0,Everyone,Art & Design
+Infinite Painter,ART_AND_DESIGN,4.1,36815,29M,1000000,Free,0,Everyone,Art & Design
+Garden Coloring Book,ART_AND_DESIGN,4.4,13791,33M,1000000,Free,0,Everyone,Art & Design
+Kids Paint Free - Drawing Fun,ART_AND_DESIGN,4.7,121,3.1M,10000,Free,0,Everyone,Art & Design;Creativity
+Text on Photo - Fonteee,ART_AND_DESIGN,4.4,13880,28M,1000000,Free,0,Everyone,Art & Design
+Name Art Photo Editor - Focus n Filters,ART_AND_DESIGN,4.4,8788,12M,1000000,Free,0,Everyone,Art & Design
+Tattoo Name On My Photo Editor,ART_AND_DESIGN,4.2,44829,20M,10000000,Free,0,Teen,Art & Design
+Mandala Coloring Book,ART_AND_DESIGN,4.6,4326,21M,100000,Free,0,Everyone,Art & Design
+3D Color Pixel by Number - Sandbox Art Coloring,ART_AND_DESIGN,4.4,1518,37M,100000,Free,0,Everyone,Art & Design
+Learn To Draw Kawaii Characters,ART_AND_DESIGN,3.2,55,2.7M,5000,Free,0,Everyone,Art & Design
+Photo Designer - Write your name with shapes,ART_AND_DESIGN,4.7,3632,5.5M,500000,Free,0,Everyone,Art & Design
+350 Diy Room Decor Ideas,ART_AND_DESIGN,4.5,27,17M,10000,Free,0,Everyone,Art & Design
+FlipaClip - Cartoon animation,ART_AND_DESIGN,4.3,194216,39M,5000000,Free,0,Everyone,Art & Design
+ibis Paint X,ART_AND_DESIGN,4.6,224399,31M,10000000,Free,0,Everyone,Art & Design
+Logo Maker - Small Business,ART_AND_DESIGN,4.0,450,14M,100000,Free,0,Everyone,Art & Design
+Boys Photo Editor - Six Pack & Men's Suit,ART_AND_DESIGN,4.1,654,12M,100000,Free,0,Everyone,Art & Design
+Superheroes Wallpapers | 4K Backgrounds,ART_AND_DESIGN,4.7,7699,4.2M,500000,Free,0,Everyone 10+,Art & Design
+Mcqueen Coloring pages,ART_AND_DESIGN,4.4,61,7.0M,100000,Free,0,Everyone,Art & Design;Action & Adventure
+HD Mickey Minnie Wallpapers,ART_AND_DESIGN,4.7,118,23M,50000,Free,0,Everyone,Art & Design
+Harley Quinn wallpapers HD,ART_AND_DESIGN,4.8,192,6.0M,10000,Free,0,Everyone,Art & Design
+Colorfit - Drawing & Coloring,ART_AND_DESIGN,4.7,20260,25M,500000,Free,0,Everyone,Art & Design;Creativity
+Animated Photo Editor,ART_AND_DESIGN,4.1,203,6.1M,100000,Free,0,Everyone,Art & Design
+Pencil Sketch Drawing,ART_AND_DESIGN,3.9,136,4.6M,10000,Free,0,Everyone,Art & Design
+Easy Realistic Drawing Tutorial,ART_AND_DESIGN,4.1,223,4.2M,100000,Free,0,Everyone,Art & Design
+Pink Silver Bow Keyboard Theme,ART_AND_DESIGN,4.2,1120,9.2M,100000,Free,0,Everyone,Art & Design
+Art Drawing Ideas,ART_AND_DESIGN,4.1,227,5.2M,50000,Free,0,Everyone,Art & Design
+Anime Manga Coloring Book,ART_AND_DESIGN,4.5,5035,11M,100000,Free,0,Everyone,Art & Design
+Easy Origami Ideas,ART_AND_DESIGN,4.2,1015,11M,100000,Free,0,Everyone,Art & Design
+I Creative Idea,ART_AND_DESIGN,4.7,353,4.2M,10000,Free,0,Teen,Art & Design
+How to draw Ladybug and Cat Noir,ART_AND_DESIGN,3.8,564,9.2M,100000,Free,0,Everyone,Art & Design
+UNICORN - Color By Number & Pixel Art Coloring,ART_AND_DESIGN,4.7,8145,24M,500000,Free,0,Everyone,Art & Design;Creativity
+Floor Plan Creator,ART_AND_DESIGN,4.1,36639,Varies with device,5000000,Free,0,Everyone,Art & Design
+PIP Camera - PIP Collage Maker,ART_AND_DESIGN,4.7,158,11M,10000,Free,0,Everyone,Art & Design
+How To Color Disney Princess - Coloring Pages,ART_AND_DESIGN,4.0,591,9.4M,500000,Free,0,Everyone,Art & Design
+Drawing Clothes Fashion Ideas,ART_AND_DESIGN,4.2,117,15M,10000,Free,0,Everyone,Art & Design
+Sad Poetry Photo Frames 2018,ART_AND_DESIGN,4.5,176,10M,100000,Free,0,Everyone,Art & Design
+Textgram - write on photos,ART_AND_DESIGN,4.4,295221,Varies with device,10000000,Free,0,Everyone,Art & Design
+Paint Splash!,ART_AND_DESIGN,3.8,2206,1.2M,100000,Free,0,Everyone,Art & Design;Creativity
+Popsicle Sticks and Similar DIY Craft Ideas,ART_AND_DESIGN,4.2,26,12M,10000,Free,0,Everyone,Art & Design
+"Canva: Poster, banner, card maker & graphic design",ART_AND_DESIGN,4.7,174531,24M,10000000,Free,0,Everyone,Art & Design
+Install images with music to make video without Net - 2018,ART_AND_DESIGN,4.6,1070,26M,100000,Free,0,Everyone,Art & Design
+Little Teddy Bear Colouring Book Game,ART_AND_DESIGN,4.2,85,8.0M,100000,Free,0,Everyone,Art & Design
+How To Draw Food,ART_AND_DESIGN,4.3,845,7.9M,100000,Free,0,Everyone,Art & Design
+Monster Truck Stunt 3D 2019,AUTO_AND_VEHICLES,4.2,367,25M,100000,Free,0,Everyone,Auto & Vehicles
+Real Tractor Farming,AUTO_AND_VEHICLES,4.0,1598,56M,1000000,Free,0,Everyone,Auto & Vehicles
+Ultimate F1 Racing Championship,AUTO_AND_VEHICLES,3.8,284,57M,100000,Free,0,Everyone,Auto & Vehicles
+Used Cars and Trucks for Sale,AUTO_AND_VEHICLES,4.6,17057,Varies with device,1000000,Free,0,Everyone,Auto & Vehicles
+American Muscle Car Race,AUTO_AND_VEHICLES,3.9,129,35M,100000,Free,0,Everyone,Auto & Vehicles
+Offroad Oil Tanker Driver Transport Truck 2019,AUTO_AND_VEHICLES,4.3,542,33M,100000,Free,0,Everyone,Auto & Vehicles
+Tickets SDA 2018 and Exam from the State Traffic Safety Inspectorate with Drom.ru,AUTO_AND_VEHICLES,4.9,10479,33M,100000,Free,0,Everyone,Auto & Vehicles
+Gas Prices (Germany only),AUTO_AND_VEHICLES,4.4,805,5.6M,50000,Free,0,Everyone,Auto & Vehicles
+Extreme Rally Championship,AUTO_AND_VEHICLES,4.2,129,54M,100000,Free,0,Everyone,Auto & Vehicles
+Restart Navigator,AUTO_AND_VEHICLES,4.0,1403,201k,100000,Free,0,Everyone,Auto & Vehicles
+"REG - Check the regnumber, find information about Swedish vehicles",AUTO_AND_VEHICLES,3.9,3971,3.6M,100000,Free,0,Everyone,Auto & Vehicles
+CityBus Lviv,AUTO_AND_VEHICLES,4.6,534,5.7M,10000,Free,0,Everyone,Auto & Vehicles
+CDL Practice Test 2018 Edition,AUTO_AND_VEHICLES,4.9,7774,17M,100000,Free,0,Everyone,Auto & Vehicles
+"ezETC (ETC balance inquiry, meter trial, real-time traffic)",AUTO_AND_VEHICLES,4.3,38846,8.6M,1000000,Free,0,Everyone,Auto & Vehicles
+Free VIN Report for Used Cars,AUTO_AND_VEHICLES,4.6,2431,2.4M,100000,Free,0,Everyone,Auto & Vehicles
+DMV Permit Practice Test 2018 Edition,AUTO_AND_VEHICLES,4.9,6090,27M,100000,Free,0,Everyone,Auto & Vehicles
+Check Vehicle Tax,AUTO_AND_VEHICLES,3.9,295,2.7M,10000,Free,0,Everyone,Auto & Vehicles
+Used Cars Mexico,AUTO_AND_VEHICLES,4.0,190,2.5M,50000,Free,0,Everyone,Auto & Vehicles
+Ulysse Speedometer,AUTO_AND_VEHICLES,4.3,40211,Varies with device,5000000,Free,0,Everyone,Auto & Vehicles
+REPUVE,AUTO_AND_VEHICLES,3.9,356,Varies with device,100000,Free,0,Everyone,Auto & Vehicles
+Used cars for sale - Trovit,AUTO_AND_VEHICLES,4.2,52530,7.0M,5000000,Free,0,Everyone,Auto & Vehicles
+"Fines of the State Traffic Safety Inspectorate are official: inspection, payment of fines",AUTO_AND_VEHICLES,4.8,116986,35M,5000000,Free,0,Everyone,Auto & Vehicles
+SK Enca Direct Malls - Used Cars Search,AUTO_AND_VEHICLES,3.6,1379,16M,500000,Free,0,Everyone,Auto & Vehicles
+"Android Auto - Maps, Media, Messaging & Voice",AUTO_AND_VEHICLES,4.2,271920,16M,10000000,Free,0,Teen,Auto & Vehicles
+PDD-UA,AUTO_AND_VEHICLES,4.8,736,Varies with device,100000,Free,0,Everyone,Auto & Vehicles
+Tickets SDA 2019 + Exam RF,AUTO_AND_VEHICLES,4.8,7021,17M,500000,Free,0,Everyone,Auto & Vehicles
+Super Cars Wallpapers And Backgrounds,AUTO_AND_VEHICLES,4.6,197,3.4M,50000,Free,0,Everyone,Auto & Vehicles
+"Police Lights, Sirens & Follow Me",AUTO_AND_VEHICLES,4.5,737,8.9M,100000,Free,0,Everyone,Auto & Vehicles
+Police Detector (Speed Camera Radar),AUTO_AND_VEHICLES,4.3,3574,3.9M,1000000,Free,0,Everyone 10+,Auto & Vehicles
+Best Car Wallpapers,AUTO_AND_VEHICLES,4.5,994,2.9M,100000,Free,0,Everyone,Auto & Vehicles
+Tickets + PDA 2018 Exam,AUTO_AND_VEHICLES,4.9,197136,38M,1000000,Free,0,Everyone,Auto & Vehicles
+Pick Your Part Garage,AUTO_AND_VEHICLES,3.9,142,32M,50000,Free,0,Everyone,Auto & Vehicles
+PakWheels: Buy & Sell Cars,AUTO_AND_VEHICLES,4.4,15168,37M,1000000,Free,0,Everyone,Auto & Vehicles
+Supervision service,AUTO_AND_VEHICLES,4.0,2155,15M,500000,Free,0,Everyone,Auto & Vehicles
+Speed Camera Detector - Traffic & Speed Alert,AUTO_AND_VEHICLES,4.3,138,5.4M,100000,Free,0,Everyone,Auto & Vehicles
+Used car search Goo net whole car Go to net,AUTO_AND_VEHICLES,3.7,5414,18M,1000000,Free,0,Everyone,Auto & Vehicles
+CarMax – Cars for Sale: Search Used Car Inventory,AUTO_AND_VEHICLES,4.4,21777,Varies with device,1000000,Free,0,Everyone,Auto & Vehicles
+BEST CAR SOUNDS,AUTO_AND_VEHICLES,4.3,348,38M,100000,Free,0,Everyone,Auto & Vehicles
+RST - Sale of cars on the PCT,AUTO_AND_VEHICLES,3.2,250,1.1M,100000,Free,0,Everyone,Auto & Vehicles
+AutoScout24 Switzerland – Find your new car,AUTO_AND_VEHICLES,4.6,13372,Varies with device,1000000,Free,0,Everyone,Auto & Vehicles
+Zona Azul Digital Fácil SP CET - OFFICIAL São Paulo,AUTO_AND_VEHICLES,4.6,7880,Varies with device,100000,Free,0,Everyone,Auto & Vehicles
+SMS Park,AUTO_AND_VEHICLES,4.5,3617,7.9M,100000,Free,0,Everyone,Auto & Vehicles
+SKencar,AUTO_AND_VEHICLES,3.7,4806,35M,1000000,Free,0,Everyone,Auto & Vehicles
+Fuelio: Gas log & costs,AUTO_AND_VEHICLES,4.6,65786,Varies with device,1000000,Free,0,Everyone,Auto & Vehicles
+auto fines,AUTO_AND_VEHICLES,4.6,31433,17M,1000000,Free,0,Everyone,Auto & Vehicles
+"Used car is the first car - used car purchase, used car quotation, dealer information to",AUTO_AND_VEHICLES,4.6,5097,19M,1000000,Free,0,Everyone,Auto & Vehicles
+All of the parking lot - National Park application (parking lot search / parking sharing / discount payment),AUTO_AND_VEHICLES,4.0,1754,14M,500000,Free,0,Everyone,Auto & Vehicles
+Inquiry Fines and Debits of Vehicles,AUTO_AND_VEHICLES,4.4,2680,2.2M,500000,Free,0,Everyone,Auto & Vehicles
+Gas Station,AUTO_AND_VEHICLES,4.0,1288,4.5M,100000,Free,0,Everyone,Auto & Vehicles
+Hush - Beauty for Everyone,BEAUTY,4.7,18900,17M,500000,Free,0,Everyone,Beauty
+"ipsy: Makeup, Beauty, and Tips",BEAUTY,4.9,49790,14M,1000000,Free,0,Everyone,Beauty
+Natural recipes for your beauty,BEAUTY,4.7,1150,9.8M,100000,Free,0,Everyone,Beauty
+"BestCam Selfie-selfie, beauty camera, photo editor",BEAUTY,3.9,1739,21M,500000,Free,0,Everyone,Beauty
+Mirror - Zoom & Exposure -,BEAUTY,3.9,32090,Varies with device,1000000,Free,0,Everyone,Beauty
+Beauty Selfie Camera,BEAUTY,4.2,2225,52M,500000,Free,0,Everyone,Beauty
+Hairstyles step by step,BEAUTY,4.6,4369,14M,100000,Free,0,Everyone,Beauty
+Filters for Selfie,BEAUTY,4.3,8572,25M,1000000,Free,0,Everyone,Beauty
+Tie - Always be happy,BEAUTY,4.7,964,9.0M,50000,Free,0,Everyone,Beauty
+Ulta Beauty,BEAUTY,4.7,42050,Varies with device,1000000,Free,0,Everyone,Beauty
+Prom MakeUp Tutorial,BEAUTY,4.8,104,12M,10000,Free,0,Everyone,Beauty
+Selfie Camera,BEAUTY,4.2,17934,Varies with device,1000000,Free,0,Everyone,Beauty
+Sweet Selfie Beauty Camera,BEAUTY,4.3,601,35M,100000,Free,0,Everyone,Beauty
+Colors of white in Urdu,BEAUTY,4.5,36,6.7M,10000,Free,0,Everyone,Beauty
+Selfie Camera Photo Editor & Filter & Sticker,BEAUTY,4.1,187,30M,50000,Free,0,Teen,Beauty
+Wrinkles and rejuvenation,BEAUTY,4.3,182,5.7M,100000,Free,0,Everyone 10+,Beauty
+Eyes Makeup Beauty Tips,BEAUTY,4.2,30,2.9M,10000,Free,0,Everyone,Beauty
+Photo Editor 2018,BEAUTY,4.5,134,17M,10000,Free,0,Everyone,Beauty
+Step By Step Eyes Makeup Tutorial,BEAUTY,4.4,74,2.9M,10000,Free,0,Everyone,Beauty
+Beauty Camera - Selfie Camera,BEAUTY,4.0,113715,Varies with device,10000000,Free,0,Everyone,Beauty
+Girls Hairstyles,BEAUTY,4.1,3595,Varies with device,500000,Free,0,Everyone,Beauty
+Mirror Camera (Mirror + Selfie Camera),BEAUTY,4.1,9315,2.6M,1000000,Free,0,Everyone,Beauty
+Beauty Tips - Beauty Tips in Sinhala,BEAUTY,4.4,75,4.2M,50000,Free,0,Everyone,Beauty
+Haircut Tutorials/Haircut Videos,BEAUTY,4.6,38,7.1M,10000,Free,0,Everyone,Beauty
+"Sephora: Skin Care, Beauty Makeup & Fragrance Shop",BEAUTY,4.5,26834,57M,1000000,Free,0,Everyone,Beauty
+Manicure - nail design,BEAUTY,4.3,119,3.7M,50000,Free,0,Everyone,Beauty
+"Sticker Camera - Selfie Filters, Beauty Camera",BEAUTY,3.9,2277,22M,500000,Free,0,Everyone,Beauty
+Filters for B Live,BEAUTY,4.4,2280,24M,500000,Free,0,Everyone,Beauty
+Skin Care and Natural Beauty,BEAUTY,4.3,654,7.4M,100000,Free,0,Teen,Beauty
+Facial Wrinkle Reduction,BEAUTY,4.6,184,21M,10000,Free,0,Everyone,Beauty
+Makeup Videos,BEAUTY,3.8,9,3.4M,5000,Free,0,Everyone,Beauty
+"Secrets of beauty, youth and health",BEAUTY,4.3,77,2.9M,10000,Free,0,Mature 17+,Beauty
+Recipes and tips for losing weight,BEAUTY,4.3,35,3.1M,10000,Free,0,Everyone 10+,Beauty
+Discover Color,BEAUTY,4.0,364,6.4M,100000,Free,0,Everyone,Beauty
+Eyeliner step by step 2018,BEAUTY,4.3,18,3.2M,5000,Free,0,Everyone,Beauty
+Dresses Ideas & Fashions +3000,BEAUTY,4.5,473,8.2M,100000,Free,0,Mature 17+,Beauty
+"Lady adviser (beauty, health)",BEAUTY,4.3,30,9.9M,10000,Free,0,Mature 17+,Beauty
+Step By Step Hairstyles For Women,BEAUTY,4.1,66,2.9M,10000,Free,0,Everyone,Beauty
+Rainbow Camera,BEAUTY,3.7,3871,23M,1000000,Free,0,Everyone,Beauty
+Methods of teeth whitening,BEAUTY,4.7,257,4.6M,50000,Free,0,Everyone,Beauty
+Girls hairstyles 2018,BEAUTY,4.2,62,3.1M,10000,Free,0,Everyone,Beauty
+Wattpad 📖 Free Books,BOOKS_AND_REFERENCE,4.6,2914724,Varies with device,100000000,Free,0,Teen,Books & Reference
+E-Book Read - Read Book for free,BOOKS_AND_REFERENCE,4.5,1857,4.9M,50000,Free,0,Everyone,Books & Reference
+Download free book with green book,BOOKS_AND_REFERENCE,4.6,4478,9.5M,100000,Free,0,Everyone 10+,Books & Reference
+Wikipedia,BOOKS_AND_REFERENCE,4.4,577550,Varies with device,10000000,Free,0,Everyone,Books & Reference
+Amazon Kindle,BOOKS_AND_REFERENCE,4.2,814080,Varies with device,100000000,Free,0,Teen,Books & Reference
+Cool Reader,BOOKS_AND_REFERENCE,4.5,246315,Varies with device,10000000,Free,0,Everyone,Books & Reference
+Dictionary - Merriam-Webster,BOOKS_AND_REFERENCE,4.5,454060,Varies with device,10000000,Free,0,Everyone,Books & Reference
+NOOK: Read eBooks & Magazines,BOOKS_AND_REFERENCE,4.5,155446,Varies with device,10000000,Free,0,Teen,Books & Reference
+Free Panda Radio Music,BOOKS_AND_REFERENCE,4.5,418,4.2M,100000,Free,0,Everyone,Books & Reference
+Book store,BOOKS_AND_REFERENCE,4.4,22486,5.4M,1000000,Free,0,Teen,Books & Reference
+FBReader: Favorite Book Reader,BOOKS_AND_REFERENCE,4.5,203130,Varies with device,10000000,Free,0,Everyone,Books & Reference
+English Grammar Complete Handbook,BOOKS_AND_REFERENCE,4.6,1435,2.8M,500000,Free,0,Everyone,Books & Reference
+Free Books - Spirit Fanfiction and Stories,BOOKS_AND_REFERENCE,4.8,116507,5.0M,1000000,Free,0,Teen,Books & Reference
+Google Play Books,BOOKS_AND_REFERENCE,3.9,1433233,Varies with device,1000000000,Free,0,Teen,Books & Reference
+AlReader -any text book reader,BOOKS_AND_REFERENCE,4.6,90468,5.9M,5000000,Free,0,Everyone,Books & Reference
+Offline English Dictionary,BOOKS_AND_REFERENCE,4.2,860,13M,100000,Free,0,Everyone,Books & Reference
+Oxford Dictionary of English : Free,BOOKS_AND_REFERENCE,4.1,363934,7.1M,10000000,Free,0,Everyone,Books & Reference
+Offline: English to Tagalog Dictionary,BOOKS_AND_REFERENCE,4.7,967,6.7M,500000,Free,0,Everyone,Books & Reference
+Spanish English Translator,BOOKS_AND_REFERENCE,4.2,87873,Varies with device,10000000,Free,0,Teen,Books & Reference
+FamilySearch Tree,BOOKS_AND_REFERENCE,4.3,17506,17M,1000000,Free,0,Everyone,Books & Reference
+Cloud of Books,BOOKS_AND_REFERENCE,3.3,1862,19M,1000000,Free,0,Everyone,Books & Reference
+Recipes of Prophetic Medicine for free,BOOKS_AND_REFERENCE,4.6,2084,6.7M,500000,Free,0,Everyone,Books & Reference
+ReadEra – free ebook reader,BOOKS_AND_REFERENCE,4.8,47303,21M,1000000,Free,0,Everyone,Books & Reference
+NOOK App for NOOK Devices,BOOKS_AND_REFERENCE,4.7,19080,Varies with device,500000,Free,0,Everyone,Books & Reference
+Anonymous caller detection,BOOKS_AND_REFERENCE,4.3,161,2.7M,10000,Free,0,Everyone,Books & Reference
+Ebook Reader,BOOKS_AND_REFERENCE,4.1,85842,37M,5000000,Free,0,Everyone,Books & Reference
+Litnet - E-books,BOOKS_AND_REFERENCE,4.6,7831,15M,100000,Free,0,Teen,Books & Reference
+Read books online,BOOKS_AND_REFERENCE,4.1,91615,23M,5000000,Free,0,Mature 17+,Books & Reference
+English to Urdu Dictionary,BOOKS_AND_REFERENCE,4.6,4620,19M,500000,Free,0,Everyone,Books & Reference
+eBoox: book reader fb2 epub zip,BOOKS_AND_REFERENCE,4.7,21336,23M,1000000,Free,0,Everyone,Books & Reference
+English Persian Dictionary,BOOKS_AND_REFERENCE,4.5,26875,73M,500000,Free,0,Everyone,Books & Reference
+Flybook,BOOKS_AND_REFERENCE,3.9,1778,4.9M,500000,Free,0,Mature 17+,Books & Reference
+All Maths Formulas,BOOKS_AND_REFERENCE,4.4,2709,6.8M,1000000,Free,0,Everyone,Books & Reference
+Ancestry,BOOKS_AND_REFERENCE,4.3,64513,Varies with device,5000000,Free,0,Everyone,Books & Reference
+HTC Help,BOOKS_AND_REFERENCE,4.2,8342,Varies with device,10000000,Free,0,Everyone,Books & Reference
+English translation from Bengali,BOOKS_AND_REFERENCE,4.5,527,2.9M,100000,Free,0,Everyone,Books & Reference
+Pdf Book Download - Read Pdf Book,BOOKS_AND_REFERENCE,4.4,1322,3.5M,100000,Free,0,Everyone,Books & Reference
+Free Book Reader,BOOKS_AND_REFERENCE,3.4,1680,4.0M,100000,Free,0,Everyone,Books & Reference
+eBoox new: Reader for fb2 epub zip books,BOOKS_AND_REFERENCE,4.9,2739,21M,50000,Free,0,Everyone,Books & Reference
+"Only 30 days in English, the guideline is guaranteed",BOOKS_AND_REFERENCE,4.6,1065,2.3M,500000,Free,0,Everyone,Books & Reference
+Moon+ Reader,BOOKS_AND_REFERENCE,4.4,233757,Varies with device,10000000,Free,0,Everyone,Books & Reference
+SH-02J Owner's Manual (Android 8.0),BOOKS_AND_REFERENCE,4.3,2,7.2M,50000,Free,0,Everyone,Books & Reference
+English-Myanmar Dictionary,BOOKS_AND_REFERENCE,4.4,8788,10M,1000000,Free,0,Everyone,Books & Reference
+Golden Dictionary (EN-AR),BOOKS_AND_REFERENCE,4.4,51269,6.1M,1000000,Free,0,Everyone,Books & Reference
+All Language Translator Free,BOOKS_AND_REFERENCE,4.4,30105,2.1M,1000000,Free,0,Everyone,Books & Reference
+Azpen eReader,BOOKS_AND_REFERENCE,3.5,156,42M,500000,Free,0,Everyone,Books & Reference
+URBANO V 02 instruction manual,BOOKS_AND_REFERENCE,4.3,114,7.3M,100000,Free,0,Everyone,Books & Reference
+English Dictionary - Offline,BOOKS_AND_REFERENCE,4.4,341157,30M,10000000,Free,0,Everyone 10+,Books & Reference
+Visual Voicemail by MetroPCS,BUSINESS,4.1,16129,Varies with device,10000000,Free,0,Everyone,Business
+Indeed Job Search,BUSINESS,4.3,674730,Varies with device,50000000,Free,0,Everyone,Business
+Uber Driver,BUSINESS,4.4,1254730,Varies with device,10000000,Free,0,Everyone,Business
+ADP Mobile Solutions,BUSINESS,4.3,85185,29M,5000000,Free,0,Everyone,Business
+Snag - Jobs Hiring Now,BUSINESS,4.3,32584,Varies with device,1000000,Free,0,Everyone,Business
+Docs To Go™ Free Office Suite,BUSINESS,4.1,217730,Varies with device,50000000,Free,0,Everyone,Business
+Google My Business,BUSINESS,4.4,70991,Varies with device,5000000,Free,0,Everyone,Business
+OfficeSuite : Free Office + PDF Editor,BUSINESS,4.3,1002861,35M,100000000,Free,0,Everyone,Business
+USPS MOBILE®,BUSINESS,3.9,16589,9.1M,1000000,Free,0,Everyone,Business
+Job Search by ZipRecruiter,BUSINESS,4.8,148945,25M,1000000,Free,0,Everyone,Business
+Curriculum vitae App CV Builder Free Resume Maker,BUSINESS,4.5,4458,3.9M,500000,Free,0,Everyone,Business
+Google Primer,BUSINESS,4.4,62272,18M,10000000,Free,0,Everyone,Business
+Alba Heaven - Alvarez Job Portal Services,BUSINESS,4.0,8941,12M,5000000,Free,0,Everyone,Business
+SuperLivePro,BUSINESS,4.3,46353,21M,1000000,Free,0,Everyone,Business
+Facebook Pages Manager,BUSINESS,4.0,1279184,Varies with device,50000000,Free,0,Everyone,Business
+OfficeSuite Pro + PDF (Trial),BUSINESS,4.2,88073,Varies with device,10000000,Free,0,Everyone,Business
+My Space - Employment Center,BUSINESS,4.5,67000,Varies with device,1000000,Free,0,Everyone,Business
+Box,BUSINESS,4.2,159872,Varies with device,10000000,Free,0,Everyone,Business
+Polaris Office for LG,BUSINESS,4.2,30847,55M,5000000,Free,0,Everyone,Business
+Call Blocker,BUSINESS,4.6,188841,3.2M,5000000,Free,0,Everyone,Business
+Jobs in Alabama - Jobs in Alba,BUSINESS,4.1,11622,Varies with device,5000000,Free,0,Everyone,Business
+Square Point of Sale - POS,BUSINESS,4.6,95912,Varies with device,5000000,Free,0,Everyone,Business
+Plugin:AOT v5.0,BUSINESS,3.1,4034,23k,100000,Free,0,Everyone,Business
+Kariyer.net,BUSINESS,3.9,45964,16M,1000000,Free,0,Everyone,Business
+SEEK Job Search,BUSINESS,4.3,14955,Varies with device,1000000,Free,0,Everyone,Business
+Become a Job - Find a job or advertise,BUSINESS,4.1,6903,14M,1000000,Free,0,Everyone,Business
+ZOOM Cloud Meetings,BUSINESS,4.4,31614,37M,10000000,Free,0,Everyone,Business
+Easy Installer - Apps On SD,BUSINESS,4.1,23055,Varies with device,5000000,Free,0,Everyone,Business
+Facebook Ads Manager,BUSINESS,4.1,19023,Varies with device,1000000,Free,0,Everyone,Business
+"IndiaMART: Search Products, Buy, Sell & Trade",BUSINESS,4.5,207372,11M,5000000,Free,0,Everyone,Business
+ViettelPost express delivery,BUSINESS,4.4,1225,25M,100000,Free,0,Everyone,Business
+MyASUS - Service Center,BUSINESS,4.4,380837,7.3M,10000000,Free,0,Everyone,Business
+Job Korea - Career Jobs,BUSINESS,4.3,10600,6.5M,1000000,Free,0,Everyone,Business
+"104 Looking for a job - looking for a job, looking for a job, looking for a part-time job, health checkup, resume, treatment room",BUSINESS,4.4,74359,25M,1000000,Free,0,Everyone,Business
+Myanmar 2D/3D,BUSINESS,4.6,822,3.1M,100000,Free,0,Everyone,Business
+Quick PDF Scanner + OCR FREE,BUSINESS,4.2,80805,Varies with device,5000000,Free,0,Everyone,Business
+sABN,BUSINESS,4.4,2287,1.5M,1000000,Free,0,Everyone,Business
+ATI Cargoes and Transportation,BUSINESS,4.7,4162,7.5M,100000,Free,0,Everyone,Business
+Secure Folder,BUSINESS,3.8,14760,8.6M,50000000,Free,0,Everyone,Business
+UPS Mobile,BUSINESS,3.9,23243,Varies with device,5000000,Free,0,Everyone,Business
+Y! Mobile menu,BUSINESS,4.1,9,1.2M,100000,Free,0,Everyone,Business
+SignEasy | Sign and Fill PDF and other Documents,BUSINESS,4.3,8978,Varies with device,1000000,Free,0,Everyone,Business
+Quick PDF Scanner + OCR FREE,BUSINESS,4.2,80805,Varies with device,5000000,Free,0,Everyone,Business
+Genius Scan - PDF Scanner,BUSINESS,4.4,42492,Varies with device,1000000,Free,0,Everyone,Business
+Tiny Scanner - PDF Scanner App,BUSINESS,4.7,286897,39M,10000000,Free,0,Everyone,Business
+Fast Scanner : Free PDF Scan,BUSINESS,4.5,103755,14M,10000000,Free,0,Everyone,Business
+Mobile Doc Scanner (MDScan) Lite,BUSINESS,4.2,46505,19M,1000000,Free,0,Everyone,Business
+TurboScan: scan documents and receipts in PDF,BUSINESS,4.7,11442,6.8M,100000,Paid,$4.99,Everyone,Business
+Tiny Scanner Pro: PDF Doc Scan,BUSINESS,4.8,10295,39M,100000,Paid,$4.99,Everyone,Business
+Box,BUSINESS,4.2,159872,Varies with device,10000000,Free,0,Everyone,Business
+Zenefits,BUSINESS,4.2,296,14M,50000,Free,0,Everyone,Business
+Google Ads,BUSINESS,4.3,29313,20M,5000000,Free,0,Everyone,Business
+Google My Business,BUSINESS,4.4,70991,Varies with device,5000000,Free,0,Everyone,Business
+Slack,BUSINESS,4.4,51507,Varies with device,5000000,Free,0,Everyone,Business
+FreshBooks Classic,BUSINESS,4.1,1802,26M,100000,Free,0,Everyone,Business
+Insightly CRM,BUSINESS,3.8,1383,51M,100000,Free,0,Everyone,Business
+QuickBooks Accounting: Invoicing & Expenses,BUSINESS,4.3,23175,41M,1000000,Free,0,Everyone,Business
+HipChat - Chat Built for Teams,BUSINESS,3.8,5868,20M,500000,Free,0,Everyone,Business
+Xero Accounting Software,BUSINESS,3.5,2111,Varies with device,100000,Free,0,Everyone,Business
+"MailChimp - Email, Marketing Automation",BUSINESS,4.1,5448,12M,500000,Free,0,Everyone,Business
+Crew - Free Messaging and Scheduling,BUSINESS,4.6,4159,48M,500000,Free,0,Everyone,Business
+Asana: organize team projects,BUSINESS,4.3,20815,10M,1000000,Free,0,Everyone,Business
+Google Analytics,BUSINESS,4.5,78662,22M,1000000,Free,0,Everyone,Business
+AdWords Express,BUSINESS,4.1,7149,11M,1000000,Free,0,Everyone,Business
+Accounting App - Zoho Books,BUSINESS,4.5,3079,8.5M,100000,Free,0,Everyone,Business
+Invoice & Time Tracking - Zoho,BUSINESS,4.6,5800,8.6M,100000,Free,0,Everyone,Business
+join.me - Simple Meetings,BUSINESS,4.0,6989,Varies with device,1000000,Free,0,Everyone,Business
+Invoice 2go — Professional Invoices and Estimates,BUSINESS,4.2,16422,28M,1000000,Free,0,Everyone,Business
+Cisco Webex Meetings,BUSINESS,4.4,108741,28M,10000000,Free,0,Everyone,Business
+ZOOM Cloud Meetings,BUSINESS,4.4,31614,37M,10000000,Free,0,Everyone,Business
+ScreenMeet. Easy Phone Meeting,BUSINESS,4.0,624,9.0M,100000,Free,0,Everyone,Business
+Cisco Webex Teams,BUSINESS,4.2,1661,46M,100000,Free,0,Everyone,Business
+Microsoft Remote Desktop,BUSINESS,4.2,97702,Varies with device,5000000,Free,0,Everyone,Business
+Start Meeting,BUSINESS,4.1,308,14M,50000,Free,0,Everyone,Business
+join.me - Simple Meetings,BUSINESS,4.0,6989,Varies with device,1000000,Free,0,Everyone,Business
+ClickMeeting Webinars,BUSINESS,3.8,5211,26M,1000000,Free,0,Everyone,Business
+BlueJeans for Android,BUSINESS,3.9,1058,23M,500000,Free,0,Everyone,Business
+Skype for Business for Android,BUSINESS,3.9,78172,Varies with device,10000000,Free,0,Everyone,Business
+Box,BUSINESS,4.2,159872,Varies with device,10000000,Free,0,Everyone,Business
+Zenefits,BUSINESS,4.2,296,14M,50000,Free,0,Everyone,Business
+Google Ads,BUSINESS,4.3,29313,20M,5000000,Free,0,Everyone,Business
+Google My Business,BUSINESS,4.4,70991,Varies with device,5000000,Free,0,Everyone,Business
+Slack,BUSINESS,4.4,51507,Varies with device,5000000,Free,0,Everyone,Business
+FreshBooks Classic,BUSINESS,4.1,1802,26M,100000,Free,0,Everyone,Business
+Insightly CRM,BUSINESS,3.8,1383,51M,100000,Free,0,Everyone,Business
+QuickBooks Accounting: Invoicing & Expenses,BUSINESS,4.3,23175,41M,1000000,Free,0,Everyone,Business
+HipChat - Chat Built for Teams,BUSINESS,3.8,5868,20M,500000,Free,0,Everyone,Business
+Xero Accounting Software,BUSINESS,3.5,2111,Varies with device,100000,Free,0,Everyone,Business
+"MailChimp - Email, Marketing Automation",BUSINESS,4.1,5448,12M,500000,Free,0,Everyone,Business
+Crew - Free Messaging and Scheduling,BUSINESS,4.6,4159,48M,500000,Free,0,Everyone,Business
+Asana: organize team projects,BUSINESS,4.3,20815,10M,1000000,Free,0,Everyone,Business
+Google Analytics,BUSINESS,4.5,78662,22M,1000000,Free,0,Everyone,Business
+AdWords Express,BUSINESS,4.1,7149,11M,1000000,Free,0,Everyone,Business
+Accounting App - Zoho Books,BUSINESS,4.5,3079,8.5M,100000,Free,0,Everyone,Business
+Invoice & Time Tracking - Zoho,BUSINESS,4.6,5800,8.6M,100000,Free,0,Everyone,Business
+join.me - Simple Meetings,BUSINESS,4.0,6989,Varies with device,1000000,Free,0,Everyone,Business
+Invoice 2go — Professional Invoices and Estimates,BUSINESS,4.2,16422,28M,1000000,Free,0,Everyone,Business
+SignEasy | Sign and Fill PDF and other Documents,BUSINESS,4.3,8978,Varies with device,1000000,Free,0,Everyone,Business
+Quick PDF Scanner + OCR FREE,BUSINESS,4.2,80804,Varies with device,5000000,Free,0,Everyone,Business
+Genius Scan - PDF Scanner,BUSINESS,4.4,42492,Varies with device,1000000,Free,0,Everyone,Business
+Tiny Scanner - PDF Scanner App,BUSINESS,4.7,286897,39M,10000000,Free,0,Everyone,Business
+Fast Scanner : Free PDF Scan,BUSINESS,4.5,103755,14M,10000000,Free,0,Everyone,Business
+Mobile Doc Scanner (MDScan) Lite,BUSINESS,4.2,46505,19M,1000000,Free,0,Everyone,Business
+TurboScan: scan documents and receipts in PDF,BUSINESS,4.7,11442,6.8M,100000,Paid,$4.99,Everyone,Business
+Tiny Scanner Pro: PDF Doc Scan,BUSINESS,4.8,10295,39M,100000,Paid,$4.99,Everyone,Business
+Docs To Go™ Free Office Suite,BUSINESS,4.1,217730,Varies with device,50000000,Free,0,Everyone,Business
+OfficeSuite : Free Office + PDF Editor,BUSINESS,4.3,1002859,35M,100000000,Free,0,Everyone,Business
+Slack,BUSINESS,4.4,51510,Varies with device,5000000,Free,0,Everyone,Business
+Verify - Receipts & Expenses,BUSINESS,4.5,413,29M,10000,Free,0,Everyone,Business
+QuickBooks Accounting: Invoicing & Expenses,BUSINESS,4.3,23175,41M,1000000,Free,0,Everyone,Business
+LINE WEBTOON - Free Comics,COMICS,4.5,1013635,Varies with device,10000000,Free,0,Teen,Comics
+Manga Master - Best manga & comic reader,COMICS,4.6,24005,4.9M,500000,Free,0,Adults only 18+,Comics
+GANMA! - All original stories free of charge for all original comics,COMICS,4.7,57106,27M,1000000,Free,0,Teen,Comics
+Röhrich Werner Soundboard,COMICS,4.7,2249,32M,500000,Free,0,Everyone,Comics
+Unicorn Pokez - Color By Number,COMICS,4.8,516,12M,50000,Free,0,Everyone,Comics;Creativity
+MangaToon - Comics updated Daily,COMICS,3.9,834,15M,50000,Free,0,Mature 17+,Comics
+Manga Net – Best Online Manga Reader,COMICS,4.1,1010,11M,50000,Free,0,Mature 17+,Comics
+Manga Rock - Best Manga Reader,COMICS,4.4,238970,28M,1000000,Free,0,Teen,Comics
+Manga - read Thai translation,COMICS,4.6,302,2.2M,10000,Free,0,Teen,Comics
+The Vietnam Story - Fun Stories,COMICS,4.5,438,3.4M,10000,Free,0,Everyone,Comics
+Dragon Ball Wallpaper - Ringtones,COMICS,4.7,73,8.3M,10000,Free,0,Everyone,Comics
+Funny Jokes Photos,COMICS,4.4,39,4.3M,10000,Free,0,Everyone 10+,Comics
+Truyện Vui Tý Quậy,COMICS,4.5,144,4.7M,10000,Free,0,Everyone,Comics
+Comic Es - Shojo manga / love comics free of charge ♪ ♪,COMICS,3.9,2181,10M,100000,Free,0,Teen,Comics
+comico Popular Original Cartoon Updated Everyday Comico,COMICS,3.2,93965,15M,5000000,Free,0,Teen,Comics
+Daily Manga - Comic & Webtoon,COMICS,3.2,1446,7.1M,100000,Free,0,Mature 17+,Comics
+"漫咖 Comics - Manga,Novel and Stories",COMICS,4.1,12088,21M,1000000,Free,0,Mature 17+,Comics
+Emmanuella Funny Videos 2018,COMICS,4.5,314,6.1M,100000,Free,0,Everyone,Comics
+DC Comics,COMICS,4.2,25671,Varies with device,1000000,Free,0,Teen,Comics
+Manga Zero - Japanese cartoon and comic reader,COMICS,4.2,15194,15M,1000000,Free,0,Teen,Comics
+Marvel Unlimited,COMICS,3.7,22551,11M,1000000,Free,0,Teen,Comics
+"Tapas – Comics, Novels, and Stories",COMICS,4.5,29839,29M,1000000,Free,0,Teen,Comics
+Children's cartoons (Mithu-Mina-Raju),COMICS,4.6,279,3.3M,100000,Free,0,Everyone,Comics
+Narrator's Voice,COMICS,4.5,564387,Varies with device,5000000,Free,0,Everyone,Comics
+【Ranobbe complete free】 Novelba - Free app that you can read and write novels,COMICS,4.2,1330,22M,50000,Free,0,Everyone,Comics
+Faustop Sounds,COMICS,4.7,1677,40M,100000,Free,0,Everyone,Comics
+Manga Mania - Best online manga reader,COMICS,4.4,757,10M,10000,Free,0,Teen,Comics
+- Free Comics - Comic Apps,COMICS,3.5,115,9.1M,10000,Free,0,Mature 17+,Comics
+Manga AZ - Manga Comic Reader,COMICS,3.3,125,4.7M,5000,Free,0,Teen,Comics
+Buff Thun - Daily Free Webtoon / Comics / Web Fiction / Mini Game,COMICS,4.5,9952,38M,500000,Free,0,Everyone 10+,Comics
+pixiv comic - everyone's manga app,COMICS,4.4,18814,Varies with device,1000000,Free,0,Mature 17+,Comics
+Funny Jokes and Stories 2018,COMICS,4.2,21,6.7M,5000,Free,0,Everyone,Comics
+Hojiboy Tojiboyev Life Hacks,COMICS,5.0,15,37M,1000,Free,0,Everyone,Comics
+Perfect Viewer,COMICS,4.4,51981,Varies with device,5000000,Free,0,Everyone,Comics
+"Best Wallpapers Backgrounds(100,000+ 4K HD)",COMICS,4.7,3596,7.8M,10000,Free,0,Teen,Comics
+think Comics,COMICS,4.4,1006,19M,50000,Free,0,Everyone,Comics
+Memes Button,COMICS,4.4,5968,5.7M,1000000,Free,0,Everyone,Comics
+"Laftel - Watching and Announcing Snooping, Streaming",COMICS,4.6,4895,35M,100000,Free,0,Everyone,Comics
+Messenger – Text and Video Chat for Free,COMMUNICATION,4.0,56642847,Varies with device,1000000000,Free,0,Everyone,Communication
+WhatsApp Messenger,COMMUNICATION,4.4,69119316,Varies with device,1000000000,Free,0,Everyone,Communication
+Messenger for SMS,COMMUNICATION,4.3,125257,17M,10000000,Free,0,Teen,Communication
+Google Chrome: Fast & Secure,COMMUNICATION,4.3,9642995,Varies with device,1000000000,Free,0,Everyone,Communication
+Messenger Lite: Free Calls & Messages,COMMUNICATION,4.4,1429035,Varies with device,100000000,Free,0,Everyone,Communication
+Gmail,COMMUNICATION,4.3,4604324,Varies with device,1000000000,Free,0,Everyone,Communication
+Hangouts,COMMUNICATION,4.0,3419249,Varies with device,1000000000,Free,0,Everyone,Communication
+Viber Messenger,COMMUNICATION,4.3,11334799,Varies with device,500000000,Free,0,Everyone,Communication
+My Tele2,COMMUNICATION,4.3,158679,8.8M,5000000,Free,0,Everyone,Communication
+Firefox Browser fast & private,COMMUNICATION,4.4,3075028,Varies with device,100000000,Free,0,Everyone,Communication
+Yahoo Mail – Stay Organized,COMMUNICATION,4.3,4187998,16M,100000000,Free,0,Everyone,Communication
+imo beta free calls and text,COMMUNICATION,4.3,659395,11M,100000000,Free,0,Everyone,Communication
+imo free video calls and chat,COMMUNICATION,4.3,4785892,11M,500000000,Free,0,Everyone,Communication
+Contacts,COMMUNICATION,4.3,66602,Varies with device,50000000,Free,0,Everyone,Communication
+Call Free – Free Call,COMMUNICATION,4.3,30209,15M,5000000,Free,0,Everyone,Communication
+Web Browser & Explorer,COMMUNICATION,4.0,36901,6.6M,5000000,Free,0,Everyone,Communication
+Opera Mini - fast web browser,COMMUNICATION,4.5,5149854,Varies with device,100000000,Free,0,Everyone,Communication
+Browser 4G,COMMUNICATION,4.3,192948,6.6M,10000000,Free,0,Everyone,Communication
+MegaFon Dashboard,COMMUNICATION,3.7,99559,Varies with device,10000000,Free,0,Everyone,Communication
+ZenUI Dialer & Contacts,COMMUNICATION,4.5,437674,Varies with device,10000000,Free,0,Everyone,Communication
+Cricket Visual Voicemail,COMMUNICATION,3.9,13698,5.1M,10000000,Free,0,Everyone,Communication
+Opera Browser: Fast and Secure,COMMUNICATION,4.4,2473509,Varies with device,100000000,Free,0,Everyone,Communication
+TracFone My Account,COMMUNICATION,3.6,20769,18M,1000000,Free,0,Everyone,Communication
+Firefox Focus: The privacy browser,COMMUNICATION,4.4,36880,4.0M,1000000,Free,0,Everyone,Communication
+Google Voice,COMMUNICATION,4.2,171031,Varies with device,10000000,Free,0,Everyone,Communication
+Chrome Dev,COMMUNICATION,4.4,63543,Varies with device,5000000,Free,0,Everyone,Communication
+Xperia Link™,COMMUNICATION,4.1,45487,Varies with device,10000000,Free,0,Everyone,Communication
+TouchPal Keyboard - Fun Emoji & Android Keyboard,COMMUNICATION,4.4,615381,37M,10000000,Free,0,Mature 17+,Communication
+Who,COMMUNICATION,4.3,2451083,Varies with device,100000000,Free,0,Teen,Communication
+Skype Lite - Free Video Call & Chat,COMMUNICATION,4.2,33053,22M,5000000,Free,0,Everyone,Communication
+WeChat,COMMUNICATION,4.2,5387333,Varies with device,100000000,Free,0,Everyone,Communication
+UC Browser Mini -Tiny Fast Private & Secure,COMMUNICATION,4.4,3648120,3.3M,100000000,Free,0,Teen,Communication
+WhatsApp Business,COMMUNICATION,4.4,136662,32M,10000000,Free,0,Everyone,Communication
+My magenta,COMMUNICATION,3.9,42370,37M,1000000,Free,0,Everyone,Communication
+Android Messages,COMMUNICATION,4.2,781810,Varies with device,100000000,Free,0,Everyone,Communication
+Telegram,COMMUNICATION,4.4,3128250,Varies with device,100000000,Free,0,Mature 17+,Communication
+Google Duo - High Quality Video Calls,COMMUNICATION,4.6,2083237,Varies with device,500000000,Free,0,Everyone,Communication
+Puffin Web Browser,COMMUNICATION,4.3,541389,Varies with device,10000000,Free,0,Everyone,Communication
+Seznam.cz,COMMUNICATION,4.3,46702,Varies with device,1000000,Free,0,Everyone,Communication
+Antillean Gold Telegram (original version),COMMUNICATION,4.4,2939,17M,100000,Free,0,Everyone,Communication
+AT&T Visual Voicemail,COMMUNICATION,3.7,13761,Varies with device,10000000,Free,0,Everyone,Communication
+GMX Mail,COMMUNICATION,4.3,258556,Varies with device,10000000,Free,0,Everyone,Communication
+Omlet Chat,COMMUNICATION,3.9,40751,35M,10000000,Free,0,Teen,Communication
+UC Browser - Fast Download Private & Secure,COMMUNICATION,4.5,17712922,40M,500000000,Free,0,Teen,Communication
+My Vodacom SA,COMMUNICATION,3.7,25021,61M,5000000,Free,0,Everyone,Communication
+Microsoft Edge,COMMUNICATION,4.3,27187,66M,5000000,Free,0,Everyone,Communication
+WhatsApp Messenger,COMMUNICATION,4.4,69119316,Varies with device,1000000000,Free,0,Everyone,Communication
+Messenger – Text and Video Chat for Free,COMMUNICATION,4.0,56646578,Varies with device,1000000000,Free,0,Everyone,Communication
+imo free video calls and chat,COMMUNICATION,4.3,4785988,11M,500000000,Free,0,Everyone,Communication
+Hangouts Dialer - Call Phones,COMMUNICATION,4.0,122498,79k,10000000,Free,0,Everyone,Communication
+Viber Messenger,COMMUNICATION,4.3,11334973,Varies with device,500000000,Free,0,Everyone,Communication
+Hangouts,COMMUNICATION,4.0,3419433,Varies with device,1000000000,Free,0,Everyone,Communication
+"Talkatone: Free Texts, Calls & Phone Number",COMMUNICATION,4.1,132014,25M,10000000,Free,0,Everyone,Communication
+Calls & Text by Mo+,COMMUNICATION,4.2,83239,14M,5000000,Free,0,Everyone,Communication
+free video calls and chat,COMMUNICATION,4.2,594728,Varies with device,50000000,Free,0,Everyone,Communication
+WeChat,COMMUNICATION,4.2,5387446,Varies with device,100000000,Free,0,Everyone,Communication
+Skype - free IM & video calls,COMMUNICATION,4.1,10484169,Varies with device,1000000000,Free,0,Everyone,Communication
+Telegram,COMMUNICATION,4.4,3128509,Varies with device,100000000,Free,0,Mature 17+,Communication
+Who,COMMUNICATION,4.3,2451093,Varies with device,100000000,Free,0,Teen,Communication
+Google Voice,COMMUNICATION,4.2,171031,Varies with device,10000000,Free,0,Everyone,Communication
+"GO SMS Pro - Messenger, Free Themes, Emoji",COMMUNICATION,4.4,2876500,24M,100000000,Free,0,Everyone,Communication
+Android Messages,COMMUNICATION,4.2,781810,Varies with device,100000000,Free,0,Everyone,Communication
+"Messaging+ SMS, MMS Free",COMMUNICATION,4.1,28238,17M,1000000,Free,0,Everyone,Communication
+chomp SMS,COMMUNICATION,4.3,335646,8.3M,10000000,Free,0,Everyone,Communication
+Glide - Video Chat Messenger,COMMUNICATION,4.3,350154,Varies with device,10000000,Free,0,Everyone,Communication
+Text SMS,COMMUNICATION,4.5,349384,8.2M,10000000,Free,0,Everyone,Communication
+Google Allo,COMMUNICATION,4.3,346982,Varies with device,10000000,Free,0,Everyone,Communication
+Talkray - Free Calls & Texts,COMMUNICATION,4.2,244863,Varies with device,10000000,Free,0,Everyone,Communication
+LINE: Free Calls & Messages,COMMUNICATION,4.2,10790289,Varies with device,500000000,Free,0,Everyone,Communication
+GroupMe,COMMUNICATION,4.5,330761,Varies with device,10000000,Free,0,Everyone,Communication
+mysms SMS Text Messaging Sync,COMMUNICATION,4.3,37320,8.4M,1000000,Free,0,Everyone,Communication
+BBM - Free Calls & Messages,COMMUNICATION,4.3,12842860,Varies with device,100000000,Free,0,Everyone,Communication
+KakaoTalk: Free Calls & Text,COMMUNICATION,4.3,2546527,Varies with device,100000000,Free,0,Everyone,Communication
+Firefox Focus: The privacy browser,COMMUNICATION,4.4,36893,4.0M,1000000,Free,0,Everyone,Communication
+2ndLine - Second Phone Number,COMMUNICATION,4.2,15880,32M,1000000,Free,0,Everyone,Communication
+Google Allo,COMMUNICATION,4.3,346980,Varies with device,10000000,Free,0,Everyone,Communication
+Google Chrome: Fast & Secure,COMMUNICATION,4.3,9643041,Varies with device,1000000000,Free,0,Everyone,Communication
+Firefox Browser fast & private,COMMUNICATION,4.4,3075118,Varies with device,100000000,Free,0,Everyone,Communication
+"CM Browser - Ad Blocker , Fast Download , Privacy",COMMUNICATION,4.6,2264916,6.1M,50000000,Free,0,Everyone,Communication
+Puffin Web Browser,COMMUNICATION,4.3,541389,Varies with device,10000000,Free,0,Everyone,Communication
+Opera Browser: Fast and Secure,COMMUNICATION,4.4,2473693,Varies with device,100000000,Free,0,Everyone,Communication
+Ninesky Browser,COMMUNICATION,4.2,42925,2.8M,1000000,Free,0,Everyone,Communication
+Opera Mini - fast web browser,COMMUNICATION,4.5,5150471,Varies with device,100000000,Free,0,Everyone,Communication
+"Dolphin Browser - Fast, Private & Adblock🐬",COMMUNICATION,4.5,2511130,Varies with device,50000000,Free,0,Everyone,Communication
+UC Browser Mini -Tiny Fast Private & Secure,COMMUNICATION,4.4,3648480,3.3M,100000000,Free,0,Teen,Communication
+UC Browser - Fast Download Private & Secure,COMMUNICATION,4.5,17714850,40M,500000000,Free,0,Teen,Communication
+Ghostery Privacy Browser,COMMUNICATION,4.1,13100,2.2M,1000000,Free,0,Everyone,Communication
+InBrowser - Incognito Browsing,COMMUNICATION,4.2,27156,Varies with device,1000000,Free,0,Everyone,Communication
+Web Browser for Android,COMMUNICATION,4.1,55098,4.3M,1000000,Free,0,Everyone,Communication
+DU Browser—Browse fast & fun,COMMUNICATION,4.3,1133501,4.7M,10000000,Free,0,Everyone,Communication
+Lightning Web Browser,COMMUNICATION,4.1,12578,2.3M,500000,Free,0,Everyone,Communication
+Web Browser,COMMUNICATION,4.2,10965,2.3M,500000,Free,0,Everyone,Communication
+Puffin Browser Pro,COMMUNICATION,4.0,18247,Varies with device,100000,Paid,$3.99,Everyone,Communication
+Contacts+,COMMUNICATION,4.2,190613,11M,10000000,Free,0,Everyone,Communication
+ExDialer - Dialer & Contacts,COMMUNICATION,4.2,125232,2.7M,10000000,Free,0,Everyone,Communication
+Calls & Text by Mo+,COMMUNICATION,4.2,83239,14M,5000000,Free,0,Everyone,Communication
+Viber Messenger,COMMUNICATION,4.3,11334973,Varies with device,500000000,Free,0,Everyone,Communication
+PHONE for Google Voice & GTalk,COMMUNICATION,4.3,72065,13M,1000000,Free,0,Everyone,Communication
+Safest Call Blocker,COMMUNICATION,4.4,27540,3.7M,1000000,Free,0,Everyone,Communication
+Full Screen Caller ID,COMMUNICATION,4.2,104990,10M,5000000,Free,0,Everyone,Communication
+Hiya - Caller ID & Block,COMMUNICATION,4.4,177703,13M,10000000,Free,0,Mature 17+,Communication
+Call Blocker,COMMUNICATION,4.1,17529,10M,1000000,Free,0,Everyone,Communication
+Mr. Number-Block calls & spam,COMMUNICATION,4.2,177263,13M,10000000,Free,0,Mature 17+,Communication
+Should I Answer?,COMMUNICATION,4.8,237468,8.8M,1000000,Free,0,Everyone,Communication
+RocketDial Dialer & Contacts,COMMUNICATION,4.4,32254,5.5M,1000000,Free,0,Everyone,Communication
+"CallApp: Caller ID, Blocker & Phone Call Recorder",COMMUNICATION,4.4,483565,20M,10000000,Free,0,Everyone,Communication
+Whoscall - Caller ID & Block,COMMUNICATION,4.4,552441,29M,10000000,Free,0,Everyone,Communication
+CIA - Caller ID & Call Blocker,COMMUNICATION,4.0,60308,Varies with device,5000000,Free,0,Everyone,Communication
+Calls Blacklist - Call Blocker,COMMUNICATION,4.5,457283,Varies with device,10000000,Free,0,Everyone,Communication
+Call Control - Call Blocker,COMMUNICATION,4.4,93825,11M,5000000,Free,0,Everyone,Communication
+True Contact - Real Caller ID,COMMUNICATION,4.1,32283,Varies with device,1000000,Free,0,Everyone,Communication
+Video Caller Id,COMMUNICATION,4.2,15287,17M,1000000,Free,0,Everyone,Communication
+Sync.ME – Caller ID & Block,COMMUNICATION,4.5,205739,17M,5000000,Free,0,Everyone,Communication
+Burner - Free Phone Number,COMMUNICATION,4.3,14873,Varies with device,1000000,Free,0,Everyone,Communication
+"Truecaller: Caller ID, SMS spam blocking & Dialer",COMMUNICATION,4.5,7820209,Varies with device,100000000,Free,0,Everyone,Communication
+Caller ID +,COMMUNICATION,4.0,9498,118k,1000000,Free,0,Everyone,Communication
+Gmail,COMMUNICATION,4.3,4604483,Varies with device,1000000000,Free,0,Everyone,Communication
+Yahoo Mail – Stay Organized,COMMUNICATION,4.3,4188142,16M,100000000,Free,0,Everyone,Communication
+K-9 Mail,COMMUNICATION,4.2,88427,5.1M,5000000,Free,0,Everyone,Communication
+"myMail – Email for Hotmail, Gmail and Outlook Mail",COMMUNICATION,4.5,305218,Varies with device,10000000,Free,0,Everyone,Communication
+Email TypeApp - Mail App,COMMUNICATION,4.6,183374,44M,1000000,Free,0,Everyone,Communication
+All Email Providers,COMMUNICATION,4.1,20901,7.3M,1000000,Free,0,Everyone,Communication
+"Newton Mail - Email App for Gmail, Outlook, IMAP",COMMUNICATION,4.0,122595,30M,1000000,Free,0,Everyone,Communication
+GO Notifier,COMMUNICATION,4.2,124346,695k,10000000,Free,0,Everyone,Communication
+Mail.Ru - Email App,COMMUNICATION,4.6,837842,Varies with device,50000000,Free,0,Everyone,Communication
+Mail1Click - Secure Mail,COMMUNICATION,4.1,255,1.6M,10000,Free,0,Everyone,Communication
+Daum Mail - Next Mail,COMMUNICATION,4.3,41420,19M,5000000,Free,0,Everyone,Communication
+mail.com mail,COMMUNICATION,4.2,44706,Varies with device,1000000,Free,0,Everyone,Communication
+SolMail - All-in-One email app,COMMUNICATION,4.3,23707,Varies with device,500000,Free,0,Everyone,Communication
+Hangouts,COMMUNICATION,4.0,3419513,Varies with device,1000000000,Free,0,Everyone,Communication
+imo free video calls and chat,COMMUNICATION,4.3,4785988,11M,500000000,Free,0,Everyone,Communication
+free video calls and chat,COMMUNICATION,4.2,594728,Varies with device,50000000,Free,0,Everyone,Communication
+Viber Messenger,COMMUNICATION,4.3,11335255,Varies with device,500000000,Free,0,Everyone,Communication
+Skype - free IM & video calls,COMMUNICATION,4.1,10484169,Varies with device,1000000000,Free,0,Everyone,Communication
+WeChat,COMMUNICATION,4.2,5387446,Varies with device,100000000,Free,0,Everyone,Communication
+Vonage Mobile® Call Video Text,COMMUNICATION,4.1,29208,23M,1000000,Free,0,Everyone,Communication
+JusTalk - Free Video Calls and Fun Video Chat,COMMUNICATION,4.6,191032,26M,5000000,Free,0,Everyone,Communication
+Glide - Video Chat Messenger,COMMUNICATION,4.3,350154,Varies with device,10000000,Free,0,Everyone,Communication
+Talkray - Free Calls & Texts,COMMUNICATION,4.2,244863,Varies with device,10000000,Free,0,Everyone,Communication
+LINE: Free Calls & Messages,COMMUNICATION,4.2,10790289,Varies with device,500000000,Free,0,Everyone,Communication
+KakaoTalk: Free Calls & Text,COMMUNICATION,4.3,2546527,Varies with device,100000000,Free,0,Everyone,Communication
+"Moco+ - Chat, Meet People",DATING,4.2,1545,Varies with device,10000,Paid,$3.99,Mature 17+,Dating
+Calculator,DATING,2.6,57,6.2M,1000,Paid,$6.99,Everyone,Dating
+Truth or Dare Pro,DATING,4.0,0,20M,50,Paid,$1.49,Teen,Dating
+"Private Dating, Hide App- Blue for PrivacyHider",DATING,4.0,0,18k,100,Paid,$2.99,Everyone,Dating
+Ad Blocker for SayHi,DATING,4.0,4,1.2M,100,Paid,$3.99,Teen,Dating
+AMBW Dating App: Asian Men Black Women Interracial,DATING,3.5,2,17M,100,Paid,$7.99,Mature 17+,Dating
+Zoosk Dating App: Meet Singles,DATING,4.0,516801,Varies with device,10000000,Free,0,Mature 17+,Dating
+OkCupid Dating,DATING,4.1,285726,15M,10000000,Free,0,Mature 17+,Dating
+Match™ Dating - Meet Singles,DATING,3.7,76646,Varies with device,10000000,Free,0,Mature 17+,Dating
+"Hily: Dating, Chat, Match, Meet & Hook up",DATING,4.1,2556,56M,100000,Free,0,Mature 17+,Dating
+Hinge: Dating & Relationships,DATING,4.2,7779,12M,500000,Free,0,Mature 17+,Dating
+Casual Dating & Adult Singles - Joyride,DATING,4.5,61637,11M,5000000,Free,0,Mature 17+,Dating
+BBW Dating & Plus Size Chat,DATING,4.4,12632,29M,1000000,Free,0,Mature 17+,Dating
+"Moco - Chat, Meet People",DATING,4.2,313724,Varies with device,10000000,Free,0,Mature 17+,Dating
+CMB Free Dating App,DATING,4.0,48845,40M,1000000,Free,0,Mature 17+,Dating
+Hot or Not - Find someone right now,DATING,4.1,305708,Varies with device,10000000,Free,0,Mature 17+,Dating
+eharmony - Online Dating App,DATING,3.1,31320,53M,5000000,Free,0,Mature 17+,Dating
+Free Dating App & Flirt Chat - Match with Singles,DATING,4.4,172460,3.1M,5000000,Free,0,Mature 17+,Dating
+"Chispa, the Dating App for Latino, Latina Singles",DATING,4.2,4195,24M,100000,Free,0,Mature 17+,Dating
+Clover Dating App,DATING,4.1,11633,23M,500000,Free,0,Mature 17+,Dating
+Black People Meet Singles Date,DATING,3.9,10212,5.0M,1000000,Free,0,Mature 17+,Dating
+Mingle2 - Free Online Dating & Singles Chat Rooms,DATING,4.3,37053,44M,1000000,Free,0,Mature 17+,Dating
+Free Dating App & Flirt Chat - Cheers,DATING,4.4,667,27M,10000,Free,0,Mature 17+,Dating
+stranger chat - anonymous chat,DATING,3.5,13202,6.1M,1000000,Free,0,Mature 17+,Dating
+"Blendr - Chat, Flirt & Meet",DATING,4.0,28671,Varies with device,1000000,Free,0,Mature 17+,Dating
+Free Dating Hook Up Messenger,DATING,3.3,1157,21M,100000,Free,0,Mature 17+,Dating
+Find Real Love — YouLove Premium Dating,DATING,4.5,212626,11M,10000000,Free,0,Mature 17+,Dating
+Once - Quality Matches Every day,DATING,4.4,222888,21M,1000000,Free,0,Mature 17+,Dating
+BLK - Swipe. Match. Chat.,DATING,4.1,2067,24M,100000,Free,0,Mature 17+,Dating
+Cougar Dating Life : Date Older Women Sugar Mummy,DATING,3.9,1643,31M,500000,Free,0,Mature 17+,Dating
+Howlr,DATING,3.9,105,27M,5000,Free,0,Mature 17+,Dating
+Stranger Chat & Date,DATING,3.6,3414,6.2M,500000,Free,0,Mature 17+,Dating
+Free Dating & Flirt Chat - Choice of Love,DATING,4.0,42194,Varies with device,5000000,Free,0,Mature 17+,Dating
+RandoChat - Chat roulette,DATING,3.6,11806,12M,1000000,Free,0,Mature 17+,Dating
+BeWild Free Dating & Chat App,DATING,3.4,1999,8.0M,100000,Free,0,Mature 17+,Dating
+"FastMeet: Chat, Dating, Love",DATING,4.2,22544,5.9M,1000000,Free,0,Mature 17+,Dating
+"Free Dating App - YoCutie - Flirt, Chat & Meet",DATING,4.1,97684,7.9M,1000000,Free,0,Mature 17+,Dating
+OurTime Dating for Singles 50+,DATING,3.4,2519,5.0M,100000,Free,0,Mature 17+,Dating
+FarmersOnly Dating,DATING,3.0,1146,1.4M,100000,Free,0,Mature 17+,Dating
+Dating for 50 plus Mature Singles – FINALLY,DATING,4.6,13046,13M,500000,Free,0,Mature 17+,Dating
+Sudy – Meet Elite & Rich Single,DATING,4.1,17268,40M,500000,Free,0,Mature 17+,Dating
+Christian Dating For Free App,DATING,3.9,8722,13M,500000,Free,0,Mature 17+,Dating
+Just She - Top Lesbian Dating,DATING,1.9,953,19M,100000,Free,0,Mature 17+,Dating
+Single Parent Meet #1 Dating,DATING,3.5,2593,5.0M,500000,Free,0,Mature 17+,Dating
+EliteSingles – Dating for Single Professionals,DATING,2.5,5377,19M,500000,Free,0,Mature 17+,Dating
+Millionaire Match: Rich Singles Dating App,DATING,3.9,852,27M,100000,Free,0,Mature 17+,Dating
+InterracialCupid - Interracial Dating App,DATING,3.4,212,3.0M,50000,Free,0,Mature 17+,Dating
+Sugar Mommas Dating And Single Search,DATING,3.5,1972,13M,1000000,Free,0,Mature 17+,Dating
+"Hide App, Private Dating, Safe Chat - PrivacyHider",DATING,4.4,35206,7.2M,1000000,Free,0,Everyone,Dating
+"muzmatch: Muslim & Arab Singles, Marriage & Dating",DATING,3.8,5164,25M,100000,Free,0,Mature 17+,Dating
+NoBuffDating - Free Dating App,DATING,4.2,1939,Varies with device,100000,Free,0,Mature 17+,Dating
+Sugar Daddy Dating App,DATING,2.5,277,5.7M,100000,Free,0,Mature 17+,Dating
+Adult Dirty Emojis,DATING,2.8,80,5.5M,10000,Free,0,Teen,Dating
+Free Dating App - Meet Local Singles - Flirt Chat,DATING,4.1,825,Varies with device,100000,Free,0,Mature 17+,Dating
+"Meet4U - Chat, Love, Singles!",DATING,4.2,40035,6.5M,1000000,Free,0,Mature 17+,Dating
+SnpCupid Dating,DATING,3.5,1093,5.8M,100000,Free,0,Mature 17+,Dating
+"Chat Rooms, Avatars, Date - Galaxy",DATING,4.3,135418,Varies with device,10000000,Free,0,Mature 17+,Dating
+Adult Dating - AdultFinder,DATING,3.3,1601,3.8M,500000,Free,0,Mature 17+,Dating
+Gay Sugar Daddy Dating & Hookup – Sudy Gay,DATING,4.1,2212,41M,100000,Free,0,Mature 17+,Dating
+"Meet24 - Love, Chat, Singles",DATING,4.2,57081,7.9M,1000000,Free,0,Mature 17+,Dating
+BBWCupid - BBW Dating App,DATING,3.5,241,2.8M,50000,Free,0,Mature 17+,Dating
+ChatVideo Meet new people,DATING,4.2,63986,20M,5000000,Free,0,Mature 17+,Dating
+"TryDate - Free Online Dating App, Chat Meet Adults",DATING,4.4,7888,15M,500000,Free,0,Mature 17+,Dating
+Black White Interracial Dating - Interracial Match,DATING,4.1,535,28M,100000,Free,0,Mature 17+,Dating
+"USA Singles Meet, Match and Date Free - Date",DATING,4.2,5084,9.6M,100000,Free,0,Mature 17+,Dating
+FlirtChat - ♥Free Dating/Flirting App♥,DATING,4.3,2430,13M,500000,Free,0,Mature 17+,Dating
+OkCupid Dating,DATING,4.1,285726,15M,10000000,Free,0,Mature 17+,Dating
+CMB Free Dating App,DATING,4.0,48845,40M,1000000,Free,0,Mature 17+,Dating
+"Hily: Dating, Chat, Match, Meet & Hook up",DATING,4.1,2556,56M,100000,Free,0,Mature 17+,Dating
+Hinge: Dating & Relationships,DATING,4.2,7779,12M,500000,Free,0,Mature 17+,Dating
+The League,DATING,3.0,837,9.4M,100000,Free,0,Mature 17+,Dating
+BBW Dating & Plus Size Chat,DATING,4.4,12632,29M,1000000,Free,0,Mature 17+,Dating
+Casual Dating & Adult Singles - Joyride,DATING,4.5,61637,11M,5000000,Free,0,Mature 17+,Dating
+EliteSingles – Dating for Single Professionals,DATING,2.5,5377,19M,500000,Free,0,Mature 17+,Dating
+Clover Dating App,DATING,4.1,11633,23M,500000,Free,0,Mature 17+,Dating
+"Moco - Chat, Meet People",DATING,4.2,313724,Varies with device,10000000,Free,0,Mature 17+,Dating
+"Herpes Dating: 1,000K+ Singles",DATING,4.0,738,27M,10000,Free,0,Mature 17+,Dating
+Hot or Not - Find someone right now,DATING,4.1,305708,Varies with device,10000000,Free,0,Mature 17+,Dating
+Just She - Top Lesbian Dating,DATING,1.9,953,19M,100000,Free,0,Mature 17+,Dating
+Heart mill,DATING,3.3,4631,45M,100000,Free,0,Mature 17+,Dating
+Once - Quality Matches Every day,DATING,4.4,222888,21M,1000000,Free,0,Mature 17+,Dating
+Sudy – Meet Elite & Rich Single,DATING,4.1,17268,40M,500000,Free,0,Mature 17+,Dating
+"muzmatch: Muslim & Arab Singles, Marriage & Dating",DATING,3.8,5164,25M,100000,Free,0,Mature 17+,Dating
+95Live -SG#1 Live Streaming App,DATING,4.1,4953,15M,1000000,Free,0,Teen,Dating
+"Chispa, the Dating App for Latino, Latina Singles",DATING,4.2,4195,24M,100000,Free,0,Mature 17+,Dating
+"Blendr - Chat, Flirt & Meet",DATING,4.0,28671,Varies with device,1000000,Free,0,Mature 17+,Dating
+Find Real Love — YouLove Premium Dating,DATING,4.5,212626,11M,10000000,Free,0,Mature 17+,Dating
+Mutual - LDS Dating,DATING,3.7,1439,38M,50000,Free,0,Mature 17+,Dating
+Cougar Dating Life : Date Older Women Sugar Mummy,DATING,3.9,1645,31M,500000,Free,0,Mature 17+,Dating
+stranger chat - anonymous chat,DATING,3.5,13204,6.1M,1000000,Free,0,Mature 17+,Dating
+Millionaire Match: Rich Singles Dating App,DATING,3.9,853,27M,100000,Free,0,Mature 17+,Dating
+2RedBeans,DATING,4.0,337,32M,10000,Free,0,Mature 17+,Dating
+Dating for 50 plus Mature Singles – FINALLY,DATING,4.6,13049,13M,500000,Free,0,Mature 17+,Dating
+"SweetRing - Meet, Match, Date",DATING,4.0,51698,63M,1000000,Free,0,Mature 17+,Dating
+"BiggerCity: Chat for gay bears, chubs & chasers",DATING,4.1,923,44M,100000,Free,0,Mature 17+,Dating
+"Moco+ - Chat, Meet People",DATING,4.2,1546,Varies with device,10000,Paid,$3.99,Mature 17+,Dating
+SilverSingles: The 50+ Dating App,DATING,3.3,149,16M,10000,Free,0,Mature 17+,Dating
+Herpes Positive Singles Dating,DATING,4.4,198,28M,10000,Free,0,Mature 17+,Dating
+"Chat Rooms, Avatars, Date - Galaxy",DATING,4.3,135420,Varies with device,10000000,Free,0,Mature 17+,Dating
+"FastMeet: Chat, Dating, Love",DATING,4.2,22545,5.9M,1000000,Free,0,Mature 17+,Dating
+Christian Dating For Free App,DATING,3.9,8723,13M,500000,Free,0,Mature 17+,Dating
+Glam - Premium Dating App,DATING,4.3,23170,9.0M,500000,Free,0,Mature 17+,Dating
+"iDates - Chats, Flirts, Dating, Love & Relations",DATING,3.4,13890,20M,500000,Free,0,Mature 17+,Dating
+"Meet24 - Love, Chat, Singles",DATING,4.2,57083,7.9M,1000000,Free,0,Mature 17+,Dating
+Black White Interracial Dating - Interracial Match,DATING,4.1,537,28M,100000,Free,0,Mature 17+,Dating
+JustDating,DATING,4.0,13440,49M,500000,Free,0,Mature 17+,Dating
+Interracial Match Dating App,DATING,3.6,143,27M,10000,Free,0,Mature 17+,Dating
+Russian Dating & Chat for Russian speaking RusDate,DATING,4.2,1059,18M,100000,Free,0,Mature 17+,Dating
+Sky People (SPI): A secure blind date through authentication by Seoul National University,DATING,3.5,894,14M,100000,Free,0,Mature 17+,Dating
+Sweet mi - unlimited hunnam hunting blind date,DATING,4.0,6191,27M,500000,Free,0,Mature 17+,Dating
+Gay Sugar Daddy Dating & Hookup – Sudy Gay,DATING,4.1,2212,41M,100000,Free,0,Mature 17+,Dating
+Mingle - Online Dating App to Chat & Meet People,DATING,4.1,15081,38M,1000000,Free,0,Mature 17+,Dating
+Adult Dirty Emojis,DATING,2.8,80,5.5M,10000,Free,0,Teen,Dating
+BBW Dating & Curvy Singles Chat- LargeFriends,DATING,4.4,218,27M,10000,Free,0,Mature 17+,Dating
+"Hide App, Private Dating, Safe Chat - PrivacyHider",DATING,4.4,35205,7.2M,1000000,Free,0,Everyone,Dating
+Hitwe - meet people and chat,DATING,4.2,243950,21M,10000000,Free,0,Mature 17+,Dating
+A hundred,DATING,4.1,236,8.8M,10000,Free,0,Mature 17+,Dating
+JustSayHi- Dating App. Chat & Meet Singles Nearby,DATING,4.2,5152,38M,100000,Free,0,Mature 17+,Dating
+FERZU - Furries Social Network,DATING,3.9,1576,Varies with device,10000,Free,0,Mature 17+,Dating
+WannaMeet – Dating & Chat App,DATING,4.1,6701,11M,1000000,Free,0,Mature 17+,Dating
+"Meet4U - Chat, Love, Singles!",DATING,4.2,40039,6.5M,1000000,Free,0,Mature 17+,Dating
+Luxy Pro- Elite Dating Single,DATING,3.9,742,26M,50000,Free,0,Mature 17+,Dating
+Dating Network,DATING,4.0,187,19M,10000,Free,0,Mature 17+,Dating
+"Chatting - Free chat, random chat, boyfriend, girlfriend",DATING,4.2,2506,6.1M,500000,Free,0,Mature 17+,Dating
+"iPair-Meet, Chat, Dating",DATING,4.5,182986,77M,5000000,Free,0,Mature 17+,Dating
+"Meet, chat & date. Free dating app - Chocolate app",DATING,3.9,8661,9.5M,1000000,Free,0,Mature 17+,Dating
+Transenger – Ts Dating and Chat for Free,DATING,3.6,8,14M,1000,Free,0,Mature 17+,Dating
+O-Star,DATING,4.4,59,38M,5000,Free,0,Everyone,Dating
+Free Cam Girls - Live Webcam,DATING,3.5,35,16M,1000,Free,0,Mature 17+,Dating
+Cardi B Live Stream Video Chat - Prank,DATING,4.4,28,3.4M,500,Free,0,Everyone,Dating
+Live Girls Talk - Free Video Chat,DATING,4.8,125,4.7M,5000,Free,0,Mature 17+,Dating
+Live Talk - Free Text and Video Chat,DATING,4.6,185,5.0M,10000,Free,0,Mature 17+,Dating
+Chat Kids - Chat Room For Kids,DATING,4.7,6,4.9M,100,Free,0,Mature 17+,Dating
+Girls Live Chat - Free Text & Video Chat,DATING,4.8,110,4.9M,10000,Free,0,Mature 17+,Dating
+Random Video Chat,DATING,4.0,3,16M,1000,Free,0,Mature 17+,Dating
+MouseMingle,DATING,2.7,3,3.9M,100,Free,0,Mature 17+,Dating
+American Girls Mobile Numbers,DATING,5.0,5,4.4M,1000,Free,0,Mature 17+,Dating
+Random Video Chat App With Strangers,DATING,4.0,3,4.8M,1000,Free,0,Mature 17+,Dating
+FREE VIDEO CHAT - LIVE VIDEO AND TEXT CHAT,DATING,4.8,84,4.5M,1000,Free,0,Mature 17+,Dating
+Awake Dating,DATING,5.0,2,70M,100,Free,0,Mature 17+,Dating
+Live Chat - Free Video Chat Rooms,DATING,4.8,20,4.9M,500,Free,0,Mature 17+,Dating
+Meet With Strangers: Video Chat & Dating,DATING,4.0,2,3.7M,500,Free,0,Mature 17+,Dating
+FREE LIVE TALK,DATING,4.9,776,4.9M,5000,Free,0,Mature 17+,Dating
+Random Chat App with Strangers,DATING,3.0,2,16M,100,Free,0,Mature 17+,Dating
+Ost. Zombies Cast - New Music and Lyrics,DATING,4.0,1,4.6M,100,Free,0,Teen,Dating
+Dating White Girls,DATING,4.0,0,3.6M,50,Free,0,Mature 17+,Dating
+Live Chat - Free Video Talk,DATING,4.7,14,21M,5000,Free,0,Mature 17+,Dating
+Geeks Dating,DATING,4.0,0,13M,50,Free,0,Mature 17+,Dating
+Live chat - free video chat,DATING,4.0,1,8.7M,500,Free,0,Mature 17+,Dating
+House party - live chat,DATING,1.0,1,9.2M,10,Free,0,Mature 17+,Dating
+Fishing Brain & Boating Maps Marine,DATING,4.0,3,6.9M,500,Free,0,Everyone,Dating
+CAM5678 Video Chat,DATING,4.0,0,39M,500,Free,0,Mature 17+,Dating
+Video chat live advices,DATING,4.0,0,8.0M,100,Free,0,Everyone,Dating
+chat live chat,DATING,4.0,24,3.9M,1000,Free,0,Mature 17+,Dating
+Pet Lovers Dating,DATING,4.0,0,14M,10,Free,0,Mature 17+,Dating
+Friend Find: free chat + flirt dating app,DATING,4.0,23,11M,100,Free,0,Mature 17+,Dating
+Latin Dating,DATING,4.0,0,13M,10,Free,0,Mature 17+,Dating
+Spine- The dating app,DATING,5.0,5,9.3M,500,Free,0,Teen,Dating
+Online Chat Girls Meet,DATING,4.7,18,5.0M,500,Free,0,Mature 17+,Dating
+Wifi Mingle,DATING,4.0,0,10.0M,10,Free,0,Everyone,Dating
+Girls Live Talk - Free Text and Video Chat,DATING,5.0,6,5.0M,100,Free,0,Mature 17+,Dating
+Soy Luna - Top Music And Lyrics,DATING,4.0,1,5.0M,100,Free,0,Teen,Dating
+When Will You Get Married,DATING,4.0,2,3.6M,10,Free,0,Everyone,Dating
+HOW TO ASK A GIRL OUT,DATING,4.0,0,19M,10,Free,0,Everyone,Dating
+Online Girls Chat Group,DATING,5.0,5,5.0M,100,Free,0,Mature 17+,Dating
+The DJ - Match with People,DATING,4.0,0,9.8M,50,Free,0,Mature 17+,Dating
+Toronto Dating,DATING,4.0,0,14M,100,Free,0,Mature 17+,Dating
+i miss you quotes and photos,DATING,4.0,0,5.0M,100,Free,0,Everyone,Dating
+JoJo Siwa Top Hits Music,DATING,4.0,0,4.9M,10,Free,0,Teen,Dating
+UK Girls Mobile Numbers,DATING,3.0,1,5.5M,500,Free,0,Mature 17+,Dating
+chat saudi arabia,DATING,4.1,11,11M,1000,Free,0,Mature 17+,Dating
+Chat Click - Dating Search,DATING,4.0,4,3.8M,500,Free,0,Mature 17+,Dating
+Iraq love chat,DATING,4.0,14,5.0M,50,Free,0,Teen,Dating
+Healthy Relationships Guide,DATING,4.0,0,8.2M,1,Free,0,Everyone,Dating
+following,DATING,4.0,1,21M,10,Free,0,Mature 17+,Dating
+Gods by Night,DATING,4.0,104,12M,1000,Free,0,Mature 17+,Dating
+PlusOne,DATING,4.0,0,10M,1,Free,0,Mature 17+,Dating
+Love Calendar - Couple Sharing Calendar & CoupleDay,DATING,4.0,14,3.3M,50,Free,0,Everyone,Dating
+Speeding Joyride & Car Meet App,DATING,5.0,3,25M,100,Free,0,Mature 17+,Dating
+LOBSTR - go on a lunch date,DATING,3.7,101,15M,10000,Free,0,Mature 17+,Dating
+Titanic App - Feminist Dating Application,DATING,4.5,120,10M,500,Free,0,Mature 17+,Dating
+French Chat Room,DATING,4.2,24,4.9M,1000,Free,0,Mature 17+,Dating
+Soul Mate,DATING,4.0,0,4.4M,10,Free,0,Mature 17+,Dating
+Diamond Engagement Rings,DATING,4.0,0,3.5M,5,Free,0,Everyone,Dating
+Dating Tips For Men,DATING,4.0,0,7.8M,10,Free,0,Everyone,Dating
+Halalguur,DATING,4.3,6,9.0M,100,Free,0,Mature 17+,Dating
+95Live -SG#1 Live Streaming App,DATING,4.1,4954,15M,1000000,Free,0,Teen,Dating
+Just She - Top Lesbian Dating,DATING,1.9,954,19M,100000,Free,0,Mature 17+,Dating
+"Hily: Dating, Chat, Match, Meet & Hook up",DATING,4.1,2560,56M,100000,Free,0,Mature 17+,Dating
+O-Star,DATING,4.4,59,38M,5000,Free,0,Everyone,Dating
+Random Video Chat,DATING,4.0,3,16M,1000,Free,0,Mature 17+,Dating
+Black People Meet Singles Date,DATING,3.9,10212,5.0M,1000000,Free,0,Mature 17+,Dating
+Howlr,DATING,3.9,105,27M,5000,Free,0,Mature 17+,Dating
+Find Lover,DATING,4.0,21,4.7M,1000,Free,0,Mature 17+,Dating
+Free Dating & Flirt Chat - Choice of Love,DATING,4.0,42197,Varies with device,5000000,Free,0,Mature 17+,Dating
+Cardi B Live Stream Video Chat - Prank,DATING,4.4,28,3.4M,500,Free,0,Everyone,Dating
+Chat Kids - Chat Room For Kids,DATING,4.7,6,4.9M,100,Free,0,Mature 17+,Dating
+"muzmatch: Muslim & Arab Singles, Marriage & Dating",DATING,3.8,5168,25M,100000,Free,0,Mature 17+,Dating
+BBW Dating & Plus Size Chat,DATING,4.4,12633,29M,1000000,Free,0,Mature 17+,Dating
+"2Date Dating App, Love and matching",DATING,4.4,41605,8.1M,500000,Free,0,Mature 17+,Dating
+Transenger – Ts Dating and Chat for Free,DATING,3.6,8,14M,1000,Free,0,Mature 17+,Dating
+BBW Dating & Curvy Singles Chat- LargeFriends,DATING,4.4,218,27M,10000,Free,0,Mature 17+,Dating
+MouseMingle,DATING,2.7,3,3.9M,100,Free,0,Mature 17+,Dating
+FlirtChat - ♥Free Dating/Flirting App♥,DATING,4.3,2433,13M,500000,Free,0,Mature 17+,Dating
+Live Talk - Free Text and Video Chat,DATING,4.6,185,5.0M,10000,Free,0,Mature 17+,Dating
+Adult Dirty Emojis,DATING,2.8,80,5.5M,10000,Free,0,Teen,Dating
+Free Cam Girls - Live Webcam,DATING,3.5,35,16M,1000,Free,0,Mature 17+,Dating
+Random Video Chat App With Strangers,DATING,4.0,3,4.8M,1000,Free,0,Mature 17+,Dating
+Teenage Chat & Dating,DATING,3.4,5,14M,500,Free,0,Mature 17+,Dating
+Live Girls Talk - Free Video Chat,DATING,4.8,125,4.7M,5000,Free,0,Mature 17+,Dating
+Girls Online Talk - Free Text and Video Chat,DATING,4.7,791,3.7M,10000,Free,0,Mature 17+,Dating
+Girls Live Chat - Free Text & Video Chat,DATING,4.8,110,4.9M,10000,Free,0,Mature 17+,Dating
+Online Girls Chat,DATING,4.8,5323,3.5M,50000,Free,0,Mature 17+,Dating
+LIVE VIDEO TALK,DATING,4.7,478,4.5M,10000,Free,0,Mature 17+,Dating
+Free Dating App - Meet Local Singles - Flirt Chat,DATING,4.1,825,Varies with device,100000,Free,0,Mature 17+,Dating
+SkyLove – Dating and chat,DATING,3.5,69,36M,5000,Free,0,Mature 17+,Dating
+Free Live Talk-Video Call,DATING,4.7,158,4.5M,10000,Free,0,Mature 17+,Dating
+FindLoving,DATING,3.8,24,19M,1000,Free,0,Mature 17+,Dating
+Sugar Daddies Dating App,DATING,2.9,53,14M,10000,Free,0,Mature 17+,Dating
+"iPair-Meet, Chat, Dating",DATING,4.5,182986,77M,5000000,Free,0,Mature 17+,Dating
+Free Dating Hook Up Messenger,DATING,3.3,1157,21M,100000,Free,0,Mature 17+,Dating
+"Free Dating App - YoCutie - Flirt, Chat & Meet",DATING,4.1,97699,7.9M,1000000,Free,0,Mature 17+,Dating
+"Chat Mexico: meet people, flirt and friendship",DATING,4.0,8,9.3M,5000,Free,0,Mature 17+,Dating
+Duolingo: Learn Languages Free,EDUCATION,4.7,6289924,Varies with device,100000000,Free,0,Everyone,Education;Education
+TED,EDUCATION,4.6,181893,18M,10000000,Free,0,Everyone 10+,Education
+English Communication - Learn English for Chinese (Learn English for Chinese),EDUCATION,4.7,2544,18M,100000,Free,0,Everyone,Education
+Khan Academy,EDUCATION,4.6,85375,21M,5000000,Free,0,Everyone,Education
+Learn English with Wlingua,EDUCATION,4.7,314299,3.3M,10000000,Free,0,Everyone,Education
+Ai La Trieu Phu - ALTP Free,EDUCATION,4.4,776,24M,100000,Free,0,Everyone,Education
+Princess Coloring Book,EDUCATION,4.5,9770,39M,5000000,Free,0,Everyone,Education;Creativity
+Learn Spanish - Español,EDUCATION,4.7,32346,3.2M,1000000,Free,0,Everyone,Education
+English Grammar Test,EDUCATION,4.8,4075,5.1M,500000,Free,0,Everyone,Education
+Speed Reading,EDUCATION,4.6,10611,11M,500000,Free,0,Everyone,Education
+English for beginners,EDUCATION,4.6,9321,27M,1000000,Free,0,Everyone,Education
+Flame - درب عقلك يوميا,EDUCATION,4.6,56065,37M,1000000,Free,0,Everyone,Education
+Mermaids,EDUCATION,4.2,14286,Varies with device,5000000,Free,0,Everyone,Education;Creativity
+"Learn Japanese, Korean, Chinese Offline & Free",EDUCATION,4.9,133136,26M,1000000,Free,0,Everyone,Education;Education
+Kids Mode,EDUCATION,3.8,2469,11M,500000,Free,0,Everyone,Education
+PBS KIDS Video,EDUCATION,4.2,36212,Varies with device,5000000,Free,0,Everyone,Education;Music & Video
+Dinosaurs Coloring Pages,EDUCATION,4.4,390,41M,500000,Free,0,Everyone,Education;Education
+Cars Coloring Pages,EDUCATION,4.4,1090,49M,1000000,Free,0,Everyone,Education;Creativity
+Babbel – Learn Languages,EDUCATION,4.3,266948,21M,10000000,Free,0,Everyone,Education
+Math Tricks,EDUCATION,4.5,342918,8.1M,10000000,Free,0,Everyone,Education
+Monster Truck Driver & Racing,EDUCATION,4.4,748,51M,1000000,Free,0,Everyone,Education;Action & Adventure
+Learn English Words Free,EDUCATION,4.6,172640,14M,5000000,Free,0,Everyone,Education
+Japanese / English one-shop search dictionary - Free Japanese - English - Japanese dictionary application,EDUCATION,3.9,61,18M,50000,Free,0,Mature 17+,Education
+English speaking texts,EDUCATION,4.4,1619,3.0M,1000000,Free,0,Everyone,Education
+Thai Handwriting,EDUCATION,4.3,3168,19M,1000000,Free,0,Everyone,Education
+THAI DICT 2018,EDUCATION,4.4,29855,Varies with device,1000000,Free,0,Mature 17+,Education
+Kanji test · Han search Kanji training (free version),EDUCATION,4.2,6736,22M,1000000,Free,0,Mature 17+,Education
+Game for KIDS: KIDS match'em,EDUCATION,4.4,7005,6.9M,1000000,Free,0,Everyone,Education
+Flippy Campus - Buy & sell on campus at a discount,EDUCATION,4.0,889,7.4M,500000,Free,0,Everyone,Education
+Free intellectual training game application |,EDUCATION,4.2,5741,84M,1000000,Free,0,Everyone,Education;Pretend Play
+ABC Preschool Free,EDUCATION,3.8,27572,25M,5000000,Free,0,Everyone,Education;Education
+PINKFONG Baby Shark,EDUCATION,4.5,10852,18M,1000000,Free,0,Everyone,Education
+English words application mikan,EDUCATION,4.7,9888,Varies with device,500000,Free,0,Everyone,Education
+Learn English for beginners,EDUCATION,4.5,1929,2.5M,500000,Free,0,Everyone,Education
+Listen and learn English in seven days,EDUCATION,4.3,1516,3.9M,100000,Free,0,Everyone,Education
+Lumosity: #1 Brain Games & Cognitive Training App,EDUCATION,4.2,215301,Varies with device,10000000,Free,0,Everyone,Education
+Learn English from Persian: Persian to English,EDUCATION,4.3,423,21M,100000,Free,0,Everyone,Education
+English with Lingualeo,EDUCATION,4.7,254519,27M,5000000,Free,0,Everyone,Education
+"Learn languages, grammar & vocabulary with Memrise",EDUCATION,4.7,1107903,Varies with device,10000000,Free,0,Everyone,Education
+Khan Academy,EDUCATION,4.6,85375,21M,5000000,Free,0,Everyone,Education
+TED,EDUCATION,4.6,181893,18M,10000000,Free,0,Everyone 10+,Education
+Quizlet: Learn Languages & Vocab with Flashcards,EDUCATION,4.6,211856,Varies with device,10000000,Free,0,Everyone,Education
+Udemy - Online Courses,EDUCATION,4.5,99020,18M,1000000,Free,0,Everyone,Education
+Coursera: Online courses,EDUCATION,4.4,90481,Varies with device,5000000,Free,0,Everyone,Education
+"edX - Online Courses by Harvard, MIT & more",EDUCATION,4.6,32381,10M,1000000,Free,0,Everyone 10+,Education
+Elevate - Brain Training Games,EDUCATION,4.5,248912,Varies with device,5000000,Free,0,Everyone,Education
+NeuroNation - Focus and Brain Training,EDUCATION,4.5,248555,Varies with device,5000000,Free,0,Everyone,Education;Brain Games
+Lumosity: #1 Brain Games & Cognitive Training App,EDUCATION,4.2,215301,Varies with device,10000000,Free,0,Everyone,Education
+Peak – Brain Games & Training,EDUCATION,4.4,272145,Varies with device,10000000,Free,0,Everyone,Education;Brain Games
+Memorado - Brain Games,EDUCATION,4.4,56897,97M,1000000,Free,0,Everyone,Education;Brain Games
+Lynda - Online Training Videos,EDUCATION,4.2,8599,17M,1000000,Free,0,Everyone,Education
+Brilliant,EDUCATION,4.5,41185,Varies with device,1000000,Free,0,Everyone,Education
+CppDroid - C/C++ IDE,EDUCATION,4.1,29980,Varies with device,1000000,Free,0,Everyone,Education
+Quiz&Learn Python,EDUCATION,4.0,304,2.0M,10000,Free,0,Everyone,Education
+C++ Tutorials,EDUCATION,4.1,358,1.9M,50000,Free,0,Everyone,Education
+C++ Programming,EDUCATION,4.3,11904,1.8M,1000000,Free,0,Everyone,Education
+C Programming,EDUCATION,4.3,22251,1.8M,1000000,Free,0,Everyone,Education
+Udacity - Lifelong Learning,EDUCATION,4.3,22384,17M,1000000,Free,0,Everyone,Education
+Udemy - Online Courses,EDUCATION,4.5,99020,18M,1000000,Free,0,Everyone,Education
+Learn C++,EDUCATION,4.6,73404,5.3M,1000000,Free,0,Everyone,Education
+Learn programming,EDUCATION,4.1,12733,Varies with device,1000000,Free,0,Everyone,Education
+Learn JavaScript,EDUCATION,4.6,25183,5.4M,1000000,Free,0,Everyone,Education
+Learn Java,EDUCATION,4.7,52743,5.4M,1000000,Free,0,Everyone,Education
+Learn HTML,EDUCATION,4.7,61749,5.4M,1000000,Free,0,Everyone,Education
+"Programming Hub, Learn to code",EDUCATION,4.3,55704,15M,1000000,Free,0,Everyone,Education
+Learn SQL,EDUCATION,4.7,19277,5.3M,1000000,Free,0,Everyone,Education
+Ready4 SAT (Prep4 SAT),EDUCATION,4.6,13612,48M,100000,Free,0,Everyone,Education
+Socratic - Math Answers & Homework Help,EDUCATION,4.6,37862,5.4M,1000000,Free,0,Everyone,Education
+Ready4 GMAT (Prep4 GMAT),EDUCATION,4.6,18372,47M,100000,Free,0,Everyone,Education
+Pocket GMAT Math,EDUCATION,4.3,656,556k,10000,Free,0,Everyone,Education
+GMAT Question Bank,EDUCATION,4.2,240,29M,10000,Free,0,Everyone,Education
+GRE Tutor,EDUCATION,4.0,275,2.3M,50000,Free,0,Everyone,Education
+GRE Flashcards,EDUCATION,4.5,13791,Varies with device,500000,Free,0,Everyone,Education
+"play2prep: ACT, SAT prep",EDUCATION,4.2,3692,4.4M,100000,Free,0,Everyone,Education
+SAT Test,EDUCATION,4.1,2363,6.6M,100000,Free,0,Everyone,Education
+GMAT Math Flashcards,EDUCATION,4.4,1769,Varies with device,100000,Free,0,Everyone,Education
+Pocket SAT Math,EDUCATION,4.0,430,526k,10000,Free,0,Everyone,Education
+TOEFL Prep & Practice from Magoosh,EDUCATION,4.5,756,12M,100000,Free,0,Everyone,Education
+GRE Prep & Practice by Magoosh,EDUCATION,4.4,3963,Varies with device,100000,Free,0,Everyone,Education
+GRE® Flashcards by Kaplan,EDUCATION,4.0,316,29M,50000,Free,0,Everyone,Education
+SAT Vocabulary,EDUCATION,4.2,642,Varies with device,50000,Free,0,Everyone,Education
+Magoosh GMAT Prep & Practice,EDUCATION,4.3,1058,Varies with device,100000,Free,0,Everyone,Education
+SAT Flashcards: Prep & Vocabulary,EDUCATION,4.2,2277,Varies with device,100000,Free,0,Everyone,Education
+Khan Academy,EDUCATION,4.6,85375,21M,5000000,Free,0,Everyone,Education
+TED,EDUCATION,4.6,181893,18M,10000000,Free,0,Everyone 10+,Education
+Duolingo: Learn Languages Free,EDUCATION,4.7,6290507,Varies with device,100000000,Free,0,Everyone,Education;Education
+Quizlet: Learn Languages & Vocab with Flashcards,EDUCATION,4.6,211856,Varies with device,10000000,Free,0,Everyone,Education
+Coursera: Online courses,EDUCATION,4.4,90481,Varies with device,5000000,Free,0,Everyone,Education
+Udemy - Online Courses,EDUCATION,4.5,99020,18M,1000000,Free,0,Everyone,Education
+Udacity - Lifelong Learning,EDUCATION,4.3,22384,17M,1000000,Free,0,Everyone,Education
+"edX - Online Courses by Harvard, MIT & more",EDUCATION,4.6,32380,10M,1000000,Free,0,Everyone 10+,Education
+Rosetta Stone: Learn to Speak & Read New Languages,EDUCATION,4.5,172505,76M,5000000,Free,0,Everyone,Education;Education
+Google Classroom,EDUCATION,4.2,69493,Varies with device,10000000,Free,0,Everyone,Education
+Lynda - Online Training Videos,EDUCATION,4.2,8599,17M,1000000,Free,0,Everyone,Education
+"Learn languages, grammar & vocabulary with Memrise",EDUCATION,4.7,1107884,Varies with device,10000000,Free,0,Everyone,Education
+Brilliant,EDUCATION,4.5,41185,Varies with device,1000000,Free,0,Everyone,Education
+LinkedIn Learning: Online Courses to Learn Skills,EDUCATION,4.6,7973,18M,1000000,Free,0,Everyone,Education
+Babbel – Learn Languages,EDUCATION,4.3,266935,21M,10000000,Free,0,Everyone,Education
+Learn English with Phrases,EDUCATION,4.2,5695,Varies with device,1000000,Free,0,Everyone,Education
+Free english course,EDUCATION,4.7,142632,6.9M,5000000,Free,0,Everyone,Education
+Duolingo: Learn Languages Free,EDUCATION,4.7,6290507,Varies with device,100000000,Free,0,Everyone,Education;Education
+Learn 50 languages,EDUCATION,4.4,55256,14M,5000000,Free,0,Everyone,Education
+Rosetta Stone: Learn to Speak & Read New Languages,EDUCATION,4.5,172508,76M,5000000,Free,0,Everyone,Education;Education
+Babbel – Learn Spanish,EDUCATION,4.4,54798,11M,1000000,Free,0,Everyone,Education
+Mango Languages: Lovable Language Courses,EDUCATION,4.0,4815,19M,500000,Free,0,Everyone,Education
+Learn English with Aco,EDUCATION,4.6,75112,6.5M,1000000,Free,0,Everyone,Education
+Learn to Speak English,EDUCATION,4.4,33646,7.0M,1000000,Free,0,Everyone,Education
+"Learn languages, grammar & vocabulary with Memrise",EDUCATION,4.7,1107903,Varies with device,10000000,Free,0,Everyone,Education
+Learn English with Wlingua,EDUCATION,4.7,314300,3.3M,10000000,Free,0,Everyone,Education
+"busuu: Learn Languages - Spanish, English & More",EDUCATION,4.3,206527,21M,10000000,Free,0,Everyone 10+,Education
+My Class Schedule: Timetable,EDUCATION,4.1,9348,Varies with device,1000000,Free,0,Everyone,Education
+Study Checker,EDUCATION,4.2,3816,2.6M,500000,Free,0,Everyone,Education
+My Study Life - School Planner,EDUCATION,4.3,47847,21M,1000000,Free,0,Everyone,Education
+HomeWork,EDUCATION,4.3,16195,5.2M,1000000,Free,0,Everyone,Education
+Next Gen Science Standards,EDUCATION,4.3,206,18M,50000,Free,0,Everyone,Education
+myHomework Student Planner,EDUCATION,4.0,28392,Varies with device,1000000,Free,0,Everyone,Education
+Teacher's Gradebook - Additio,EDUCATION,4.2,3241,16M,100000,Free,0,Everyone,Education
+Common Core,EDUCATION,4.0,835,15M,100000,Free,0,Everyone,Education
+Homework Planner,EDUCATION,4.0,2525,1.2M,100000,Free,0,Everyone,Education
+TeachersPayTeachers,EDUCATION,3.8,828,Varies with device,100000,Free,0,Everyone,Education
+Quizlet: Learn Languages & Vocab with Flashcards,EDUCATION,4.6,211856,Varies with device,10000000,Free,0,Everyone,Education
+Edmodo,EDUCATION,4.1,200058,18M,10000000,Free,0,Everyone,Education
+Socrative Teacher,EDUCATION,3.9,1239,1.8M,100000,Free,0,Everyone,Education
+Training schedule - AllUniver,EDUCATION,4.1,702,7.6M,10000,Free,0,Everyone,Education
+Remind: School Communication,EDUCATION,4.5,108613,Varies with device,10000000,Free,0,Everyone,Education
+Google Classroom,EDUCATION,4.2,69498,Varies with device,10000000,Free,0,Everyone,Education
+ClassDojo,EDUCATION,4.4,148550,59M,10000000,Free,0,Everyone,Education;Education
+Duolingo: Learn Languages Free,EDUCATION,4.7,6290507,Varies with device,100000000,Free,0,Everyone,Education;Education
+Lerni. Learn languages.,EDUCATION,4.0,3847,6.9M,500000,Free,0,Everyone,Education
+Learn 50 languages,EDUCATION,4.4,55256,14M,5000000,Free,0,Everyone,Education
+"HelloTalk — Chat, Speak & Learn Foreign Languages",EDUCATION,4.4,84309,41M,5000000,Free,0,Everyone,Education
+Mango Languages: Lovable Language Courses,EDUCATION,4.0,4815,19M,500000,Free,0,Everyone,Education
+Rosetta Stone: Learn to Speak & Read New Languages,EDUCATION,4.5,172508,76M,5000000,Free,0,Everyone,Education;Education
+"Learn languages, grammar & vocabulary with Memrise",EDUCATION,4.7,1107948,Varies with device,10000000,Free,0,Everyone,Education
+Babbel – Learn Languages,EDUCATION,4.3,266948,21M,10000000,Free,0,Everyone,Education
+Innovative: Learn 34 Languages,EDUCATION,4.5,14206,21M,500000,Free,0,Everyone,Education
+"busuu: Learn Languages - Spanish, English & More",EDUCATION,4.3,206532,21M,10000000,Free,0,Everyone 10+,Education
+My Class Schedule: Timetable,EDUCATION,4.1,9348,Varies with device,1000000,Free,0,Everyone,Education
+Chegg Study - Homework Help,EDUCATION,4.3,14700,21M,1000000,Free,0,Everyone,Education
+Canvas Student,EDUCATION,4.5,42828,Varies with device,1000000,Free,0,Everyone,Education
+Timetable,EDUCATION,4.2,40209,Varies with device,1000000,Free,0,Everyone,Education
+Socratic - Math Answers & Homework Help,EDUCATION,4.6,37862,5.4M,1000000,Free,0,Everyone,Education
+EasyBib: Citation Generator,EDUCATION,3.5,1405,7.3M,100000,Free,0,Everyone,Education
+Google Classroom,EDUCATION,4.2,69498,Varies with device,10000000,Free,0,Everyone,Education
+ClassDojo,EDUCATION,4.4,148549,59M,10000000,Free,0,Everyone,Education;Education
+"HelloTalk — Chat, Speak & Learn Foreign Languages",EDUCATION,4.4,84311,41M,5000000,Free,0,Everyone,Education
+Quizlet: Learn Languages & Vocab with Flashcards,EDUCATION,4.6,211856,Varies with device,10000000,Free,0,Everyone,Education
+"busuu: Learn Languages - Spanish, English & More",EDUCATION,4.3,206532,21M,10000000,Free,0,Everyone 10+,Education
+Rosetta Stone: Learn to Speak & Read New Languages,EDUCATION,4.5,172508,76M,5000000,Free,0,Everyone,Education;Education
+SoloLearn: Learn to Code for Free,EDUCATION,4.8,256079,7.6M,1000000,Free,0,Teen,Education
+Kids Learn Languages by Mondly,EDUCATION,4.4,2078,Varies with device,100000,Free,0,Everyone,Education;Education
+Blinkist - Nonfiction Books,EDUCATION,4.1,16103,13M,1000000,Free,0,Everyone,Education
+Sago Mini Hat Maker,EDUCATION,4.9,11,63M,1000,Paid,$3.99,Everyone,Education;Pretend Play
+Fuzzy Numbers: Pre-K Number Foundation,EDUCATION,4.7,21,44M,1000,Paid,$5.99,Everyone,Education;Education
+Toca Life: City,EDUCATION,4.7,31085,24M,500000,Paid,$3.99,Everyone,Education;Pretend Play
+Toca Life: Hospital,EDUCATION,4.7,3528,24M,100000,Paid,$3.99,Everyone,Education;Pretend Play
+Netflix,ENTERTAINMENT,4.4,5456208,Varies with device,100000000,Free,0,Teen,Entertainment
+Complete Spanish Movies,ENTERTAINMENT,4.0,11656,4.5M,1000000,Free,0,Everyone,Entertainment
+Pluto TV - It’s Free TV,ENTERTAINMENT,4.2,28948,Varies with device,1000000,Free,0,Teen,Entertainment
+Tubi TV - Free Movies & TV,ENTERTAINMENT,4.3,296771,11M,10000000,Free,0,Teen,Entertainment
+YouTube Kids,ENTERTAINMENT,4.5,470089,Varies with device,50000000,Free,0,Everyone,Entertainment;Music & Video
+Mobile TV,ENTERTAINMENT,3.5,10939,4.6M,10000000,Free,0,Everyone,Entertainment
+TV+,ENTERTAINMENT,4.2,98509,Varies with device,5000000,Free,0,Everyone,Entertainment
+Digital TV,ENTERTAINMENT,3.1,5241,Varies with device,5000000,Free,0,Everyone,Entertainment
+Motorola Spotlight Player™,ENTERTAINMENT,4.6,22508,3.3M,10000000,Free,0,Everyone,Entertainment
+Vigo Lite,ENTERTAINMENT,4.2,10291,6.5M,5000000,Free,0,Teen,Entertainment
+Google Play Games,ENTERTAINMENT,4.3,7165362,Varies with device,1000000000,Free,0,Teen,Entertainment
+Hotstar,ENTERTAINMENT,4.3,4885646,Varies with device,100000000,Free,0,Teen,Entertainment
+"Peers.TV: broadcast TV channels First, Match TV, TNT ...",ENTERTAINMENT,4.1,141980,Varies with device,5000000,Free,0,Teen,Entertainment
+The green alien dance,ENTERTAINMENT,3.8,6979,12M,1000000,Free,0,Everyone,Entertainment
+Spectrum TV,ENTERTAINMENT,3.4,46618,Varies with device,5000000,Free,0,Teen,Entertainment
+H TV,ENTERTAINMENT,4.3,103078,5.6M,5000000,Free,0,Everyone,Entertainment
+StarTimes - Live International Champions Cup,ENTERTAINMENT,4.4,17682,9.7M,1000000,Free,0,Everyone,Entertainment
+Cinematic Cinematic,ENTERTAINMENT,4.4,37000,15M,1000000,Free,0,Mature 17+,Entertainment
+MEGOGO - Cinema and TV,ENTERTAINMENT,4.0,175528,Varies with device,10000000,Free,0,Everyone,Entertainment
+Talking Angela,ENTERTAINMENT,3.7,1828284,52M,100000000,Free,0,Everyone,Entertainment
+DStv Now,ENTERTAINMENT,3.9,34923,Varies with device,5000000,Free,0,Teen,Entertainment
+ivi - movies and TV shows in HD,ENTERTAINMENT,4.5,684116,Varies with device,10000000,Free,0,Teen,Entertainment
+Radio Javan,ENTERTAINMENT,4.4,46916,4.5M,1000000,Free,0,Everyone,Entertainment
+Viki: Asian TV Dramas & Movies,ENTERTAINMENT,4.3,407698,Varies with device,10000000,Free,0,Teen,Entertainment
+Talking Ginger 2,ENTERTAINMENT,4.2,702975,49M,50000000,Free,0,Everyone,Entertainment
+Girly Lock Screen Wallpaper with Quotes,ENTERTAINMENT,4.2,32458,18M,5000000,Free,0,Everyone,Entertainment
+No.Draw - Colors by Number 2018,ENTERTAINMENT,4.5,235496,13M,10000000,Free,0,Everyone,Entertainment;Brain Games
+🔥 Football Wallpapers 4K | Full HD Backgrounds 😍,ENTERTAINMENT,4.7,11661,4.0M,1000000,Free,0,Everyone,Entertainment
+"Movies by Flixster, with Rotten Tomatoes",ENTERTAINMENT,4.5,653008,16M,10000000,Free,0,Everyone,Entertainment
+Low Poly – Puzzle art game,ENTERTAINMENT,4.5,23063,17M,1000000,Free,0,Everyone,Entertainment;Brain Games
+BBC Media Player,ENTERTAINMENT,3.4,87384,Varies with device,10000000,Free,0,Everyone,Entertainment
+Amazon Prime Video,ENTERTAINMENT,4.2,411683,24M,50000000,Free,0,Teen,Entertainment
+Adult Glitter Color by Number Book - Sandbox Pages,ENTERTAINMENT,4.3,8918,Varies with device,1000000,Free,0,Everyone,Entertainment;Creativity
+IMDb Movies & TV,ENTERTAINMENT,4.2,501498,12M,100000000,Free,0,Teen,Entertainment
+Twitch: Livestream Multiplayer Games & Esports,ENTERTAINMENT,4.6,2133296,Varies with device,50000000,Free,0,Teen,Entertainment
+Ziggo GO,ENTERTAINMENT,4.1,29690,78M,1000000,Free,0,Teen,Entertainment
+YouTube Gaming,ENTERTAINMENT,4.2,130549,Varies with device,5000000,Free,0,Teen,Entertainment
+PlayStation App,ENTERTAINMENT,4.2,613059,25M,50000000,Free,0,Everyone,Entertainment
+Talking Ben the Dog,ENTERTAINMENT,4.3,1633682,57M,100000000,Free,0,Everyone,Entertainment
+"Red Bull TV: Live Sports, Music & Entertainment",ENTERTAINMENT,4.4,42050,Varies with device,1000000,Free,0,Teen,Entertainment
+Trailer Addict Movie Trailers,ENTERTAINMENT,3.9,2646,9.1M,100000,Free,0,Teen,Entertainment
+Cinemark Theatres,ENTERTAINMENT,4.1,21867,39M,1000000,Free,0,Teen,Entertainment
+Regal Cinemas,ENTERTAINMENT,4.3,32732,Varies with device,1000000,Free,0,Everyone,Entertainment
+"Movies by Flixster, with Rotten Tomatoes",ENTERTAINMENT,4.5,653008,16M,10000000,Free,0,Everyone,Entertainment
+Fandango Movies - Times + Tickets,ENTERTAINMENT,4.6,243747,Varies with device,10000000,Free,0,Teen,Entertainment
+Marcus Theatres,ENTERTAINMENT,3.6,2639,8.5M,100000,Free,0,Everyone,Entertainment
+Harkins Theatres,ENTERTAINMENT,4.3,1511,12M,100000,Free,0,Everyone,Entertainment
+AMC Theatres,ENTERTAINMENT,4.3,44550,72M,1000000,Free,0,Everyone,Entertainment
+IMDb Movies & TV,ENTERTAINMENT,4.2,501497,12M,100000000,Free,0,Teen,Entertainment
+Netflix,ENTERTAINMENT,4.4,5456208,Varies with device,100000000,Free,0,Teen,Entertainment
+Food Network,ENTERTAINMENT,4.1,7813,Varies with device,500000,Free,0,Teen,Entertainment
+Cooking Channel,ENTERTAINMENT,4.1,1033,16M,100000,Free,0,Teen,Entertainment
+Animal Planet GO,ENTERTAINMENT,4.2,2442,9.6M,100000,Free,0,Teen,Entertainment
+"VRV: Anime, game videos & more",ENTERTAINMENT,3.9,15254,Varies with device,1000000,Free,0,Teen,Entertainment
+DramaFever: Stream Asian Drama Shows & Movies,ENTERTAINMENT,4.2,155234,22M,1000000,Free,0,Teen,Entertainment
+Crunchyroll - Everything Anime,ENTERTAINMENT,3.7,310066,Varies with device,10000000,Free,0,Teen,Entertainment
+Investigation Discovery GO,ENTERTAINMENT,4.5,12216,13M,1000000,Free,0,Teen,Entertainment
+Crackle - Free TV & Movies,ENTERTAINMENT,3.7,388089,Varies with device,10000000,Free,0,Teen,Entertainment
+CBS - Full Episodes & Live TV,ENTERTAINMENT,3.8,92058,12M,10000000,Free,0,Teen,Entertainment
+STARZ,ENTERTAINMENT,4.3,88185,Varies with device,10000000,Free,0,Mature 17+,Entertainment
+Acorn TV: World-class TV from Britain and Beyond,ENTERTAINMENT,3.0,493,23M,50000,Free,0,Everyone,Entertainment
+HISTORY: Watch TV Show Full Episodes & Specials,ENTERTAINMENT,4.1,33387,20M,1000000,Free,0,Teen,Entertainment
+Nick,ENTERTAINMENT,4.2,123279,25M,10000000,Free,0,Everyone 10+,Entertainment;Music & Video
+VH1,ENTERTAINMENT,4.1,27424,17M,1000000,Free,0,Teen,Entertainment
+FOX NOW - On Demand & Live TV,ENTERTAINMENT,3.9,60841,Varies with device,5000000,Free,0,Teen,Entertainment
+A&E - Watch Full Episodes of TV Shows,ENTERTAINMENT,4.0,29706,19M,1000000,Free,0,Teen,Entertainment
+The CW,ENTERTAINMENT,4.4,288150,21M,5000000,Free,0,Teen,Entertainment
+BET NOW - Watch Shows,ENTERTAINMENT,4.2,14807,19M,1000000,Free,0,Teen,Entertainment
+"Hulu: Stream TV, Movies & more",ENTERTAINMENT,4.0,319692,Varies with device,10000000,Free,0,Teen,Entertainment
+HBO NOW: Stream TV & Movies,ENTERTAINMENT,3.9,61201,Varies with device,10000000,Free,0,Teen,Entertainment
+Univision NOW - Live TV and On Demand,ENTERTAINMENT,4.0,22998,Varies with device,1000000,Free,0,Teen,Entertainment
+SHOWTIME,ENTERTAINMENT,4.2,12398,Varies with device,1000000,Free,0,Teen,Entertainment
+Lifetime - Watch Full Episodes & Original Movies,ENTERTAINMENT,4.0,35928,19M,1000000,Free,0,Teen,Entertainment
+SeriesGuide – Show & Movie Manager,ENTERTAINMENT,4.3,64448,4.4M,1000000,Free,0,Mature 17+,Entertainment
+Comedy Central,ENTERTAINMENT,3.9,22378,19M,1000000,Free,0,Teen,Entertainment
+IMDb Movies & TV,ENTERTAINMENT,4.2,501498,12M,100000000,Free,0,Teen,Entertainment
+Netflix,ENTERTAINMENT,4.4,5456599,Varies with device,100000000,Free,0,Teen,Entertainment
+Tubi TV - Free Movies & TV,ENTERTAINMENT,4.3,296829,11M,10000000,Free,0,Teen,Entertainment
+Crunchyroll - Everything Anime,ENTERTAINMENT,3.7,310095,Varies with device,10000000,Free,0,Teen,Entertainment
+STARZ,ENTERTAINMENT,4.3,88185,Varies with device,10000000,Free,0,Mature 17+,Entertainment
+Crackle - Free TV & Movies,ENTERTAINMENT,3.7,388089,Varies with device,10000000,Free,0,Teen,Entertainment
+CBS - Full Episodes & Live TV,ENTERTAINMENT,3.8,92058,12M,10000000,Free,0,Teen,Entertainment
+Nick,ENTERTAINMENT,4.2,123279,25M,10000000,Free,0,Everyone 10+,Entertainment;Music & Video
+"Hulu: Stream TV, Movies & more",ENTERTAINMENT,4.0,319691,Varies with device,10000000,Free,0,Teen,Entertainment
+FOX NOW - On Demand & Live TV,ENTERTAINMENT,3.9,60841,Varies with device,5000000,Free,0,Teen,Entertainment
+The CW,ENTERTAINMENT,4.4,288150,21M,5000000,Free,0,Teen,Entertainment
+CW Seed,ENTERTAINMENT,4.5,16372,13M,500000,Free,0,Teen,Entertainment
+The NBC App - Watch Live TV and Full Episodes,ENTERTAINMENT,4.1,58028,17M,5000000,Free,0,Teen,Entertainment
+HISTORY: Watch TV Show Full Episodes & Specials,ENTERTAINMENT,4.1,33387,20M,1000000,Free,0,Teen,Entertainment
+HBO NOW: Stream TV & Movies,ENTERTAINMENT,3.9,61201,Varies with device,10000000,Free,0,Teen,Entertainment
+WWE,ENTERTAINMENT,4.5,736864,20M,10000000,Free,0,Teen,Entertainment
+A&E - Watch Full Episodes of TV Shows,ENTERTAINMENT,4.0,29706,19M,1000000,Free,0,Teen,Entertainment
+VH1,ENTERTAINMENT,4.1,27424,17M,1000000,Free,0,Teen,Entertainment
+Universal Kids,ENTERTAINMENT,3.6,1968,21M,500000,Free,0,Everyone,Entertainment;Music & Video
+MTV,ENTERTAINMENT,3.8,35279,15M,1000000,Free,0,Teen,Entertainment
+Lifetime - Watch Full Episodes & Original Movies,ENTERTAINMENT,4.0,35931,19M,1000000,Free,0,Teen,Entertainment
+BET NOW - Watch Shows,ENTERTAINMENT,4.2,14807,19M,1000000,Free,0,Teen,Entertainment
+LEGO® TV,ENTERTAINMENT,3.7,17247,7.2M,1000000,Free,0,Everyone 10+,Entertainment;Music & Video
+HBO GO: Stream with TV Package,ENTERTAINMENT,3.8,87723,32M,10000000,Free,0,Teen,Entertainment
+Showtime Anytime,ENTERTAINMENT,3.7,18523,Varies with device,1000000,Free,0,Teen,Entertainment
+PlayKids - Educational cartoons and games for kids,ENTERTAINMENT,4.1,182103,Varies with device,10000000,Free,0,Everyone,Entertainment;Music & Video
+FOX,ENTERTAINMENT,3.7,197774,44M,10000000,Free,0,Mature 17+,Entertainment
+Telemundo Now,ENTERTAINMENT,3.9,8674,19M,1000000,Free,0,Teen,Entertainment
+Netflix,ENTERTAINMENT,4.4,5456708,Varies with device,100000000,Free,0,Teen,Entertainment
+Tubi TV - Free Movies & TV,ENTERTAINMENT,4.3,296771,11M,10000000,Free,0,Teen,Entertainment
+Vudu Movies & TV,ENTERTAINMENT,3.9,58082,Varies with device,10000000,Free,0,Teen,Entertainment
+Crackle - Free TV & Movies,ENTERTAINMENT,3.7,388089,Varies with device,10000000,Free,0,Teen,Entertainment
+Crunchyroll - Everything Anime,ENTERTAINMENT,3.7,310066,Varies with device,10000000,Free,0,Teen,Entertainment
+Nick,ENTERTAINMENT,4.2,123279,25M,10000000,Free,0,Everyone 10+,Entertainment;Music & Video
+STARZ,ENTERTAINMENT,4.3,88185,Varies with device,10000000,Free,0,Mature 17+,Entertainment
+"Hulu: Stream TV, Movies & more",ENTERTAINMENT,4.0,319691,Varies with device,10000000,Free,0,Teen,Entertainment
+Food Network,ENTERTAINMENT,4.1,7813,Varies with device,500000,Free,0,Teen,Entertainment
+FOX NOW - On Demand & Live TV,ENTERTAINMENT,3.9,60841,Varies with device,5000000,Free,0,Teen,Entertainment
+"Movies by Flixster, with Rotten Tomatoes",ENTERTAINMENT,4.5,653008,16M,10000000,Free,0,Everyone,Entertainment
+Yidio: TV Show & Movie Guide,ENTERTAINMENT,3.9,27424,Varies with device,1000000,Free,0,Teen,Entertainment
+HISTORY: Watch TV Show Full Episodes & Specials,ENTERTAINMENT,4.1,33387,20M,1000000,Free,0,Teen,Entertainment
+Viki: Asian TV Dramas & Movies,ENTERTAINMENT,4.3,407719,Varies with device,10000000,Free,0,Teen,Entertainment
+The CW,ENTERTAINMENT,4.4,288150,21M,5000000,Free,0,Teen,Entertainment
+Redbox,ENTERTAINMENT,4.1,115033,30M,10000000,Free,0,Everyone,Entertainment
+Univision NOW - Live TV and On Demand,ENTERTAINMENT,4.0,22997,Varies with device,1000000,Free,0,Teen,Entertainment
+HBO NOW: Stream TV & Movies,ENTERTAINMENT,3.9,61201,Varies with device,10000000,Free,0,Teen,Entertainment
+Tribeca Shortlist - Handpicked Movies,ENTERTAINMENT,3.9,801,57M,100000,Free,0,Teen,Entertainment
+A&E - Watch Full Episodes of TV Shows,ENTERTAINMENT,4.0,29706,19M,1000000,Free,0,Teen,Entertainment
+VH1,ENTERTAINMENT,4.1,27424,17M,1000000,Free,0,Teen,Entertainment
+SHOWTIME,ENTERTAINMENT,4.2,12398,Varies with device,1000000,Free,0,Teen,Entertainment
+MTV,ENTERTAINMENT,3.8,35279,15M,1000000,Free,0,Teen,Entertainment
+Lifetime - Watch Full Episodes & Original Movies,ENTERTAINMENT,4.0,35931,19M,1000000,Free,0,Teen,Entertainment
+Comedy Central,ENTERTAINMENT,3.9,22378,19M,1000000,Free,0,Teen,Entertainment
+BET NOW - Watch Shows,ENTERTAINMENT,4.2,14807,19M,1000000,Free,0,Teen,Entertainment
+FOX,ENTERTAINMENT,3.7,197774,44M,10000000,Free,0,Mature 17+,Entertainment
+Telemundo Now,ENTERTAINMENT,3.9,8674,19M,1000000,Free,0,Teen,Entertainment
+Nick Jr. - Shows & Games,ENTERTAINMENT,4.2,8968,35M,1000000,Free,0,Everyone,Entertainment;Music & Video
+Sticker Market: Emoji keyboard,ENTERTAINMENT,4.3,303,44M,10000,Free,0,Teen,Entertainment
+Viki: Asian TV Dramas & Movies,ENTERTAINMENT,4.3,407719,Varies with device,10000000,Free,0,Teen,Entertainment
+Kidjo TV Kids Have Fun & Learn,ENTERTAINMENT,4.6,732,Varies with device,100000,Free,0,Everyone,Entertainment;Music & Video
+Laugh Out Loud by Kevin Hart,ENTERTAINMENT,4.3,1856,20M,100000,Free,0,Teen,Entertainment
+ColorFul - Adult Coloring Book,ENTERTAINMENT,4.6,50725,19M,5000000,Free,0,Everyone,Entertainment
+Nick,ENTERTAINMENT,4.2,123279,25M,10000000,Free,0,Everyone 10+,Entertainment;Music & Video
+Fandango Movies - Times + Tickets,ENTERTAINMENT,4.6,243747,Varies with device,10000000,Free,0,Teen,Entertainment
+Hamilton — The Official App,ENTERTAINMENT,4.5,1575,43M,100000,Free,0,Everyone,Entertainment
+My Talking Pet,ENTERTAINMENT,4.6,6238,Varies with device,100000,Paid,$4.99,Everyone,Entertainment
+Funny Pics,ENTERTAINMENT,3.9,9941,Varies with device,1000000,Free,0,Teen,Entertainment
+Funny Quotes Free,ENTERTAINMENT,4.2,23666,3.6M,1000000,Free,0,Teen,Entertainment
+LOL Pics (Funny Pictures),ENTERTAINMENT,4.4,67554,7.7M,1000000,Free,0,Teen,Entertainment
+Meme Creator,ENTERTAINMENT,4.2,38769,44M,1000000,Free,0,Mature 17+,Entertainment
+"Imgur: Find funny GIFs, memes & watch viral videos",ENTERTAINMENT,4.3,160164,12M,10000000,Free,0,Teen,Entertainment
+Meme Generator,ENTERTAINMENT,4.6,3771,53M,100000,Paid,$2.99,Mature 17+,Entertainment
+SketchBook - draw and paint,ENTERTAINMENT,4.3,256664,77M,10000000,Free,0,Everyone,Entertainment
+Colorfy: Coloring Book for Adults - Free,ENTERTAINMENT,4.5,787177,Varies with device,10000000,Free,0,Everyone,Entertainment
+All Events in City,EVENTS,4.0,3782,9.5M,100000,Free,0,Everyone,Events
+Ticketmaster Event Tickets,EVENTS,4.0,40113,36M,5000000,Free,0,Everyone,Events
+Reminder,EVENTS,4.5,7074,6.3M,500000,Free,0,Everyone,Events
+Birdays - Birthday reminder,EVENTS,4.5,2153,5.9M,50000,Free,0,Everyone,Events
+"StubHub - Tickets to Sports, Concerts & Events",EVENTS,4.0,26089,Varies with device,5000000,Free,0,Everyone,Events
+Fever,EVENTS,4.0,20611,12M,1000000,Free,0,Teen,Events
+DroidAdmin for Android - Advice,EVENTS,4.2,811,2.8M,10000,Free,0,Everyone,Events
+"SeatGeek – Tickets to Sports, Concerts, Broadway",EVENTS,4.4,15558,26M,1000000,Free,0,Everyone,Events
+my4D,EVENTS,4.6,573,8.7M,100000,Free,0,Everyone,Events
+VAN NIAN 2018 - Vietnamese Calendar,EVENTS,4.4,37,16M,10000,Free,0,Everyone,Events
+Vivid Seats – Event Tickets,EVENTS,4.6,8232,53M,1000000,Free,0,Everyone,Events
+Name days,EVENTS,4.1,3089,Varies with device,100000,Free,0,Everyone,Events
+LBB - Find New & Unique Things To Do Around You,EVENTS,4.6,3874,14M,100000,Free,0,Everyone,Events
+Happy Birthday Songs Offline,EVENTS,4.4,464,8.9M,100000,Free,0,Everyone,Events
+Series Valley of the Wolves full of part,EVENTS,4.6,731,11M,50000,Free,0,Everyone,Events
+Mummatikabalkuragi,EVENTS,4.9,69,334k,1000,Free,0,Teen,Events
+"Gametime - Tickets to Sports, Concerts, Theater",EVENTS,4.5,8800,24M,1000000,Free,0,Everyone,Events
+"PTI Flex Maker, Photo Frame Editor & Songs 2018",EVENTS,4.6,99,13M,10000,Free,0,Everyone,Events
+Wipe out,EVENTS,4.7,30,Varies with device,500,Free,0,Teen,Events
+Birthdays & Other Events,EVENTS,4.3,456,2.8M,50000,Free,0,Everyone,Events
+Sarajevo Film Festival - Official,EVENTS,4.4,6,9.7M,100,Free,0,Everyone 10+,Events
+Summer Madness,EVENTS,4.4,4,1.4M,100,Free,0,Everyone,Events
+Events High - Meet Your City!,EVENTS,4.2,3200,Varies with device,100000,Free,0,Everyone 10+,Events
+vide-greniers.org,EVENTS,4.3,5839,3.5M,100000,Free,0,Everyone,Events
+SUMMER SONIC app,EVENTS,5.0,4,61M,500,Free,0,Everyone,Events
+Quake & Volcanoes: 3D Globe of Volcanic Eruptions,EVENTS,4.4,663,6.0M,100000,Free,0,Everyone,Events
+Prosperity,EVENTS,5.0,16,2.3M,100,Free,0,Everyone,Events
+Picktrainer: India's largest photo contest app,EVENTS,4.5,1065,9.0M,100000,Free,0,Everyone,Events
+AAS-IN-ASIA 2018,EVENTS,4.4,3,11M,100,Free,0,Everyone,Events
+Moot Peru 2018,EVENTS,4.4,13,27M,1000,Free,0,Everyone,Events
+FM News,EVENTS,4.4,46,3.6M,5000,Free,0,Everyone,Events
+Goldstar: Live Event Tickets,EVENTS,4.5,1953,Varies with device,100000,Free,0,Teen,Events
+Emmabodafestivalen,EVENTS,4.8,12,29M,1000,Free,0,Everyone 10+,Events
+KudaGo - things to do in NY,EVENTS,4.4,4298,4.4M,100000,Free,0,Everyone,Events
+Mindvalley U Tallinn 2018,EVENTS,5.0,1,21M,100,Free,0,Everyone,Events
+Rockmaraton Info,EVENTS,4.4,49,13M,1000,Free,0,Everyone,Events
+Freitas Auctioneer Official,EVENTS,3.7,100,27M,50000,Free,0,Everyone,Events
+mobLee Events,EVENTS,4.4,11,11M,5000,Free,0,Everyone,Events
+"Xceed - Clubs, DJs, Festivals & Tickets",EVENTS,4.1,399,24M,100000,Free,0,Everyone,Events
+AMM Events & CPD,EVENTS,4.4,5,6.1M,100,Free,0,Everyone,Events
+Arab Halls - For Wedding & Events,EVENTS,4.8,28,6.3M,1000,Free,0,Everyone,Events
+MeAuDote - An act of love that saves a life,EVENTS,4.4,250,23M,1000,Free,0,Everyone,Events
+TCF National Conference,EVENTS,4.4,1,34M,100,Free,0,Everyone,Events
+Endurance Lifestyle,EVENTS,4.6,7,3.8M,500,Free,0,Teen,Events
+K PLUS,FINANCE,4.4,124424,Varies with device,10000000,Free,0,Everyone,Finance
+ING Banking,FINANCE,4.4,39041,Varies with device,1000000,Free,0,Everyone,Finance
+Citibanamex Movil,FINANCE,3.6,52306,42M,5000000,Free,0,Everyone,Finance
+The postal bank,FINANCE,3.7,36718,Varies with device,5000000,Free,0,Everyone,Finance
+KTB Netbank,FINANCE,3.8,42644,19M,5000000,Free,0,Everyone,Finance
+Mobile Bancomer,FINANCE,4.2,278082,70M,10000000,Free,0,Everyone,Finance
+Nedbank Money,FINANCE,4.2,6076,32M,500000,Free,0,Everyone,Finance
+SCB EASY,FINANCE,4.2,112656,93M,5000000,Free,0,Everyone,Finance
+CASHIER,FINANCE,3.3,335738,Varies with device,10000000,Free,0,Everyone,Finance
+Rabo Banking,FINANCE,3.4,31906,Varies with device,1000000,Free,0,Everyone,Finance
+Capitec Remote Banking,FINANCE,4.3,20672,Varies with device,1000000,Free,0,Everyone,Finance
+Itau bank,FINANCE,4.2,957973,40M,10000000,Free,0,Everyone,Finance
+Nubank,FINANCE,4.7,130582,24M,5000000,Free,0,Everyone,Finance
+The Societe Generale App,FINANCE,4.1,31218,Varies with device,1000000,Free,0,Everyone,Finance
+IKO,FINANCE,4.7,167168,20M,1000000,Free,0,Everyone,Finance
+Cash App,FINANCE,4.0,34428,15M,10000000,Free,0,Everyone,Finance
+Standard Bank / Stanbic Bank,FINANCE,3.6,15247,28M,1000000,Free,0,Everyone,Finance
+Bualuang mBanking,FINANCE,4.0,48445,10M,5000000,Free,0,Everyone,Finance
+Intesa Sanpaolo Mobile,FINANCE,3.6,35518,Varies with device,1000000,Free,0,Everyone,Finance
+UBA Mobile Banking,FINANCE,4.3,12185,Varies with device,1000000,Free,0,Everyone,Finance
+BBVA Spain,FINANCE,4.2,36746,Varies with device,5000000,Free,0,Everyone,Finance
+MyMo by GSB,FINANCE,4.2,21996,14M,1000000,Free,0,Everyone,Finance
+VTB-Online,FINANCE,4.1,138371,Varies with device,5000000,Free,0,Everyone,Finance
+Ecobank Mobile Banking,FINANCE,4.0,12073,42M,1000000,Free,0,Everyone,Finance
+Banorte Movil,FINANCE,4.1,111632,65M,1000000,Free,0,Everyone,Finance
+Wells Fargo Mobile,FINANCE,4.4,250706,37M,10000000,Free,0,Everyone,Finance
+Credit Karma,FINANCE,4.7,706301,Varies with device,10000000,Free,0,Everyone,Finance
+BZWBK24 mobile,FINANCE,4.5,64959,39M,1000000,Free,0,Everyone,Finance
+PayPal,FINANCE,4.3,659741,47M,50000000,Free,0,Everyone,Finance
+Capital One® Mobile,FINANCE,4.6,510392,79M,10000000,Free,0,Everyone,Finance
+Zenith Bank Mobile App,FINANCE,4.3,7215,18M,1000000,Free,0,Everyone,Finance
+"GCash - Buy Load, Pay Bills, Send Money",FINANCE,4.0,25508,Varies with device,1000000,Free,0,Everyone,Finance
+Post Bank,FINANCE,4.5,60449,100M,1000000,Free,0,Everyone,Finance
+İşCep,FINANCE,4.5,381788,32M,10000000,Free,0,Everyone,Finance
+People's Bank,FINANCE,3.6,10697,46M,1000000,Free,0,Everyone,Finance
+Google Pay,FINANCE,4.2,347838,Varies with device,100000000,Free,0,Everyone,Finance
+Transfer,FINANCE,4.1,31804,9.8M,5000000,Free,0,Everyone,Finance
+T-Mobile in,FINANCE,3.5,3856,8.2M,1000000,Free,0,Everyone,Finance
+TrueMoney Wallet,FINANCE,4.4,199684,18M,5000000,Free,0,Everyone,Finance
+Alfa-Bank (Alfa-Bank),FINANCE,4.0,44545,Varies with device,1000000,Free,0,Everyone,Finance
+Bank of Brazil,FINANCE,4.5,1336246,39M,10000000,Free,0,Everyone,Finance
+WiseBanyan - Invest For Free,FINANCE,4.2,257,44M,10000,Free,0,Everyone,Finance
+"Robinhood - Investing, No Fees",FINANCE,4.6,57493,Varies with device,1000000,Free,0,Everyone,Finance
+Wells Fargo Daily Change,FINANCE,4.2,283,5.0M,100000,Free,0,Everyone,Finance
+"Even - organize your money, get paid early",FINANCE,4.8,12304,21M,100000,Free,0,Everyone,Finance
+Digit Save Money Automatically,FINANCE,4.5,8188,22M,100000,Free,0,Everyone,Finance
+Stash: Invest. Learn. Save.,FINANCE,4.2,11919,23M,1000000,Free,0,Everyone,Finance
+Acorns - Invest Spare Change,FINANCE,4.3,45957,Varies with device,1000000,Free,0,Everyone,Finance
+Google Pay,FINANCE,4.2,347838,Varies with device,100000000,Free,0,Everyone,Finance
+"Money Lover: Expense Tracker, Budget Planner",FINANCE,4.4,126431,Varies with device,1000000,Free,0,Everyone,Finance
+Expense IQ Money Manager,FINANCE,4.4,21570,27M,1000000,Free,0,Everyone,Finance
+Money Manager Expense & Budget,FINANCE,4.6,134564,Varies with device,5000000,Free,0,Everyone,Finance
+Wells Fargo Daily Change,FINANCE,4.2,283,5.0M,100000,Free,0,Everyone,Finance
+"Prism Pay Bills, Track Money, Personal Finance",FINANCE,4.6,16961,32M,500000,Free,0,Everyone,Finance
+Monefy - Money Manager,FINANCE,4.6,111254,7.4M,1000000,Free,0,Everyone,Finance
+Simple - Better Banking,FINANCE,4.4,7731,24M,100000,Free,0,Everyone,Finance
+Chime - Mobile Banking,FINANCE,4.3,5928,22M,500000,Free,0,Everyone,Finance
+Bluebird by American Express,FINANCE,4.2,15703,Varies with device,1000000,Free,0,Everyone,Finance
+Walmart MoneyCard,FINANCE,4.2,6148,10M,1000000,Free,0,Everyone,Finance
+Moven - Smart Finances,FINANCE,3.8,861,17M,100000,Free,0,Everyone,Finance
+Qapital - Save Small. Live Large,FINANCE,4.5,8662,38M,100000,Free,0,Everyone,Finance
+Experian - Free Credit Report,FINANCE,4.6,23130,46M,1000000,Free,0,Everyone,Finance
+Branch,FINANCE,4.6,69973,3.8M,1000000,Free,0,Everyone,Finance
+"WalletHub - Free Credit Score, Report & Monitoring",FINANCE,4.7,1311,9.3M,50000,Free,0,Everyone,Finance
+CreditWise from Capital One,FINANCE,4.6,26587,8.4M,1000000,Free,0,Everyone,Finance
+"NerdWallet: Personal Finance, Credit Score & Cash",FINANCE,4.6,2417,28M,100000,Free,0,Everyone,Finance
+Credit Karma,FINANCE,4.7,706302,Varies with device,10000000,Free,0,Everyone,Finance
+my face,FINANCE,3.8,1054,9.7M,100000,Free,0,Everyone,Finance
+Credit Sesame,FINANCE,4.3,25166,11M,1000000,Free,0,Everyone,Finance
+"Mint: Budget, Bills, Finance",FINANCE,4.3,129304,Varies with device,5000000,Free,0,Everyone,Finance
+Fresh EBT - Food Stamp Balance,FINANCE,4.5,19870,7.4M,1000000,Free,0,Everyone,Finance
+"Hurdlr: Track Mileage, Expenses, and Log Receipts",FINANCE,4.6,3596,19M,100000,Free,0,Everyone,Finance
+Mobills: Budget Planner,FINANCE,4.6,161440,16M,1000000,Free,0,Everyone,Finance
+Everlance: Free Mileage Log,FINANCE,4.7,7514,14M,100000,Free,0,Everyone,Finance
+MileIQ - Free Mileage Tracker for Business,FINANCE,4.5,46106,22M,1000000,Free,0,Everyone,Finance
+QuickBooks Self-Employed:Mileage Tracker and Taxes,FINANCE,4.4,15141,25M,1000000,Free,0,Everyone,Finance
+FREE Stock Market Trading Tips,FINANCE,3.9,714,3.6M,50000,Free,0,Everyone,Finance
+MetaTrader 5,FINANCE,4.5,42410,Varies with device,1000000,Free,0,Everyone,Finance
+MetaTrader 4,FINANCE,4.6,260547,Varies with device,5000000,Free,0,Everyone,Finance
+Stock Quote,FINANCE,4.1,4344,4.5M,500000,Free,0,Everyone,Finance
+Seeking Alpha,FINANCE,4.5,22808,Varies with device,1000000,Free,0,Everyone,Finance
+Stock Trainer: Virtual Trading (Stock Markets),FINANCE,4.4,42809,23M,1000000,Free,0,Everyone,Finance
+Stocks: Realtime Quotes Charts,FINANCE,4.5,16808,Varies with device,1000000,Free,0,Everyone,Finance
+"Stocks, Forex, Bitcoin, Ethereum: Portfolio & News",FINANCE,4.6,157505,Varies with device,5000000,Free,0,Everyone,Finance
+CNBC: Breaking Business News & Live Market Data,FINANCE,4.2,24647,Varies with device,1000000,Free,0,Everyone,Finance
+US Stock Market,FINANCE,4.4,1922,4.2M,100000,Free,0,Everyone,Finance
+Bloomberg Professional,FINANCE,4.1,3334,Varies with device,500000,Free,0,Everyone,Finance
+E*TRADE Mobile,FINANCE,3.9,10658,58M,1000000,Free,0,Everyone,Finance
+"Robinhood - Investing, No Fees",FINANCE,4.6,57493,Varies with device,1000000,Free,0,Everyone,Finance
+MSN Money- Stock Quotes & News,FINANCE,4.5,78361,22M,1000000,Free,0,Everyone,Finance
+Fox Business,FINANCE,3.7,2594,Varies with device,500000,Free,0,Everyone,Finance
+NSE Mobile Trading,FINANCE,4.1,13868,1.4M,1000000,Free,0,Everyone,Finance
+Yahoo Finance,FINANCE,4.4,135952,Varies with device,5000000,Free,0,Everyone,Finance
+"JStock - Stock Market, Portfolio & News",FINANCE,4.6,11066,9.1M,500000,Free,0,Everyone,Finance
+Digit Save Money Automatically,FINANCE,4.5,8188,22M,100000,Free,0,Everyone,Finance
+Acorns - Invest Spare Change,FINANCE,4.3,45962,Varies with device,1000000,Free,0,Everyone,Finance
+Webull - Stock Quotes & Free Stock Trading,FINANCE,4.3,34861,Varies with device,1000000,Free,0,Everyone,Finance
+"Trading 212 - Forex, Stocks, CFDs",FINANCE,4.3,37580,Varies with device,5000000,Free,0,Everyone,Finance
+"Moneycontrol – Stocks, Sensex, Mutual Funds, IPO",FINANCE,4.4,281485,Varies with device,5000000,Free,0,Everyone,Finance
+Current debit card and app made for teens,FINANCE,4.3,685,21M,50000,Free,0,Everyone,Finance
+"Money Lover: Expense Tracker, Budget Planner",FINANCE,4.4,126447,Varies with device,1000000,Free,0,Everyone,Finance
+"Mint: Budget, Bills, Finance",FINANCE,4.3,129304,Varies with device,5000000,Free,0,Everyone,Finance
+Betterment,FINANCE,4.4,3780,11M,100000,Free,0,Everyone,Finance
+Citizens Bank Mobile Banking,FINANCE,4.1,15192,38M,1000000,Free,0,Everyone,Finance
+GoBank,FINANCE,4.4,5950,12M,500000,Free,0,Everyone,Finance
+NetSpend Prepaid,FINANCE,4.2,15993,45M,1000000,Free,0,Everyone,Finance
+BBVA Compass Banking,FINANCE,4.3,5905,50M,500000,Free,0,Everyone,Finance
+Simple - Better Banking,FINANCE,4.4,7731,24M,100000,Free,0,Everyone,Finance
+PayPal,FINANCE,4.3,659760,47M,50000000,Free,0,Everyone,Finance
+BankMobile Vibe App,FINANCE,4.3,14627,23M,1000000,Free,0,Everyone,Finance
+Netspend Skylight ONE,FINANCE,3.9,1098,46M,100000,Free,0,Everyone,Finance
+ACE Elite,FINANCE,4.1,2898,45M,100000,Free,0,Everyone,Finance
+U.S. Bank,FINANCE,4.1,70782,50M,1000000,Free,0,Everyone,Finance
+Huntington Mobile,FINANCE,4.2,11264,24M,1000000,Free,0,Everyone,Finance
+USAA Mobile,FINANCE,4.5,100997,33M,5000000,Free,0,Everyone,Finance
+Google Pay,FINANCE,4.2,347874,Varies with device,100000000,Free,0,Everyone,Finance
+Associated Credit Union Mobile,FINANCE,4.7,3290,12M,50000,Free,0,Everyone,Finance
+Bank of America Mobile Banking,FINANCE,4.4,341090,53M,10000000,Free,0,Everyone,Finance
+USE Credit Union Mobile,FINANCE,4.6,964,14M,10000,Free,0,Everyone,Finance
+Discover Mobile,FINANCE,4.6,87951,68M,5000000,Free,0,Everyone,Finance
+Wells Fargo Mobile,FINANCE,4.4,250719,37M,10000000,Free,0,Everyone,Finance
+Capital One® Mobile,FINANCE,4.6,510401,79M,10000000,Free,0,Everyone,Finance
+Amex Mobile,FINANCE,4.3,24729,32M,1000000,Free,0,Everyone,Finance
+Citi Mobile®,FINANCE,4.0,78306,46M,5000000,Free,0,Everyone,Finance
+Navy Federal Credit Union,FINANCE,4.4,43313,40M,1000000,Free,0,Everyone,Finance
+Chase Mobile,FINANCE,4.6,1374549,32M,10000000,Free,0,Everyone,Finance
+HDFC Bank MobileBanking,FINANCE,4.2,208463,Varies with device,10000000,Free,0,Everyone,Finance
+Barclays US for Android,FINANCE,4.1,6998,24M,1000000,Free,0,Everyone,Finance
+McDonald's,FOOD_AND_DRINK,3.6,145323,42M,10000000,Free,0,Everyone,Food & Drink
+Easy and Fast Recipes,FOOD_AND_DRINK,4.2,95,12M,50000,Free,0,Everyone,Food & Drink
+Cookpad - FREE recipe search makes fun cooking · musical making!,FOOD_AND_DRINK,4.1,64784,13M,10000000,Free,0,Everyone,Food & Drink
+DELISH KITCHEN - FREE recipe movies make food fun and easy!,FOOD_AND_DRINK,4.6,32997,13M,1000000,Free,0,Everyone,Food & Drink
+Sumine side dish - dish recipe side dish,FOOD_AND_DRINK,4.2,82,4.9M,10000,Free,0,Everyone,Food & Drink
+Easy Recipes,FOOD_AND_DRINK,4.7,2707,8.9M,100000,Free,0,Everyone,Food & Drink
+Delicious Recipes,FOOD_AND_DRINK,4.7,129737,Varies with device,1000000,Free,0,Teen,Food & Drink
+Tastely,FOOD_AND_DRINK,4.7,611136,19M,10000000,Free,0,Everyone,Food & Drink
+Pastry & Cooking (Without Net),FOOD_AND_DRINK,4.7,6118,Varies with device,1000000,Free,0,Everyone,Food & Drink
+Frigo Magic: Easy recipe idea and anti-waste,FOOD_AND_DRINK,4.1,2473,14M,500000,Free,0,Everyone,Food & Drink
+McDonald's - McDonald's Japan,FOOD_AND_DRINK,3.4,109784,64M,10000000,Free,0,Everyone,Food & Drink
+Debonairs Pizza,FOOD_AND_DRINK,3.8,3320,8.4M,500000,Free,0,Everyone,Food & Drink
+Popeyes® App,FOOD_AND_DRINK,3.7,61,11M,50000,Free,0,Everyone,Food & Drink
+Dunkin' Donuts,FOOD_AND_DRINK,4.2,68103,66M,1000000,Free,0,Everyone,Food & Drink
+Pyaterochka,FOOD_AND_DRINK,3.1,8412,Varies with device,1000000,Free,0,Everyone,Food & Drink
+Refreshing app Free application that can use deal coupons,FOOD_AND_DRINK,3.5,10741,41M,1000000,Free,0,Everyone,Food & Drink
+Simple Recipes,FOOD_AND_DRINK,4.7,3803,15M,500000,Free,0,Everyone,Food & Drink
+Grubhub: Food Delivery,FOOD_AND_DRINK,4.5,155944,35M,5000000,Free,0,Everyone,Food & Drink
+Panera Bread,FOOD_AND_DRINK,4.2,10159,36M,1000000,Free,0,Everyone,Food & Drink
+Chick-fil-A,FOOD_AND_DRINK,4.3,28008,17M,5000000,Free,0,Everyone,Food & Drink
+hellofood - Food Delivery,FOOD_AND_DRINK,4.0,43614,25M,1000000,Free,0,Everyone,Food & Drink
+Starbucks,FOOD_AND_DRINK,4.5,455377,35M,10000000,Free,0,Everyone,Food & Drink
+Easy and quick desserts,FOOD_AND_DRINK,4.6,1398,10M,100000,Free,0,Everyone 10+,Food & Drink
+Domino's Pizza USA,FOOD_AND_DRINK,4.7,1032935,Varies with device,10000000,Free,0,Everyone,Food & Drink
+Chef - Recipes & Cooking,FOOD_AND_DRINK,4.1,32405,12M,5000000,Free,0,Everyone,Food & Drink
+"Delivery Club-food delivery: pizza, sushi, burger, salad",FOOD_AND_DRINK,4.3,151080,Varies with device,5000000,Free,0,Everyone,Food & Drink
+HungerStation,FOOD_AND_DRINK,3.8,22513,11M,1000000,Free,0,Everyone,Food & Drink
+Delivery yogi.,FOOD_AND_DRINK,4.4,90042,Varies with device,10000000,Free,0,Everyone,Food & Drink
+Delivery trough - delivery trough delivery trough,FOOD_AND_DRINK,4.3,58316,Varies with device,5000000,Free,0,Everyone,Food & Drink
+Dr. Oetker recipe ideas,FOOD_AND_DRINK,4.2,8509,17M,1000000,Free,0,Everyone,Food & Drink
+SONIC Drive-In,FOOD_AND_DRINK,4.3,19314,43M,1000000,Free,0,Everyone,Food & Drink
+SUBWAY®,FOOD_AND_DRINK,3.8,21314,41M,1000000,Free,0,Everyone,Food & Drink
+GialloZafferano: Recipes,FOOD_AND_DRINK,4.3,30224,Varies with device,1000000,Free,0,Everyone,Food & Drink
+Dairy Queen,FOOD_AND_DRINK,3.7,731,43M,100000,Free,0,Everyone,Food & Drink
+9th stage,FOOD_AND_DRINK,4.5,454,16M,100000,Free,0,Everyone,Food & Drink
+OpenRice,FOOD_AND_DRINK,3.6,14952,39M,1000000,Free,0,Everyone,Food & Drink
+SarashpazPapion (Cooking with Chef Bowls),FOOD_AND_DRINK,4.8,1250,13M,50000,Free,0,Everyone,Food & Drink
+Little Caesars,FOOD_AND_DRINK,3.3,1726,30M,500000,Free,0,Everyone,Food & Drink
+Recipes Pastries and homemade pies More than 500 recipes for pastries,FOOD_AND_DRINK,4.7,14065,7.1M,500000,Free,0,Everyone,Food & Drink
+Om Waleed Sweets,FOOD_AND_DRINK,4.6,556,23M,100000,Free,0,Teen,Food & Drink
+"Eat Fast Prepare ""Without Internet""",FOOD_AND_DRINK,4.6,4925,17M,1000000,Free,0,Everyone,Food & Drink
+Wendy’s – Food and Offers,FOOD_AND_DRINK,3.4,6507,18M,1000000,Free,0,Everyone,Food & Drink
+My Recipes Cookbook : RecetteTek,FOOD_AND_DRINK,4.6,11707,Varies with device,100000,Free,0,Everyone,Food & Drink
+Healthy Recipes Free,FOOD_AND_DRINK,4.0,1077,17M,100000,Free,0,Everyone,Food & Drink
+Cookbook Recipes,FOOD_AND_DRINK,4.1,46539,Varies with device,5000000,Free,0,Teen,Food & Drink
+ChefTap Recipes & Grocery List,FOOD_AND_DRINK,4.5,9066,15M,500000,Free,0,Everyone,Food & Drink
+Recipe Keeper,FOOD_AND_DRINK,4.4,1962,22M,100000,Free,0,Everyone,Food & Drink
+My CookBook (Recipe Manager),FOOD_AND_DRINK,4.5,22071,Varies with device,1000000,Free,0,Everyone,Food & Drink
+50 Healthy Slow Cooker Recipes,FOOD_AND_DRINK,4.0,196,9.0M,10000,Free,0,Everyone 10+,Food & Drink
+Easy Healthy Recipes,FOOD_AND_DRINK,4.1,278,7.2M,50000,Free,0,Everyone,Food & Drink
+Allrecipes Dinner Spinner,FOOD_AND_DRINK,4.5,61881,Varies with device,5000000,Free,0,Everyone,Food & Drink
+My CookBook Pro (Ad Free),FOOD_AND_DRINK,4.6,2129,Varies with device,10000,Paid,$3.49,Everyone,Food & Drink
+Paprika Recipe Manager,FOOD_AND_DRINK,4.1,1268,2.3M,50000,Paid,$4.99,Everyone,Food & Drink
+Yummly Recipes & Shopping List,FOOD_AND_DRINK,4.5,91359,27M,1000000,Free,0,Everyone,Food & Drink
+Kitchen Stories - Recipes & Cooking,FOOD_AND_DRINK,4.6,22015,Varies with device,1000000,Free,0,Everyone,Food & Drink
+Cookpad,FOOD_AND_DRINK,4.5,131569,8.2M,10000000,Free,0,Everyone,Food & Drink
+"BigOven Recipes, Meal Planner, Grocery List & More",FOOD_AND_DRINK,4.3,31986,76M,1000000,Free,0,Teen,Food & Drink
+Postmates Food Delivery: Order Eats & Alcohol,FOOD_AND_DRINK,3.6,22875,22M,1000000,Free,0,Everyone,Food & Drink
+Instacart: Grocery Delivery,FOOD_AND_DRINK,4.4,17071,Varies with device,1000000,Free,0,Everyone,Food & Drink
+OpenTable: Restaurants Near Me,FOOD_AND_DRINK,4.6,90242,19M,5000000,Free,0,Everyone,Food & Drink
+Foursquare City Guide,FOOD_AND_DRINK,4.1,483960,Varies with device,10000000,Free,0,Teen,Food & Drink
+Zomato - Restaurant Finder and Food Delivery App,FOOD_AND_DRINK,4.3,511228,Varies with device,10000000,Free,0,Everyone,Food & Drink
+Munchery: Chef Crafted Fresh Food Delivered,FOOD_AND_DRINK,3.9,464,28M,50000,Free,0,Everyone,Food & Drink
+Grubhub: Food Delivery,FOOD_AND_DRINK,4.5,155944,35M,5000000,Free,0,Everyone,Food & Drink
+"delivery.com: Order Food, Alcohol & Laundry",FOOD_AND_DRINK,4.1,1920,Varies with device,100000,Free,0,Everyone,Food & Drink
+Postmates Food Delivery: Order Eats & Alcohol,FOOD_AND_DRINK,3.6,22875,22M,1000000,Free,0,Everyone,Food & Drink
+Domino's Pizza USA,FOOD_AND_DRINK,4.7,1032935,Varies with device,10000000,Free,0,Everyone,Food & Drink
+Eat24 Food Delivery & Takeout,FOOD_AND_DRINK,4.3,40116,Varies with device,1000000,Free,0,Everyone,Food & Drink
+BeyondMenu Food Delivery,FOOD_AND_DRINK,4.7,51517,Varies with device,1000000,Free,0,Everyone,Food & Drink
+EatStreet Food Delivery App,FOOD_AND_DRINK,4.6,7690,25M,100000,Free,0,Everyone,Food & Drink
+Pizza Hut,FOOD_AND_DRINK,4.4,321134,30M,10000000,Free,0,Everyone,Food & Drink
+Caviar - Food Delivery,FOOD_AND_DRINK,4.2,3755,8.5M,100000,Free,0,Everyone,Food & Drink
+DoorDash - Food Delivery,FOOD_AND_DRINK,4.5,104504,Varies with device,1000000,Free,0,Everyone,Food & Drink
+Chick-fil-A,FOOD_AND_DRINK,4.3,28009,17M,5000000,Free,0,Everyone,Food & Drink
+Uber Eats: Local Food Delivery,FOOD_AND_DRINK,4.2,333208,34M,10000000,Free,0,Everyone,Food & Drink
+Seamless Food Delivery/Takeout,FOOD_AND_DRINK,4.5,35218,34M,1000000,Free,0,Everyone,Food & Drink
+Talabat: Food Delivery,FOOD_AND_DRINK,4.5,116403,Varies with device,5000000,Free,0,Everyone,Food & Drink
+TheFork - Restaurants booking and special offers,FOOD_AND_DRINK,4.3,37517,17M,5000000,Free,0,Everyone,Food & Drink
+foodpanda - Local Food Delivery,FOOD_AND_DRINK,4.0,292969,16M,10000000,Free,0,Everyone,Food & Drink
+Zomato - Restaurant Finder and Food Delivery App,FOOD_AND_DRINK,4.3,511420,Varies with device,10000000,Free,0,Everyone,Food & Drink
+Home Workout - No Equipment,HEALTH_AND_FITNESS,4.8,428156,15M,10000000,Free,0,Everyone,Health & Fitness
+Step Counter - Calorie Counter,HEALTH_AND_FITNESS,4.0,1577,2.2M,500000,Free,0,Everyone,Health & Fitness
+Lose Belly Fat in 30 Days - Flat Stomach,HEALTH_AND_FITNESS,4.9,38098,11M,5000000,Free,0,Everyone,Health & Fitness
+Pedometer - Step Counter Free & Calorie Burner,HEALTH_AND_FITNESS,4.8,31139,6.9M,1000000,Free,0,Everyone,Health & Fitness
+Six Pack in 30 Days - Abs Workout,HEALTH_AND_FITNESS,4.9,272337,13M,10000000,Free,0,Everyone,Health & Fitness
+Lose Weight in 30 Days,HEALTH_AND_FITNESS,4.8,220125,11M,10000000,Free,0,Everyone,Health & Fitness
+Pedometer,HEALTH_AND_FITNESS,4.4,400592,2.9M,10000000,Free,0,Everyone,Health & Fitness
+LG Health,HEALTH_AND_FITNESS,3.3,20098,25M,10000000,Free,0,Everyone,Health & Fitness
+Step Counter - Pedometer Free & Calorie Counter,HEALTH_AND_FITNESS,4.7,117925,7.0M,10000000,Free,0,Everyone,Health & Fitness
+"Pedometer, Step Counter & Weight Loss Tracker App",HEALTH_AND_FITNESS,4.6,548021,27M,10000000,Free,0,Everyone,Health & Fitness
+Sportractive GPS Running Cycling Distance Tracker,HEALTH_AND_FITNESS,4.8,48276,7.5M,1000000,Free,0,Everyone,Health & Fitness
+30 Day Fitness Challenge - Workout at Home,HEALTH_AND_FITNESS,4.8,471036,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Home Workout for Men - Bodybuilding,HEALTH_AND_FITNESS,4.8,12705,15M,1000000,Free,0,Everyone,Health & Fitness
+Fat Burning Workout - Home Weight lose,HEALTH_AND_FITNESS,4.5,706,9.4M,100000,Free,0,Everyone,Health & Fitness
+Buttocks and Abdomen,HEALTH_AND_FITNESS,4.4,465,6.4M,500000,Free,0,Everyone,Health & Fitness
+Walking for Weight Loss - Walk Tracker,HEALTH_AND_FITNESS,4.5,644,5.5M,100000,Free,0,Everyone,Health & Fitness
+Running & Jogging,HEALTH_AND_FITNESS,4.5,6238,3.9M,500000,Free,0,Everyone,Health & Fitness
+Walk with Map My Walk,HEALTH_AND_FITNESS,4.5,144040,55M,5000000,Free,0,Everyone,Health & Fitness
+Sleep Sounds,HEALTH_AND_FITNESS,4.8,51227,28M,1000000,Free,0,Everyone,Health & Fitness
+Fitbit,HEALTH_AND_FITNESS,3.9,357417,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Lose Belly Fat-Home Abs Fitness Workout,HEALTH_AND_FITNESS,4.6,199,8.8M,50000,Free,0,Everyone,Health & Fitness
+Runtastic Running App & Mile Tracker,HEALTH_AND_FITNESS,4.5,827597,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Cycling - Bike Tracker,HEALTH_AND_FITNESS,4.5,9116,4.0M,500000,Free,0,Everyone,Health & Fitness
+Abs Training-Burn belly fat,HEALTH_AND_FITNESS,4.7,2071,6.9M,100000,Free,0,Everyone,Health & Fitness
+Calorie Counter - EasyFit free,HEALTH_AND_FITNESS,4.7,50294,11M,1000000,Free,0,Everyone,Health & Fitness
+Nike+ Run Club,HEALTH_AND_FITNESS,4.4,708674,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Aunjai i lert u,HEALTH_AND_FITNESS,4.2,1140,5.5M,500000,Free,0,Teen,Health & Fitness
+Garmin Connect™,HEALTH_AND_FITNESS,3.9,232153,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+BetterMe: Weight Loss Workouts,HEALTH_AND_FITNESS,4.2,14709,15M,5000000,Free,0,Everyone,Health & Fitness
+Bike Computer - GPS Cycling Tracker,HEALTH_AND_FITNESS,4.4,12029,4.3M,1000000,Free,0,Everyone,Health & Fitness
+Calorie Counter - MyFitnessPal,HEALTH_AND_FITNESS,4.6,1873516,Varies with device,50000000,Free,0,Everyone,Health & Fitness
+Six Packs for Man–Body Building with No Equipment,HEALTH_AND_FITNESS,4.6,2880,7.1M,100000,Free,0,Everyone,Health & Fitness
+Weight Watchers Mobile,HEALTH_AND_FITNESS,4.2,270267,58M,5000000,Free,0,Everyone,Health & Fitness
+Endomondo - Running & Walking,HEALTH_AND_FITNESS,4.5,559186,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Running Distance Tracker +,HEALTH_AND_FITNESS,4.7,77777,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+The TK-App - everything under control,HEALTH_AND_FITNESS,4.5,8642,18M,100000,Free,0,Everyone,Health & Fitness
+Runkeeper - GPS Track Run Walk,HEALTH_AND_FITNESS,4.5,501144,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Walking: Pedometer diet,HEALTH_AND_FITNESS,3.7,1861,1.5M,1000000,Free,0,Everyone,Health & Fitness
+Recipes for hair and face tried,HEALTH_AND_FITNESS,4.5,1203,6.5M,500000,Free,0,Everyone,Health & Fitness
+Abs Workout - 30 Days Fitness App for Six Pack Abs,HEALTH_AND_FITNESS,4.6,299,11M,100000,Free,0,Everyone,Health & Fitness
+8fit Workouts & Meal Planner,HEALTH_AND_FITNESS,4.6,115721,67M,10000000,Free,0,Everyone,Health & Fitness
+Keep Trainer - Workout Trainer & Fitness Coach,HEALTH_AND_FITNESS,4.7,14810,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+Run with Map My Run,HEALTH_AND_FITNESS,4.5,183662,57M,5000000,Free,0,Everyone,Health & Fitness
+Weight Loss Running by Verv,HEALTH_AND_FITNESS,4.5,27393,59M,1000000,Free,0,Mature 17+,Health & Fitness
+Couch to 10K Running Trainer,HEALTH_AND_FITNESS,4.6,10445,48M,500000,Free,0,Everyone,Health & Fitness
+PumpUp — Fitness Community,HEALTH_AND_FITNESS,4.0,49479,57M,1000000,Free,0,Teen,Health & Fitness
+"Home workouts - fat burning, abs, legs, arms,chest",HEALTH_AND_FITNESS,4.3,4848,13M,1000000,Free,0,Everyone,Health & Fitness
+Running Weight Loss Walking Jogging Hiking FITAPP,HEALTH_AND_FITNESS,4.4,20812,Varies with device,1000000,Free,0,Teen,Health & Fitness
+"Strava Training: Track Running, Cycling & Swimming",HEALTH_AND_FITNESS,4.5,328469,Varies with device,10000000,Free,0,Teen,Health & Fitness
+Workout Trainer: fitness coach,HEALTH_AND_FITNESS,4.2,100406,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+"Fabulous: Motivate Me! Meditate, Relax, Sleep",HEALTH_AND_FITNESS,4.6,205299,31M,5000000,Free,0,Everyone,Health & Fitness
+StrongLifts 5x5 Workout Gym Log & Personal Trainer,HEALTH_AND_FITNESS,4.9,66791,10M,1000000,Free,0,Everyone,Health & Fitness
+Run with Map My Run,HEALTH_AND_FITNESS,4.5,183669,57M,5000000,Free,0,Everyone,Health & Fitness
+7 Minute Workout,HEALTH_AND_FITNESS,4.5,399009,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Workout Tracker & Gym Trainer - Fitness Log Book,HEALTH_AND_FITNESS,4.6,5420,21M,500000,Free,0,Everyone,Health & Fitness
+Freeletics: Personal Trainer & Fitness Workouts,HEALTH_AND_FITNESS,4.5,130104,25M,10000000,Free,0,Everyone,Health & Fitness
+Nike Training Club - Workouts & Fitness Plans,HEALTH_AND_FITNESS,4.6,251534,93M,10000000,Free,0,Everyone,Health & Fitness
+Fitbit Coach,HEALTH_AND_FITNESS,4.6,28951,60M,1000000,Free,0,Everyone,Health & Fitness
+"JEFIT Workout Tracker, Weight Lifting, Gym Log App",HEALTH_AND_FITNESS,4.5,60096,27M,5000000,Free,0,Teen,Health & Fitness
+Map My Ride GPS Cycling Riding,HEALTH_AND_FITNESS,4.5,106547,54M,1000000,Free,0,Everyone,Health & Fitness
+Daily Workouts - Exercise Fitness Routine Trainer,HEALTH_AND_FITNESS,4.4,134195,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Google Fit - Fitness Tracking,HEALTH_AND_FITNESS,3.9,249855,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Weight Loss Running by Verv,HEALTH_AND_FITNESS,4.5,27396,59M,1000000,Free,0,Mature 17+,Health & Fitness
+Nike+ Run Club,HEALTH_AND_FITNESS,4.4,708710,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Sworkit: Workouts & Fitness Plans,HEALTH_AND_FITNESS,4.6,109756,78M,5000000,Free,0,Everyone,Health & Fitness
+Map My Fitness Workout Trainer,HEALTH_AND_FITNESS,4.4,38343,55M,1000000,Free,0,Everyone,Health & Fitness
+Sports Tracker Running Cycling,HEALTH_AND_FITNESS,4.5,190247,Varies with device,5000000,Free,0,Everyone,Health & Fitness
+Runtastic Running App & Mile Tracker,HEALTH_AND_FITNESS,4.5,827651,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+8fit Workouts & Meal Planner,HEALTH_AND_FITNESS,4.6,115721,67M,10000000,Free,0,Everyone,Health & Fitness
+Seven - 7 Minute Workout Training Challenge,HEALTH_AND_FITNESS,4.5,75571,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+Daily Yoga - Yoga Fitness Plans,HEALTH_AND_FITNESS,4.4,70769,35M,5000000,Free,0,Everyone,Health & Fitness
+Pocket Yoga,HEALTH_AND_FITNESS,4.4,2107,Varies with device,100000,Paid,$2.99,Everyone,Health & Fitness
+Relax Meditation: Sleep with Sleep Sounds,HEALTH_AND_FITNESS,4.4,26540,43M,1000000,Free,0,Everyone,Health & Fitness
+Free Meditation - Take a Break,HEALTH_AND_FITNESS,4.2,1608,39M,100000,Free,0,Everyone,Health & Fitness
+Meditate OM,HEALTH_AND_FITNESS,4.5,19074,4.2M,1000000,Free,0,Everyone,Health & Fitness
+Yoga - Track Yoga,HEALTH_AND_FITNESS,4.5,7976,44M,500000,Free,0,Everyone,Health & Fitness
+My Chakra Meditation,HEALTH_AND_FITNESS,4.4,7586,45M,500000,Free,0,Everyone,Health & Fitness
+Relax with Andrew Johnson Lite,HEALTH_AND_FITNESS,4.3,2885,Varies with device,100000,Free,0,Everyone,Health & Fitness
+"Meditation Music - Relax, Yoga",HEALTH_AND_FITNESS,4.6,48226,28M,1000000,Free,0,Everyone,Health & Fitness
+Meditation Studio,HEALTH_AND_FITNESS,4.6,1026,29M,10000,Paid,$3.99,Everyone,Health & Fitness
+Down Dog: Great Yoga Anywhere,HEALTH_AND_FITNESS,4.9,28945,12M,500000,Free,0,Teen,Health & Fitness
+21-Day Meditation Experience,HEALTH_AND_FITNESS,4.4,11506,15M,100000,Free,0,Everyone,Health & Fitness
+My Chakra Meditation 2,HEALTH_AND_FITNESS,4.3,1288,31M,100000,Free,0,Everyone,Health & Fitness
+Simply Yoga - Fitness Trainer for Workouts & Poses,HEALTH_AND_FITNESS,4.1,6826,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+"Calm - Meditate, Sleep, Relax",HEALTH_AND_FITNESS,4.6,111450,Varies with device,5000000,Free,0,Everyone,Health & Fitness
+Relax Melodies P: Sleep Sounds,HEALTH_AND_FITNESS,4.8,19543,Varies with device,100000,Paid,$2.99,Everyone,Health & Fitness
+Relax Melodies: Sleep Sounds,HEALTH_AND_FITNESS,4.5,233243,Varies with device,5000000,Free,0,Everyone,Health & Fitness
+Simple Habit Meditation,HEALTH_AND_FITNESS,4.7,11689,20M,500000,Free,0,Everyone,Health & Fitness
+Headspace: Meditation & Mindfulness,HEALTH_AND_FITNESS,4.6,77563,39M,10000000,Free,0,Everyone,Health & Fitness
+Yoga Studio: Mind & Body,HEALTH_AND_FITNESS,4.3,5499,94M,100000,Free,0,Everyone,Health & Fitness
+Daily Yoga - Yoga Fitness Plans,HEALTH_AND_FITNESS,4.4,70769,35M,5000000,Free,0,Everyone,Health & Fitness
+Pocket Yoga,HEALTH_AND_FITNESS,4.4,2107,Varies with device,100000,Paid,$2.99,Everyone,Health & Fitness
+Pregnancy & Baby Tracker,HEALTH_AND_FITNESS,4.6,48286,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+My Cycles Period and Ovulation,HEALTH_AND_FITNESS,4.3,26652,41M,1000000,Free,0,Everyone,Health & Fitness
+I’m Expecting - Pregnancy App,HEALTH_AND_FITNESS,4.6,71269,49M,1000000,Free,0,Everyone,Health & Fitness
+The Bump Pregnancy Tracker,HEALTH_AND_FITNESS,4.6,20301,22M,1000000,Free,0,Everyone,Health & Fitness
+My Days - Ovulation Calendar & Period Tracker ™,HEALTH_AND_FITNESS,4.5,93691,Varies with device,5000000,Free,0,Everyone,Health & Fitness
+Best Ovulation Tracker Fertility Calendar App Glow,HEALTH_AND_FITNESS,4.6,56145,23M,1000000,Free,0,Everyone,Health & Fitness
+"Eve Period Tracker - Love, Sex & Relationships App",HEALTH_AND_FITNESS,4.6,20326,28M,1000000,Free,0,Teen,Health & Fitness
+Fertility Friend Ovulation App,HEALTH_AND_FITNESS,4.5,12955,7.2M,1000000,Free,0,Teen,Health & Fitness
+Pregnancy Tracker,HEALTH_AND_FITNESS,4.1,2681,6.5M,500000,Free,0,Everyone,Health & Fitness
+Period Tracker,HEALTH_AND_FITNESS,4.5,325738,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+"Spot On Period, Birth Control, & Cycle Tracker",HEALTH_AND_FITNESS,4.6,4102,24M,500000,Free,0,Everyone 10+,Health & Fitness
+OvuView: Ovulation and Fertility,HEALTH_AND_FITNESS,4.5,40296,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+Period Tracker - Period Calendar Ovulation Tracker,HEALTH_AND_FITNESS,4.8,4559407,Varies with device,100000000,Free,0,Everyone,Health & Fitness
+Period Tracker Clue: Period and Ovulation Tracker,HEALTH_AND_FITNESS,4.8,570242,20M,10000000,Free,0,Everyone,Health & Fitness
+Calorie Counter - MyFitnessPal,HEALTH_AND_FITNESS,4.6,1873523,Varies with device,50000000,Free,0,Everyone,Health & Fitness
+WomanLog Calendar,HEALTH_AND_FITNESS,4.5,121838,15M,5000000,Free,0,Everyone,Health & Fitness
+Geocaching®,HEALTH_AND_FITNESS,4.1,62616,Varies with device,5000000,Free,0,Teen,Health & Fitness
+Map My Hike GPS Hiking,HEALTH_AND_FITNESS,4.4,12858,55M,500000,Free,0,Everyone,Health & Fitness
+"ViewRanger - Hike, Ride or Walk",HEALTH_AND_FITNESS,4.2,34356,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+Runtastic Mountain Bike GPS Tracker,HEALTH_AND_FITNESS,4.5,50679,38M,1000000,Free,0,Everyone,Health & Fitness
+"AllTrails: Hiking, Running & Mountain Bike Trails",HEALTH_AND_FITNESS,4.3,16943,32M,1000000,Free,0,Everyone,Health & Fitness
+Water Drink Reminder,HEALTH_AND_FITNESS,4.6,524299,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+"Zombies, Run! 5k Training (Free)",HEALTH_AND_FITNESS,4.0,267,Varies with device,50000,Free,0,Teen,Health & Fitness
+Tracks,HEALTH_AND_FITNESS,4.6,623,40M,50000,Free,0,Everyone 10+,Health & Fitness
+Weight Loss Running by Verv,HEALTH_AND_FITNESS,4.5,27396,59M,1000000,Free,0,Mature 17+,Health & Fitness
+Nike+ Run Club,HEALTH_AND_FITNESS,4.4,708710,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Seven - 7 Minute Workout Training Challenge,HEALTH_AND_FITNESS,4.5,75571,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+"YAZIO Calorie Counter, Nutrition Diary & Diet Plan",HEALTH_AND_FITNESS,4.6,117176,Varies with device,5000000,Free,0,Everyone,Health & Fitness
+"Technutri - calorie counter, diet and carb tracker",HEALTH_AND_FITNESS,4.4,70416,23M,5000000,Free,0,Everyone,Health & Fitness
+Couch to 5K by RunDouble,HEALTH_AND_FITNESS,4.7,15674,6.1M,1000000,Free,0,Everyone,Health & Fitness
+Fooducate Healthy Weight Loss & Calorie Counter,HEALTH_AND_FITNESS,4.4,14402,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+Weight Watchers Mobile,HEALTH_AND_FITNESS,4.2,270294,58M,5000000,Free,0,Everyone,Health & Fitness
+Walk with Map My Walk,HEALTH_AND_FITNESS,4.5,144050,55M,5000000,Free,0,Everyone,Health & Fitness
+Workout Trainer: fitness coach,HEALTH_AND_FITNESS,4.2,100406,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+My Diet Coach - Weight Loss Motivation & Tracker,HEALTH_AND_FITNESS,4.4,141163,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Run with Map My Run,HEALTH_AND_FITNESS,4.5,183669,57M,5000000,Free,0,Everyone,Health & Fitness
+Nike Training Club - Workouts & Fitness Plans,HEALTH_AND_FITNESS,4.6,251534,93M,10000000,Free,0,Everyone,Health & Fitness
+Fitbit Coach,HEALTH_AND_FITNESS,4.6,28951,60M,1000000,Free,0,Everyone,Health & Fitness
+Calorie Counter - MyFitnessPal,HEALTH_AND_FITNESS,4.6,1873520,Varies with device,50000000,Free,0,Everyone,Health & Fitness
+Endomondo - Running & Walking,HEALTH_AND_FITNESS,4.5,559262,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Runkeeper - GPS Track Run Walk,HEALTH_AND_FITNESS,4.5,501144,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Nike+ Run Club,HEALTH_AND_FITNESS,4.4,708753,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Lose It! - Calorie Counter,HEALTH_AND_FITNESS,4.4,69395,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Runtastic Running App & Mile Tracker,HEALTH_AND_FITNESS,4.5,827653,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Calorie Counter - MyNetDiary,HEALTH_AND_FITNESS,4.5,27439,19M,1000000,Free,0,Everyone,Health & Fitness
+10 Best Foods for You,HEALTH_AND_FITNESS,4.0,2490,3.8M,500000,Free,0,Everyone 10+,Health & Fitness
+MyPlate Calorie Tracker,HEALTH_AND_FITNESS,4.6,24094,18M,1000000,Free,0,Everyone,Health & Fitness
+My Diet Diary Calorie Counter,HEALTH_AND_FITNESS,4.1,18539,57M,1000000,Free,0,Everyone,Health & Fitness
+Calorie Counter - Macros,HEALTH_AND_FITNESS,4.0,3061,5.5M,100000,Free,0,Everyone,Health & Fitness
+Calorie Counter by FatSecret,HEALTH_AND_FITNESS,4.4,229210,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Weight Loss Tracker - RecStyle,HEALTH_AND_FITNESS,4.4,20547,5.7M,1000000,Free,0,Everyone,Health & Fitness
+Lark - 24/7 Health Coach,HEALTH_AND_FITNESS,4.1,3405,51M,100000,Free,0,Everyone,Health & Fitness
+MealLogger-Photo Food Journal,HEALTH_AND_FITNESS,3.5,217,9.4M,50000,Free,0,Teen,Health & Fitness
+Health and Nutrition Guide,HEALTH_AND_FITNESS,4.3,7895,3.3M,500000,Free,0,Everyone,Health & Fitness
+Calorie Counter & Diet Tracker,HEALTH_AND_FITNESS,4.5,32606,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+Food Calorie Calculator,HEALTH_AND_FITNESS,4.2,1324,4.0M,100000,Free,0,Everyone,Health & Fitness
+Calorie Counter - MyFitnessPal,HEALTH_AND_FITNESS,4.6,1873520,Varies with device,50000000,Free,0,Everyone,Health & Fitness
+Lose It! - Calorie Counter,HEALTH_AND_FITNESS,4.4,69395,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Calorie Counter - MyNetDiary,HEALTH_AND_FITNESS,4.5,27439,19M,1000000,Free,0,Everyone,Health & Fitness
+10 Best Foods for You,HEALTH_AND_FITNESS,4.0,2490,3.8M,500000,Free,0,Everyone 10+,Health & Fitness
+Monitor Your Weight,HEALTH_AND_FITNESS,4.5,126017,4.3M,5000000,Free,0,Everyone,Health & Fitness
+MyPlate Calorie Tracker,HEALTH_AND_FITNESS,4.6,24094,18M,1000000,Free,0,Everyone,Health & Fitness
+Weight Loss Tracker - RecStyle,HEALTH_AND_FITNESS,4.4,20547,5.7M,1000000,Free,0,Everyone,Health & Fitness
+Calorie Counter by FatSecret,HEALTH_AND_FITNESS,4.4,229214,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Eat Fit - Diet and Health Free,HEALTH_AND_FITNESS,4.1,2469,3.6M,100000,Free,0,Everyone,Health & Fitness
+Calorie Counter - Macros,HEALTH_AND_FITNESS,4.0,3061,5.5M,100000,Free,0,Everyone,Health & Fitness
+My Diet Diary Calorie Counter,HEALTH_AND_FITNESS,4.1,18539,57M,1000000,Free,0,Everyone,Health & Fitness
+Lark - 24/7 Health Coach,HEALTH_AND_FITNESS,4.1,3405,51M,100000,Free,0,Everyone,Health & Fitness
+Weight Watchers Mobile,HEALTH_AND_FITNESS,4.2,270294,58M,5000000,Free,0,Everyone,Health & Fitness
+Calorie Counter & Diet Tracker,HEALTH_AND_FITNESS,4.5,32606,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+MealLogger-Photo Food Journal,HEALTH_AND_FITNESS,3.5,217,9.4M,50000,Free,0,Teen,Health & Fitness
+Health and Nutrition Guide,HEALTH_AND_FITNESS,4.3,7895,3.3M,500000,Free,0,Everyone,Health & Fitness
+Food Calorie Calculator,HEALTH_AND_FITNESS,4.2,1324,4.0M,100000,Free,0,Everyone,Health & Fitness
+Calorie Counter - MyFitnessPal,HEALTH_AND_FITNESS,4.6,1873523,Varies with device,50000000,Free,0,Everyone,Health & Fitness
+Lose It! - Calorie Counter,HEALTH_AND_FITNESS,4.4,69395,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Self Healing,HEALTH_AND_FITNESS,4.5,14394,9.9M,500000,Free,0,Everyone,Health & Fitness
+Relax Meditation: Sleep with Sleep Sounds,HEALTH_AND_FITNESS,4.4,26540,43M,1000000,Free,0,Everyone,Health & Fitness
+Happify,HEALTH_AND_FITNESS,3.7,1812,37M,100000,Free,0,Everyone,Health & Fitness
+Binaural Beats Therapy,HEALTH_AND_FITNESS,4.3,13724,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+Pacifica - Stress & Anxiety,HEALTH_AND_FITNESS,4.5,10253,Varies with device,500000,Free,0,Teen,Health & Fitness
+Relaxing Sounds,HEALTH_AND_FITNESS,4.6,4642,40M,100000,Free,0,Everyone,Health & Fitness
+White Sound Pro,HEALTH_AND_FITNESS,4.7,16570,73M,500000,Free,0,Everyone,Health & Fitness
+"Meditation Music - Relax, Yoga",HEALTH_AND_FITNESS,4.6,48226,28M,1000000,Free,0,Everyone,Health & Fitness
+Insight Timer - Free Meditation App,HEALTH_AND_FITNESS,4.6,20161,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+Self-help Anxiety Management,HEALTH_AND_FITNESS,4.0,2894,23M,500000,Free,0,Everyone 10+,Health & Fitness
+Brain Waves - Binaural Beats,HEALTH_AND_FITNESS,4.4,5038,10M,500000,Free,0,Everyone,Health & Fitness
+21-Day Meditation Experience,HEALTH_AND_FITNESS,4.4,11506,15M,100000,Free,0,Everyone,Health & Fitness
+Prana Breath: Calm & Meditate,HEALTH_AND_FITNESS,4.8,31665,8.4M,1000000,Free,0,Everyone,Health & Fitness
+"Fabulous: Motivate Me! Meditate, Relax, Sleep",HEALTH_AND_FITNESS,4.6,205299,31M,5000000,Free,0,Everyone,Health & Fitness
+7 Cups: Anxiety & Stress Chat,HEALTH_AND_FITNESS,4.2,13799,Varies with device,500000,Free,0,Teen,Health & Fitness
+"Calm - Meditate, Sleep, Relax",HEALTH_AND_FITNESS,4.6,111455,Varies with device,5000000,Free,0,Everyone,Health & Fitness
+Runtastic Sleep Better: Sleep Cycle & Smart Alarm,HEALTH_AND_FITNESS,4.1,111462,Varies with device,5000000,Free,0,Everyone,Health & Fitness
+White Noise Lite,HEALTH_AND_FITNESS,4.4,57634,41M,1000000,Free,0,Everyone,Health & Fitness
+Relax Melodies: Sleep Sounds,HEALTH_AND_FITNESS,4.5,233243,Varies with device,5000000,Free,0,Everyone,Health & Fitness
+"Stop, Breathe & Think: Meditation & Mindfulness",HEALTH_AND_FITNESS,4.3,8576,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+Simple Habit Meditation,HEALTH_AND_FITNESS,4.7,11689,20M,500000,Free,0,Everyone,Health & Fitness
+Headspace: Meditation & Mindfulness,HEALTH_AND_FITNESS,4.6,77563,39M,10000000,Free,0,Everyone,Health & Fitness
+Daily Yoga - Yoga Fitness Plans,HEALTH_AND_FITNESS,4.4,70769,35M,5000000,Free,0,Everyone,Health & Fitness
+Zillow: Find Houses for Sale & Apartments for Rent,HOUSE_AND_HOME,4.5,417907,34M,10000000,Free,0,Everyone,House & Home
+"Viva Decora - Decoration, Photos, Architecture, House",HOUSE_AND_HOME,4.8,3167,7.5M,100000,Free,0,Everyone,House & Home
+Apartments & Rentals - Zillow,HOUSE_AND_HOME,4.2,27386,Varies with device,1000000,Free,0,Everyone,House & Home
+Realtor.com Real Estate: Homes for Sale and Rent,HOUSE_AND_HOME,4.5,162243,12M,10000000,Free,0,Everyone,House & Home
+Real Estate sale & rent Trovit,HOUSE_AND_HOME,4.1,65913,7.7M,5000000,Free,0,Everyone,House & Home
+"591 housing transactions - renting houses, middle-class houses, new cases, real-time registration, villas through the sky, apartment suites, MRT, buying a house selling prices, housing mortgages",HOUSE_AND_HOME,4.1,24977,21M,1000000,Free,0,Everyone,House & Home
+"Homes.com 🏠 For Sale, Rent",HOUSE_AND_HOME,4.0,6000,18M,1000000,Free,0,Everyone,House & Home
+"CYANOGEN. Rent, buy an apartment, a room, a cottage 3+",HOUSE_AND_HOME,4.3,37711,40M,1000000,Free,0,Everyone,House & Home
+Trulia Real Estate & Rentals,HOUSE_AND_HOME,4.5,175293,Varies with device,10000000,Free,0,Everyone,House & Home
+Latest 2018 Home Designs,HOUSE_AND_HOME,4.2,174,8.7M,10000,Free,0,Everyone,House & Home
+Houzz Interior Design Ideas,HOUSE_AND_HOME,4.6,353799,Varies with device,10000000,Free,0,Everyone,House & Home
+Good room network fast rent,HOUSE_AND_HOME,3.7,2758,8.6M,500000,Free,0,Everyone,House & Home
+Yongqing fast search,HOUSE_AND_HOME,3.7,1437,Varies with device,100000,Free,0,Everyone,House & Home
+LIFULL HOME'S,HOUSE_AND_HOME,4.2,7573,18M,1000000,Free,0,Everyone,House & Home
+"Apartment List: Housing, Apt, and Property Rentals",HOUSE_AND_HOME,4.5,8481,7.5M,1000000,Free,0,Everyone,House & Home
+Gold Butterfly Keyboard Theme,HOUSE_AND_HOME,4.3,10054,9.1M,1000000,Free,0,Everyone,House & Home
+"Apartment, Home Rental Search: Realtor.com Rentals",HOUSE_AND_HOME,3.9,10117,13M,1000000,Free,0,Everyone,House & Home
+Living Smart Home,HOUSE_AND_HOME,4.6,39189,Varies with device,1000000,Free,0,Everyone,House & Home
+591 Housing Trading - Hong Kong,HOUSE_AND_HOME,4.3,3522,15M,100000,Free,0,Everyone,House & Home
+Trulia Rent Apartments & Homes,HOUSE_AND_HOME,4.4,71419,Varies with device,5000000,Free,0,Everyone,House & Home
+Redfin Real Estate,HOUSE_AND_HOME,4.6,36857,19M,1000000,Free,0,Everyone,House & Home
+"Domofond Real Estate. Buy, rent an apartment.",HOUSE_AND_HOME,4.5,39123,Varies with device,1000000,Free,0,Everyone,House & Home
+"realestate.com.au - Buy, Rent & Sell Property",HOUSE_AND_HOME,3.8,14653,Varies with device,1000000,Free,0,Everyone,House & Home
+Yes319 real price login query,HOUSE_AND_HOME,4.2,12,5.1M,5000,Free,0,Everyone,House & Home
+DaBang - Rental Homes in Korea,HOUSE_AND_HOME,4.4,23013,26M,5000000,Free,0,Everyone,House & Home
+DIY On A Budget,HOUSE_AND_HOME,4.7,114,8.3M,10000,Free,0,Teen,House & Home
+Free Foreclosure Real Estate Search by USHUD.com,HOUSE_AND_HOME,3.4,287,27M,100000,Free,0,Everyone,House & Home
+Mortgage by Zillow: Calculator & Rates,HOUSE_AND_HOME,4.3,4435,7.9M,500000,Free,0,Everyone,House & Home
+Home Security Camera WardenCam - reuse old phones,HOUSE_AND_HOME,4.3,43800,Varies with device,1000000,Free,0,Everyone,House & Home
+Room planner: Interior & Floorplan Design for IKEA,HOUSE_AND_HOME,4.0,4281,27M,100000,Free,0,Everyone,House & Home
+Rent.com Apartment Homes,HOUSE_AND_HOME,4.0,7508,5.1M,1000000,Free,0,Everyone,House & Home
+Good house to buy a house,HOUSE_AND_HOME,3.8,491,15M,100000,Free,0,Everyone,House & Home
+LH Housing Promotion Notice,HOUSE_AND_HOME,4.2,160,3.1M,100000,Free,0,Everyone,House & Home
+Apartments.com Rental Search,HOUSE_AND_HOME,4.3,22584,16M,1000000,Free,0,Everyone,House & Home
+Hemnet,HOUSE_AND_HOME,3.6,4087,9.2M,500000,Free,0,Everyone,House & Home
+At home - rental · real estate · room finding application such as apartment · apartment,HOUSE_AND_HOME,3.8,2496,Varies with device,500000,Free,0,Everyone,House & Home
+Alfred Home Security Camera,HOUSE_AND_HOME,4.5,103305,Varies with device,5000000,Free,0,Everyone,House & Home
+House app: beautiful everyday ~,HOUSE_AND_HOME,4.6,2669,10M,500000,Free,0,Teen,House & Home
+Home tips and advice,HOUSE_AND_HOME,4.2,10,2.6M,5000,Free,0,Everyone,House & Home
+"N1.RU - Real estate: apartments, new buildings, lodging",HOUSE_AND_HOME,4.5,7619,13M,100000,Free,0,Everyone,House & Home
+Ruler,HOUSE_AND_HOME,4.7,126,1.9M,10000,Free,0,Everyone,House & Home
+Home Decor Showpiece Art making: Medium Difficulty,HOUSE_AND_HOME,4.3,273,7.0M,50000,Free,0,Everyone,House & Home
+"乐屋网: Buying a house, selling a house, renting a house",HOUSE_AND_HOME,3.7,2248,15M,100000,Free,0,Everyone,House & Home
+Real estate court auction information site - Hyundai court auction,HOUSE_AND_HOME,4.2,10,4.2M,10000,Free,0,Everyone,House & Home
+iProperty Malaysia,HOUSE_AND_HOME,4.2,809,7.8M,100000,Free,0,Everyone,House & Home
+ColorSnap® Visualizer,HOUSE_AND_HOME,3.4,3280,77M,1000000,Free,0,Everyone,House & Home
+Apartment Decorating Ideas,HOUSE_AND_HOME,3.9,1478,5.7M,100000,Free,0,Everyone,House & Home
+Bedroom Decorating Ideas,HOUSE_AND_HOME,4.0,2382,5.9M,500000,Free,0,Everyone,House & Home
+Room Painting Ideas,HOUSE_AND_HOME,4.0,4450,7.6M,1000000,Free,0,Everyone,House & Home
+Kitchen Island Ideas,HOUSE_AND_HOME,4.0,515,5.8M,50000,Free,0,Everyone,House & Home
+Houzz Interior Design Ideas,HOUSE_AND_HOME,4.6,353800,Varies with device,10000000,Free,0,Everyone,House & Home
+Living Room Decorating Ideas,HOUSE_AND_HOME,4.0,4465,5.8M,1000000,Free,0,Everyone,House & Home
+Bathroom Decorating Ideas,HOUSE_AND_HOME,4.1,2427,5.3M,500000,Free,0,Everyone,House & Home
+Wall Decorating Ideas,HOUSE_AND_HOME,3.9,6631,5.5M,1000000,Free,0,Everyone,House & Home
+Zumper - Apartment Rental Finder,HOUSE_AND_HOME,4.4,11200,25M,1000000,Free,0,Everyone,House & Home
+RadPad: Apartment Finder App,HOUSE_AND_HOME,4.4,6896,35M,500000,Free,0,Everyone,House & Home
+Mortgage by Zillow: Calculator & Rates,HOUSE_AND_HOME,4.3,4435,7.9M,500000,Free,0,Everyone,House & Home
+Redfin Real Estate,HOUSE_AND_HOME,4.6,36857,19M,1000000,Free,0,Everyone,House & Home
+"Apartment List: Housing, Apt, and Property Rentals",HOUSE_AND_HOME,4.5,8481,7.5M,1000000,Free,0,Everyone,House & Home
+Realtor.com Real Estate: Homes for Sale and Rent,HOUSE_AND_HOME,4.5,162243,12M,10000000,Free,0,Everyone,House & Home
+Trulia Real Estate & Rentals,HOUSE_AND_HOME,4.5,175293,Varies with device,10000000,Free,0,Everyone,House & Home
+Zillow: Find Houses for Sale & Apartments for Rent,HOUSE_AND_HOME,4.5,417907,34M,10000000,Free,0,Everyone,House & Home
+Homesnap Real Estate & Rentals,HOUSE_AND_HOME,4.3,3834,30M,500000,Free,0,Everyone,House & Home
+Apartments & Rentals - Zillow,HOUSE_AND_HOME,4.2,27387,Varies with device,1000000,Free,0,Everyone,House & Home
+Trulia Rent Apartments & Homes,HOUSE_AND_HOME,4.4,71421,Varies with device,5000000,Free,0,Everyone,House & Home
+Apartments.com Rental Search,HOUSE_AND_HOME,4.3,22584,16M,1000000,Free,0,Everyone,House & Home
+Houzz Interior Design Ideas,HOUSE_AND_HOME,4.6,353813,Varies with device,10000000,Free,0,Everyone,House & Home
+Trulia Mortgage Calculators,HOUSE_AND_HOME,4.1,81,16M,50000,Free,0,Everyone,House & Home
+Public Digital Library,LIBRARIES_AND_DEMO,3.9,2087,Varies with device,50000,Free,0,Everyone,Libraries & Demo
+Quotes,LIBRARIES_AND_DEMO,4.4,58,15M,10000,Free,0,Everyone,Libraries & Demo
+Best New Ringtones 2018 Free 🔥 For Android™,LIBRARIES_AND_DEMO,4.6,3014,21M,100000,Free,0,Everyone,Libraries & Demo
+Lamp detector,LIBRARIES_AND_DEMO,4.2,5,1.8M,1000,Free,0,Everyone,Libraries & Demo
+SUDOKU,LIBRARIES_AND_DEMO,4.1,923,4.3M,100000,Free,0,Everyone,Libraries & Demo
+General culture,LIBRARIES_AND_DEMO,4.2,26,10M,10000,Free,0,Everyone,Libraries & Demo
+Luffs,LIBRARIES_AND_DEMO,4.2,487,3.7M,100000,Free,0,Everyone,Libraries & Demo
+Aviary Effects: Classic,LIBRARIES_AND_DEMO,3.8,67007,232k,5000000,Free,0,Everyone,Libraries & Demo
+Chakra Cleansing,LIBRARIES_AND_DEMO,4.6,539,99M,50000,Free,0,Everyone,Libraries & Demo
+Aviary Stickers: Free Pack,LIBRARIES_AND_DEMO,3.5,126862,624k,10000000,Free,0,Everyone,Libraries & Demo
+Call Recorder,LIBRARIES_AND_DEMO,4.7,48,6.9M,1000,Free,0,Everyone,Libraries & Demo
+Pink Water Sakura Keyboard Theme,LIBRARIES_AND_DEMO,4.3,1465,7.0M,100000,Free,0,Everyone,Libraries & Demo
+auto Call Recorder 2018,LIBRARIES_AND_DEMO,4.5,929,7.0M,50000,Free,0,Everyone,Libraries & Demo
+converter video to mp3,LIBRARIES_AND_DEMO,4.4,783,6.4M,100000,Free,0,Everyone,Libraries & Demo
+eBiblio,LIBRARIES_AND_DEMO,3.4,2907,Varies with device,50000,Free,0,Everyone,Libraries & Demo
+chicken song,LIBRARIES_AND_DEMO,4.3,434,16M,100000,Free,0,Everyone,Libraries & Demo
+Words (188 Category),LIBRARIES_AND_DEMO,4.2,54,5.9M,10000,Free,0,Everyone,Libraries & Demo
+Binaural Beats Meditation,LIBRARIES_AND_DEMO,4.3,411,95M,50000,Free,0,Everyone,Libraries & Demo
+Essential Resources,LIBRARIES_AND_DEMO,4.6,237,8.5k,50000,Free,0,Everyone,Libraries & Demo
+MOMOLAND BBoom BBoom,LIBRARIES_AND_DEMO,4.6,2580,20M,100000,Free,0,Everyone,Libraries & Demo
+Cold Spirits,LIBRARIES_AND_DEMO,4.2,363,2.5M,100000,Free,0,Everyone,Libraries & Demo
+Cardboard,LIBRARIES_AND_DEMO,4.2,130272,50M,10000000,Free,0,Everyone,Libraries & Demo
+How to sew & make the easiest pattern,LIBRARIES_AND_DEMO,4.2,110,10M,10000,Free,0,Everyone,Libraries & Demo
+I will return his eggs,LIBRARIES_AND_DEMO,4.2,91,18M,100000,Free,0,Everyone,Libraries & Demo
+Bird Sounds & Bird Ringtones for Free 2018,LIBRARIES_AND_DEMO,4.6,130,12M,10000,Free,0,Everyone,Libraries & Demo
+Benefits of olive oil with garlic,LIBRARIES_AND_DEMO,4.2,25,2.5M,10000,Free,0,Everyone,Libraries & Demo
+Sad hair without net,LIBRARIES_AND_DEMO,4.2,20,2.1M,5000,Free,0,Everyone,Libraries & Demo
+Top Popular Ringtones 2018 Free 🔥,LIBRARIES_AND_DEMO,4.4,7396,22M,500000,Free,0,Everyone,Libraries & Demo
+Wifi Connect Library,LIBRARIES_AND_DEMO,3.9,58055,41k,5000000,Free,0,Everyone,Libraries & Demo
+Super Funny Ringtones 2018 🔔,LIBRARIES_AND_DEMO,4.5,1703,22M,100000,Free,0,Everyone,Libraries & Demo
+Apk Installer,LIBRARIES_AND_DEMO,3.8,7750,292k,1000000,Free,0,Everyone,Libraries & Demo
+SAMSUNG RETAILMODE 2018,LIBRARIES_AND_DEMO,4.3,6,5.5M,10000,Free,0,Everyone,Libraries & Demo
+OpenCV Manager,LIBRARIES_AND_DEMO,3.7,12657,Varies with device,1000000,Free,0,Everyone,Libraries & Demo
+Eternal life,LIBRARIES_AND_DEMO,5.0,26,2.5M,1000,Free,0,Everyone,Libraries & Demo
+V380s,LIBRARIES_AND_DEMO,3.2,1919,8.1M,500000,Free,0,Everyone,Libraries & Demo
+Cool Popular Ringtones 2018 🔥,LIBRARIES_AND_DEMO,4.5,60170,28M,1000000,Free,0,Everyone,Libraries & Demo
+Blackpink as if it's your last,LIBRARIES_AND_DEMO,4.7,831,24M,100000,Free,0,Everyone,Libraries & Demo
+Wifi Test,LIBRARIES_AND_DEMO,4.0,8671,3.1M,1000000,Free,0,Everyone,Libraries & Demo
+Patience Words,LIBRARIES_AND_DEMO,4.2,31,3.4M,10000,Free,0,Everyone,Libraries & Demo
+Market Update Helper,LIBRARIES_AND_DEMO,4.1,20145,11k,1000000,Free,0,Everyone,Libraries & Demo
+Ayyush wih wih new without Net,LIBRARIES_AND_DEMO,3.8,912,13M,500000,Free,0,Everyone,Libraries & Demo
+Girls Nancy Ajram Without Net,LIBRARIES_AND_DEMO,4.7,2639,19M,500000,Free,0,Everyone,Libraries & Demo
+R M Lock Screen,LIBRARIES_AND_DEMO,4.5,399,9.5M,100000,Free,0,Everyone,Libraries & Demo
+Mama Lala 's song,LIBRARIES_AND_DEMO,4.2,102,21M,50000,Free,0,Everyone,Libraries & Demo
+Barcode Scanner,LIBRARIES_AND_DEMO,4.2,3945,9.4M,500000,Free,0,Everyone,Libraries & Demo
+Young Speeches,LIBRARIES_AND_DEMO,4.2,2221,2.4M,500000,Free,0,Everyone,Libraries & Demo
+New Ringtones 2018,LIBRARIES_AND_DEMO,4.1,3781,36M,1000000,Free,0,Everyone,Libraries & Demo
+EyeCloud,LIBRARIES_AND_DEMO,3.1,1267,55M,100000,Free,0,Everyone,Libraries & Demo
+Dollhouse Decorating Games,LIFESTYLE,4.1,18968,32M,5000000,Free,0,Teen,Lifestyle
+metroZONE,LIFESTYLE,4.1,47497,34M,10000000,Free,0,Everyone,Lifestyle
+Easy Hair Style Design,LIFESTYLE,4.3,601,5.1M,100000,Free,0,Everyone,Lifestyle
+Talking Babsy Baby: Baby Games,LIFESTYLE,4.0,140995,100M,10000000,Free,0,Everyone,Lifestyle;Pretend Play
+"Black Wallpaper, AMOLED, Dark Background: Darkify",LIFESTYLE,4.6,51357,80M,5000000,Free,0,Everyone,Lifestyle
+Girly Wallpapers Backgrounds,LIFESTYLE,4.4,13565,3.3M,1000000,Free,0,Everyone,Lifestyle
+Chart - Myanmar Keyboard,LIFESTYLE,4.4,39364,28M,5000000,Free,0,Everyone,Lifestyle
+Easy Makeup Tutorials,LIFESTYLE,4.3,7287,5.0M,1000000,Free,0,Everyone,Lifestyle
+Horoscopes – Daily Zodiac Horoscope and Astrology,LIFESTYLE,4.6,161143,11M,10000000,Free,0,Everyone 10+,Lifestyle
+Entel,LIFESTYLE,3.2,16168,55M,1000000,Free,0,Everyone,Lifestyle
+ZenUI Safeguard,LIFESTYLE,4.5,100,7.1M,1000000,Free,0,Everyone,Lifestyle
+Live 4D Results ! (MY & SG),LIFESTYLE,4.6,116079,3.2M,5000000,Free,0,Everyone,Lifestyle
+Diary with lock,LIFESTYLE,4.6,815893,4.4M,10000000,Free,0,Everyone,Lifestyle
+FOSSIL Q: DESIGN YOUR DIAL,LIFESTYLE,4.3,985,16M,500000,Free,0,Everyone,Lifestyle
+Telstra,LIFESTYLE,3.0,4260,6.3M,5000000,Free,0,Everyone,Lifestyle
+Family Locator - GPS Tracker,LIFESTYLE,4.4,726074,45M,10000000,Free,0,Everyone,Lifestyle
+Van Nien 2018 - Lich Van su & Lich Am,LIFESTYLE,4.4,3829,23M,1000000,Free,0,Everyone,Lifestyle
+Safeway,LIFESTYLE,4.3,33572,37M,1000000,Free,0,Everyone,Lifestyle
+HTC Speak,LIFESTYLE,3.5,6145,13M,10000000,Free,0,Everyone,Lifestyle
+Kawaii Easy Drawing : How to draw Step by Step,LIFESTYLE,4.3,34327,8.1M,5000000,Free,0,Everyone,Lifestyle
+Tattoodo - Find your next tattoo,LIFESTYLE,4.5,7457,13M,1000000,Free,0,Teen,Lifestyle
+H&M,LIFESTYLE,3.7,41941,14M,10000000,Free,0,Everyone,Lifestyle
+Samsung+,LIFESTYLE,4.5,82145,30M,50000000,Free,0,Everyone,Lifestyle
+Anime Avatar Creator: Make Your Own Avatar,LIFESTYLE,4.2,10944,36M,1000000,Free,0,Everyone,Lifestyle
+Beautiful Design Birthday Cake,LIFESTYLE,4.3,665,3.0M,500000,Free,0,Everyone,Lifestyle
+Pronunciation and know the name of the caller from his number,LIFESTYLE,4.6,2167,1.4M,500000,Free,0,Everyone,Lifestyle
+Super Slime Simulator - Satisfying Slime App,LIFESTYLE,4.5,53652,39M,1000000,Free,0,Everyone,Lifestyle
+Caf - My Account,LIFESTYLE,3.9,18961,1.8M,5000000,Free,0,Everyone,Lifestyle
+H Pack,LIFESTYLE,4.3,9412,1.7M,1000000,Free,0,Everyone,Lifestyle
+Family convenience store FamilyMart,LIFESTYLE,3.3,9663,19M,1000000,Free,0,Everyone,Lifestyle
+သိင်္ Astrology - Min Thein Kha BayDin,LIFESTYLE,4.7,2225,15M,100000,Free,0,Everyone,Lifestyle
+w UN map,LIFESTYLE,4.2,23164,10.0M,1000000,Free,0,Mature 17+,Lifestyle
+Official Matsumoto Kiyoshi application,LIFESTYLE,3.2,3031,2.7M,1000000,Free,0,Everyone,Lifestyle
+Galaxy Gift,LIFESTYLE,4.4,95557,16M,10000000,Free,0,Everyone,Lifestyle
+PASS by KT (formerly KT certified),LIFESTYLE,3.5,7869,21M,1000000,Free,0,Everyone,Lifestyle
+Safety stepping stone,LIFESTYLE,3.7,4212,20M,1000000,Free,0,Everyone,Lifestyle
+Rate Guide Bill Letter,LIFESTYLE,3.8,17368,14M,10000000,Free,0,Everyone,Lifestyle
+US Mission - buy gourmet movie KTV,LIFESTYLE,3.8,6554,76M,500000,Free,0,Teen,Lifestyle
+OK cashbag [point of pleasure],LIFESTYLE,3.7,33264,18M,10000000,Free,0,Everyone,Lifestyle
+JOANN - Crafts & Coupons,LIFESTYLE,4.6,34782,12M,1000000,Free,0,Everyone,Lifestyle
+MK eCatalog,LIFESTYLE,4.0,6676,6.2M,1000000,Free,0,Everyone,Lifestyle
+Vaniday - Beauty Booking App,LIFESTYLE,3.6,1067,Varies with device,100000,Free,0,Everyone,Lifestyle
+Fashion in Vogue,LIFESTYLE,3.8,1797,6.8M,100000,Free,0,Everyone,Lifestyle
+Mirror,LIFESTYLE,4.1,367505,Varies with device,10000000,Free,0,Everyone,Lifestyle
+StyleSeat,LIFESTYLE,4.7,20304,24M,500000,Free,0,Everyone,Lifestyle
+Wedding Countdown Widget,LIFESTYLE,3.9,7376,19M,1000000,Free,0,Everyone,Lifestyle
+My Day - Countdown Calendar 🗓️,LIFESTYLE,4.1,49147,13M,1000000,Free,0,Everyone,Lifestyle
+justWink Greeting Cards,LIFESTYLE,4.6,69177,15M,1000000,Free,0,Teen,Lifestyle
+Wedding LookBook by The Knot,LIFESTYLE,4.2,3448,13M,100000,Free,0,Everyone,Lifestyle
+Vaniday - Beauty Booking App,LIFESTYLE,3.6,1067,Varies with device,100000,Free,0,Everyone,Lifestyle
+Big Days - Events Countdown,LIFESTYLE,4.6,39724,Varies with device,1000000,Free,0,Everyone,Lifestyle
+"Wedding Planner by WeddingWire - Venues, Checklist",LIFESTYLE,4.2,3788,44M,1000000,Free,0,Everyone,Lifestyle
+Been Together (Ad) - D-day,LIFESTYLE,4.4,95736,Varies with device,10000000,Free,0,Everyone,Lifestyle
+WedMeGood - Wedding Planner,LIFESTYLE,4.6,1658,9.7M,100000,Free,0,Everyone,Lifestyle
+StyleSeat,LIFESTYLE,4.7,20304,24M,500000,Free,0,Everyone,Lifestyle
+DIY Garden Ideas,LIFESTYLE,4.1,3309,13M,500000,Free,0,Everyone,Lifestyle
+Brit + Co,LIFESTYLE,3.9,987,4.5M,10000,Free,0,Everyone,Lifestyle
+Creative Ideas - DIY & Craft,LIFESTYLE,4.0,5208,4.5M,100000,Free,0,Teen,Lifestyle
+Homestyler Interior Design & Decorating Ideas,LIFESTYLE,4.1,78298,29M,5000000,Free,0,Everyone,Lifestyle
+JOANN - Crafts & Coupons,LIFESTYLE,4.6,34802,12M,1000000,Free,0,Everyone,Lifestyle
+Wheretoget: Shop in style,LIFESTYLE,4.1,6808,12M,500000,Free,0,Teen,Lifestyle
+My Dressing - Fashion closet,LIFESTYLE,4.1,12452,Varies with device,500000,Free,0,Everyone,Lifestyle
+Chictopia,LIFESTYLE,4.1,360,4.6M,10000,Free,0,Everyone,Lifestyle
+Scarf Fashion Designer,LIFESTYLE,4.4,16637,10M,1000000,Free,0,Everyone,Lifestyle
+Fashion in Vogue,LIFESTYLE,3.8,1797,6.8M,100000,Free,0,Everyone,Lifestyle
+Zara,LIFESTYLE,4.3,95904,33M,10000000,Free,0,Everyone,Lifestyle
+Wheretoget: Shop in style,LIFESTYLE,4.1,6808,12M,500000,Free,0,Teen,Lifestyle
+My Dressing - Fashion closet,LIFESTYLE,4.1,12452,Varies with device,500000,Free,0,Everyone,Lifestyle
+Chictopia,LIFESTYLE,4.1,360,4.6M,10000,Free,0,Everyone,Lifestyle
+Scarf Fashion Designer,LIFESTYLE,4.4,16637,10M,1000000,Free,0,Everyone,Lifestyle
+Fashion in Vogue,LIFESTYLE,3.8,1797,6.8M,100000,Free,0,Everyone,Lifestyle
+Zara,LIFESTYLE,4.3,95905,33M,10000000,Free,0,Everyone,Lifestyle
+Real Estate by Movoto,LIFESTYLE,4.4,3114,13M,100000,Free,0,Everyone,Lifestyle
+Etta Homes,LIFESTYLE,4.2,220,15M,50000,Free,0,Everyone,Lifestyle
+Houlihan Lawrence,LIFESTYLE,4.4,33,23M,5000,Free,0,Everyone,Lifestyle
+Home Scouting® MLS Mobile,LIFESTYLE,4.3,1533,7.7M,100000,Free,0,Everyone,Lifestyle
+Housing-Real Estate & Property,LIFESTYLE,4.1,28301,Varies with device,1000000,Free,0,Everyone,Lifestyle
+ZipRealty Real Estate & Homes,LIFESTYLE,4.0,3937,15M,100000,Free,0,Everyone,Lifestyle
+Sotheby's International Realty,LIFESTYLE,4.2,894,25M,50000,Free,0,Everyone,Lifestyle
+Zoopla Property Search UK - Home to buy & rent,LIFESTYLE,4.1,21195,Varies with device,1000000,Free,0,Everyone,Lifestyle
+Neighborhoods & Apartments,LIFESTYLE,3.9,2042,3.0M,100000,Free,0,Everyone,Lifestyle
+Keller Williams Real Estate,LIFESTYLE,4.4,13213,22M,1000000,Free,0,Everyone,Lifestyle
+Relax Rain ~ Rain Sounds,LIFESTYLE,4.6,118034,Varies with device,5000000,Free,0,Everyone,Lifestyle
+Relax Ocean ~ Nature Sounds,LIFESTYLE,4.5,9464,Varies with device,500000,Free,0,Everyone,Lifestyle
+Bed Time Fan - White Noise Sleep Sounds,LIFESTYLE,4.5,10097,7.5M,500000,Free,0,Everyone,Lifestyle
+Nature Sounds,LIFESTYLE,4.8,28588,24M,1000000,Free,0,Everyone,Lifestyle
+SleepyTime: Bedtime Calculator,LIFESTYLE,4.4,19621,Varies with device,500000,Free,0,Everyone,Lifestyle
+White Noise Baby,LIFESTYLE,4.5,10544,44M,1000000,Free,0,Everyone,Lifestyle
+White Noise ~ Sleeping Sounds,LIFESTYLE,4.5,4427,Varies with device,100000,Free,0,Everyone,Lifestyle
+"Journey - Diary, Journal",LIFESTYLE,4.6,50338,Varies with device,1000000,Free,0,Everyone,Lifestyle
+7 Day Food Journal Challenge,LIFESTYLE,4.5,3346,14M,100000,Free,0,Teen,Lifestyle
+ROBLOX,GAME,4.5,4447388,67M,100000000,Free,0,Everyone 10+,Adventure;Action & Adventure
+Subway Surfers,GAME,4.5,27722264,76M,1000000000,Free,0,Everyone 10+,Arcade
+Candy Crush Saga,GAME,4.4,22426677,74M,500000000,Free,0,Everyone,Casual
+Solitaire,GAME,4.7,254258,23M,10000000,Free,0,Everyone,Card
+Bubble Shooter,GAME,4.5,148897,46M,10000000,Free,0,Everyone,Casual
+Hello Kitty Nail Salon,GAME,4.2,369203,24M,50000000,Free,0,Everyone,Casual;Pretend Play
+slither.io,GAME,4.4,5234162,Varies with device,100000000,Free,0,Everyone,Action
+Clash Royale,GAME,4.6,23133508,97M,100000000,Free,0,Everyone 10+,Strategy
+Temple Run 2,GAME,4.3,8118609,62M,500000000,Free,0,Everyone,Action
+Pou,GAME,4.3,10485308,24M,500000000,Free,0,Everyone,Casual
+Helix Jump,GAME,4.2,1497361,33M,100000000,Free,0,Everyone,Action
+Block Puzzle,GAME,4.6,59800,7.8M,5000000,Free,0,Everyone,Puzzle
+Angry Birds Rio,GAME,4.4,2610526,46M,100000000,Free,0,Everyone,Arcade
+Plants vs. Zombies FREE,GAME,4.4,4066989,69M,100000000,Free,0,Everyone 10+,Strategy
+Sonic Dash,GAME,4.5,3778921,75M,100000000,Free,0,Everyone,Arcade
+Candy Crush Soda Saga,GAME,4.4,6198563,67M,100000000,Free,0,Everyone,Casual
+Zombie Hunter King,GAME,4.3,10306,50M,1000000,Free,0,Mature 17+,Action
+Clash of Clans,GAME,4.6,44891723,98M,100000000,Free,0,Everyone 10+,Strategy
+Kick the Buddy,GAME,4.3,1000417,Varies with device,50000000,Free,0,Teen,Action
+Block Puzzle Classic Legend !,GAME,4.2,17039,4.9M,5000000,Free,0,Everyone,Puzzle
+PAC-MAN,GAME,4.2,685981,37M,100000000,Free,0,Everyone,Arcade
+Super Jim Jump - pixel 3d,GAME,4.5,10393,18M,1000000,Free,0,Everyone,Arcade
+8 Ball Pool,GAME,4.5,14198297,52M,100000000,Free,0,Everyone,Sports
+Magic Tiles 3,GAME,4.5,592068,Varies with device,50000000,Free,0,Everyone,Music
+Bubble Witch 3 Saga,GAME,4.7,1732263,78M,50000000,Free,0,Everyone,Puzzle
+Word Search,GAME,4.7,295241,3.9M,10000000,Free,0,Everyone,Word
+Granny,GAME,4.5,1135631,59M,50000000,Free,0,Teen,Arcade
+Angry Birds Classic,GAME,4.4,5566669,97M,100000000,Free,0,Everyone,Arcade
+Flow Free,GAME,4.3,1295557,11M,100000000,Free,0,Everyone,Puzzle
+Race the Traffic Moto,GAME,3.8,270687,38M,10000000,Free,0,Teen,Racing
+Fishdom,GAME,4.6,2157930,Varies with device,10000000,Free,0,Everyone,Puzzle
+Galaxy Attack: Alien Shooter,GAME,4.6,506275,Varies with device,10000000,Free,0,Everyone,Arcade
+Zombie Tsunami,GAME,4.4,4920817,Varies with device,100000000,Free,0,Everyone 10+,Arcade
+Bubble Shooter 2,GAME,4.3,23005,Varies with device,5000000,Free,0,Everyone,Arcade
+Barbie™ Fashion Closet,GAME,4.1,68057,85M,10000000,Free,0,Everyone,Casual;Creativity
+Candy Crush Jelly Saga,GAME,4.3,1300490,78M,50000000,Free,0,Everyone,Puzzle
+Hill Climb Racing,GAME,4.4,8923587,63M,100000000,Free,0,Everyone,Racing
+Gardenscapes,GAME,4.6,4128732,Varies with device,50000000,Free,0,Everyone,Casual
+Marble - Temple Quest,GAME,4.3,42053,24M,10000000,Free,0,Everyone,Puzzle
+Shooting King,GAME,4.4,257724,69M,10000000,Free,0,Everyone 10+,Sports
+Zombie Catchers,GAME,4.7,990491,75M,10000000,Free,0,Everyone,Action
+Minion Rush: Despicable Me Official Game,GAME,4.5,10216538,Varies with device,100000000,Free,0,Everyone 10+,Casual;Action & Adventure
+Farm Heroes Saga,GAME,4.4,7614130,70M,100000000,Free,0,Everyone,Casual
+Geometry Dash World,GAME,4.6,760628,63M,10000000,Free,0,Everyone,Arcade
+My Talking Angela,GAME,4.5,9881829,99M,100000000,Free,0,Everyone,Casual
+Cut the Rope FULL FREE,GAME,4.4,2123381,49M,100000000,Free,0,Everyone,Puzzle
+Sniper 3D Gun Shooter: Free Shooting Games - FPS,GAME,4.6,7671249,Varies with device,100000000,Free,0,Mature 17+,Action
+Subway Surfers,GAME,4.5,27723193,76M,1000000000,Free,0,Everyone 10+,Arcade
+ROBLOX,GAME,4.5,4447346,67M,100000000,Free,0,Everyone 10+,Adventure;Action & Adventure
+Pou,GAME,4.3,10485334,24M,500000000,Free,0,Everyone,Casual
+8 Ball Pool,GAME,4.5,14198602,52M,100000000,Free,0,Everyone,Sports
+Clash of Clans,GAME,4.6,44891723,98M,100000000,Free,0,Everyone 10+,Strategy
+Candy Crush Saga,GAME,4.4,22428456,74M,500000000,Free,0,Everyone,Casual
+Plants vs. Zombies FREE,GAME,4.4,4066980,69M,100000000,Free,0,Everyone 10+,Strategy
+Cooking Fever,GAME,4.5,3197865,82M,100000000,Free,0,Everyone,Arcade
+Toon Blast,GAME,4.7,1351068,Varies with device,10000000,Free,0,Everyone,Puzzle
+Score! Hero,GAME,4.6,5418675,96M,100000000,Free,0,Everyone,Sports
+My Talking Angela,GAME,4.5,9881908,99M,100000000,Free,0,Everyone,Casual
+Bubble Shooter,GAME,4.5,148895,46M,10000000,Free,0,Everyone,Casual
+Toy Blast,GAME,4.7,1889250,Varies with device,50000000,Free,0,Everyone,Puzzle
+Miraculous Ladybug & Cat Noir - The Official Game,GAME,4.5,183846,99M,10000000,Free,0,Everyone,Action
+Wordscapes,GAME,4.8,230710,87M,10000000,Free,0,Everyone,Word
+Word Search,GAME,4.7,295305,3.9M,10000000,Free,0,Everyone,Word
+Candy Crush Soda Saga,GAME,4.4,6198880,67M,100000000,Free,0,Everyone,Casual
+Fishdom,GAME,4.6,2157930,Varies with device,10000000,Free,0,Everyone,Puzzle
+Garena Free Fire,GAME,4.5,5465624,53M,100000000,Free,0,Teen,Action
+Block Puzzle,GAME,4.6,59854,7.8M,5000000,Free,0,Everyone,Puzzle
+Bowmasters,GAME,4.7,1534466,Varies with device,50000000,Free,0,Teen,Action
+Clash Royale,GAME,4.6,23134775,97M,100000000,Free,0,Everyone 10+,Strategy
+My Talking Tom,GAME,4.5,14891223,Varies with device,500000000,Free,0,Everyone,Casual
+Sniper 3D Gun Shooter: Free Shooting Games - FPS,GAME,4.6,7672495,Varies with device,100000000,Free,0,Mature 17+,Action
+Granny,GAME,4.5,1137271,59M,50000000,Free,0,Teen,Arcade
+Galaxy Attack: Alien Shooter,GAME,4.6,506275,Varies with device,10000000,Free,0,Everyone,Arcade
+Angry Birds Rio,GAME,4.4,2610622,46M,100000000,Free,0,Everyone,Arcade
+Zombie Catchers,GAME,4.7,990586,75M,10000000,Free,0,Everyone,Action
+Zombie Hunter King,GAME,4.3,10354,50M,1000000,Free,0,Mature 17+,Action
+Temple Run 2,GAME,4.3,8118937,62M,500000000,Free,0,Everyone,Action
+Zombie Tsunami,GAME,4.4,4921122,Varies with device,100000000,Free,0,Everyone 10+,Arcade
+Jungle Marble Blast,GAME,4.3,18985,23M,5000000,Free,0,Everyone,Casual
+Rider,GAME,4.5,655067,72M,10000000,Free,0,Teen,Arcade
+Farm Heroes Saga,GAME,4.4,7614271,70M,100000000,Free,0,Everyone,Casual
+Super Jim Jump - pixel 3d,GAME,4.5,10434,18M,1000000,Free,0,Everyone,Arcade
+slither.io,GAME,4.4,5234825,Varies with device,100000000,Free,0,Everyone,Action
+Roll the Ball® - slide puzzle,GAME,4.5,1385093,35M,100000000,Free,0,Everyone,Puzzle
+Talking Tom Gold Run,GAME,4.6,2698348,78M,100000000,Free,0,Everyone,Action
+Pixel Art: Color by Number Game,GAME,4.7,1125017,25M,10000000,Free,0,Everyone,Puzzle
+Dream League Soccer 2018,GAME,4.6,9882639,74M,100000000,Free,0,Everyone,Sports
+Angry Birds Classic,GAME,4.4,5566805,97M,100000000,Free,0,Everyone,Arcade
+Fruits Bomb,GAME,4.4,74673,17M,10000000,Free,0,Everyone,Casual
+Traffic Racer,GAME,4.5,5387639,53M,100000000,Free,0,Everyone,Racing
+Hill Climb Racing 2,GAME,4.6,2750410,Varies with device,100000000,Free,0,Everyone,Racing
+Flow Free,GAME,4.3,1295606,11M,100000000,Free,0,Everyone,Puzzle
+Knife Hit,GAME,4.5,461137,60M,10000000,Free,0,Everyone,Arcade
+Block Craft 3D: Building Simulator Games For Free,GAME,4.5,946926,57M,50000000,Free,0,Everyone,Simulation
+Farm Fruit Pop: Party Time,GAME,4.4,9305,14M,1000000,Free,0,Everyone,Casual
+ROBLOX,GAME,4.5,4448791,67M,100000000,Free,0,Everyone 10+,Adventure;Action & Adventure
+Helix Jump,GAME,4.2,1498648,33M,100000000,Free,0,Everyone,Action
+Subway Surfers,GAME,4.5,27724094,76M,1000000000,Free,0,Everyone 10+,Arcade
+Candy Crush Saga,GAME,4.4,22428456,74M,500000000,Free,0,Everyone,Casual
+Toon Blast,GAME,4.7,1351089,Varies with device,10000000,Free,0,Everyone,Puzzle
+Love Balls,GAME,4.2,360630,40M,50000000,Free,0,Everyone,Puzzle
+Granny,GAME,4.5,1137267,59M,50000000,Free,0,Teen,Arcade
+8 Ball Pool,GAME,4.5,14200344,52M,100000000,Free,0,Everyone,Sports
+Sniper 3D Gun Shooter: Free Shooting Games - FPS,GAME,4.6,7672495,Varies with device,100000000,Free,0,Mature 17+,Action
+slither.io,GAME,4.4,5234810,Varies with device,100000000,Free,0,Everyone,Action
+Hungry Shark Evolution,GAME,4.5,6074334,100M,100000000,Free,0,Teen,Arcade
+Temple Run 2,GAME,4.3,8118937,62M,500000000,Free,0,Everyone,Action
+Kick the Buddy,GAME,4.3,1000417,Varies with device,50000000,Free,0,Teen,Action
+Magic Tiles 3,GAME,4.5,592282,Varies with device,50000000,Free,0,Everyone,Music
+Bowmasters,GAME,4.7,1535084,Varies with device,50000000,Free,0,Teen,Action
+Piano Tiles 2™,GAME,4.7,8118880,Varies with device,100000000,Free,0,Everyone,Arcade
+Pokémon GO,GAME,4.1,10424925,85M,100000000,Free,0,Everyone,Adventure
+Wordscapes,GAME,4.8,230727,87M,10000000,Free,0,Everyone,Word
+Paint Hit,GAME,4.4,37023,33M,10000000,Free,0,Everyone,Casual
+Snake VS Block,GAME,4.2,422244,32M,50000000,Free,0,Teen,Arcade
+Rolly Vortex,GAME,4.4,98123,40M,10000000,Free,0,Teen,Arcade
+Woody Puzzle,GAME,4.7,21262,29M,1000000,Free,0,Everyone,Puzzle
+Stack Jump,GAME,4.3,118253,40M,10000000,Free,0,Teen,Arcade
+Color by Number – New Coloring Book,GAME,4.7,141529,24M,5000000,Free,0,Everyone 10+,Board
+The Cube,GAME,4.2,70226,38M,5000000,Free,0,Everyone,Arcade
+Extreme Car Driving Simulator,GAME,4.3,2251012,52M,100000000,Free,0,Everyone,Racing
+Bricks n Balls,GAME,4.4,30253,Varies with device,1000000,Free,0,Everyone,Casual
+The Fish Master!,GAME,4.1,15763,54M,1000000,Free,0,Everyone,Arcade
+Color Road,GAME,4.1,84911,71M,10000000,Free,0,Everyone,Arcade
+Draw In,GAME,4.2,46416,73M,10000000,Free,0,Everyone,Arcade
+Block Craft 3D: Building Simulator Games For Free,GAME,4.5,946926,57M,50000000,Free,0,Everyone,Simulation
+PLANK!,GAME,4.7,7196,38M,500000,Free,0,Everyone,Arcade
+Looper!,GAME,4.6,48256,62M,1000000,Free,0,Everyone,Puzzle
+Trivia Crack,GAME,4.5,6427773,95M,100000000,Free,0,Everyone,Trivia
+Will it Crush?,GAME,3.1,25825,16M,5000000,Free,0,Everyone,Simulation
+Tomb of the Mask,GAME,4.1,55380,39M,5000000,Free,0,Everyone,Action
+Baseball Boy!,GAME,3.4,148177,78M,10000000,Free,0,Everyone,Arcade
+PUBG MOBILE,GAME,4.4,3715656,36M,50000000,Free,0,Teen,Action
+Episode - Choose Your Story,GAME,4.3,1841061,Varies with device,50000000,Free,0,Teen,Simulation
+Hello Stars,GAME,4.6,101686,31M,10000000,Free,0,Everyone,Puzzle
+Run Sausage Run!,GAME,4.4,275447,Varies with device,10000000,Free,0,Everyone 10+,Arcade
+Tank Stars,GAME,4.3,174755,98M,10000000,Free,0,Everyone 10+,Arcade
+Castle Clash: Heroes of the Empire US,GAME,4.6,4578476,24M,50000000,Free,0,Everyone 10+,Strategy
+Hole.io,GAME,4.2,145353,85M,10000000,Free,0,Teen,Arcade
+Helix Jump,GAME,4.2,1499373,33M,100000000,Free,0,Everyone,Action
+Mini Golf King - Multiplayer Game,GAME,4.5,531458,100M,5000000,Free,0,Everyone,Sports
+PUBG MOBILE,GAME,4.4,3714270,36M,50000000,Free,0,Teen,Action
+Flip the Gun - Simulator Game,GAME,4.2,195558,86M,10000000,Free,0,Everyone,Arcade
+Mad Skills BMX 2,GAME,4.5,29940,80M,1000000,Free,0,Everyone,Action
+Wordscapes,GAME,4.8,230727,87M,10000000,Free,0,Everyone,Word
+"MMX Hill Dash 2 – Offroad Truck, Car & Bike Racing",GAME,4.4,41975,79M,1000000,Free,0,Everyone,Racing
+Word Link,GAME,4.6,216675,30M,10000000,Free,0,Everyone,Word
+Last Day on Earth: Survival,GAME,4.5,2311785,87M,10000000,Free,0,Teen,Action
+MARVEL Strike Force,GAME,4.3,165888,91M,5000000,Free,0,Teen,Role Playing
+Partymasters - Fun Idle Game,GAME,4.6,541144,63M,10000000,Free,0,Teen,Arcade
+Harry Potter: Hogwarts Mystery,GAME,4.4,1107310,Varies with device,10000000,Free,0,Teen,Adventure
+Offroad Outlaws,GAME,4.4,29168,Varies with device,1000000,Free,0,Everyone,Racing
+Grim Soul: Dark Fantasy Survival,GAME,4.5,189773,95M,5000000,Free,0,Teen,Role Playing
+DRAGON BALL LEGENDS,GAME,4.6,337752,48M,5000000,Free,0,Teen,Action
+Disney Heroes: Battle Mode,GAME,4.6,102107,Varies with device,5000000,Free,0,Everyone 10+,Strategy
+Homescapes,GAME,4.6,3093358,Varies with device,10000000,Free,0,Everyone,Casual
+New YAHTZEE® With Buddies Dice Game,GAME,4.1,42079,93M,5000000,Free,0,Everyone,Board
+Word Crossy - A crossword game,GAME,4.5,240416,53M,5000000,Free,0,Everyone,Word
+MLB TAP SPORTS BASEBALL 2018,GAME,4.6,32506,82M,1000000,Free,0,Everyone,Sports
+Hero Hunters,GAME,4.4,70747,99M,5000000,Free,0,Teen,Action
+Cooking Madness - A Chef's Restaurant Games,GAME,4.7,358817,49M,10000000,Free,0,Everyone,Arcade
+Ice Crush 2018 - A new Puzzle Matching Adventure,GAME,4.6,15403,25M,1000000,Free,0,Everyone,Casual
+TerraGenesis - Space Colony,GAME,4.3,38957,Varies with device,1000000,Free,0,Everyone,Simulation
+Merge Dragons!,GAME,4.5,214777,91M,5000000,Free,0,Everyone,Puzzle
+SHADOWGUN LEGENDS,GAME,4.6,100609,52M,1000000,Free,0,Teen,Action
+RULES OF SURVIVAL,GAME,4.2,1343866,56M,10000000,Free,0,Teen,Action
+Mafia City,GAME,4.5,168717,56M,10000000,Free,0,Mature 17+,Strategy
+"Cash, Inc. Money Clicker Game & Business Adventure",GAME,4.8,549720,85M,10000000,Free,0,Everyone,Simulation
+Dino War: Rise of Beasts,GAME,4.1,18996,81M,1000000,Free,0,Teen,Strategy
+Tokyo Ghoul: Dark War,GAME,4.3,25094,82M,1000000,Free,0,Teen,Role Playing
+Last Shelter: Survival,GAME,4.4,93033,98M,5000000,Free,0,Teen,Strategy
+Guns of Glory,GAME,4.0,120592,77M,10000000,Free,0,Everyone 10+,Strategy
+Lineage 2: Revolution,GAME,4.2,187972,99M,5000000,Free,0,Teen,Role Playing
+Final Fantasy XV: A New Empire,GAME,4.0,484981,Varies with device,10000000,Free,0,Everyone 10+,Strategy
+Girls' Frontline,GAME,4.2,2055,96M,100000,Free,0,Teen,Strategy
+Chapters: Interactive Stories,GAME,4.5,73539,96M,1000000,Free,0,Mature 17+,Role Playing
+Honkai Impact 3rd,GAME,4.7,59017,82M,1000000,Free,0,Teen,Action
+Master of Eternity(MOE),GAME,4.2,5829,70M,100000,Free,0,Teen,Strategy
+The Game of Life,GAME,4.4,18621,63M,100000,Paid,$2.99,Everyone,Board
+Clue,GAME,4.6,19922,35M,100000,Paid,$1.99,Everyone 10+,Board
+The Room: Old Sins,GAME,4.9,21119,48M,100000,Paid,$4.99,Everyone,Puzzle
+The Escapists,GAME,4.4,7412,84M,100000,Paid,$4.99,Teen,Strategy
+Farming Simulator 18,GAME,4.5,18125,15M,100000,Paid,$4.99,Everyone,Simulation;Education
+RollerCoaster Tycoon® Classic,GAME,4.6,10795,69M,100000,Paid,$5.99,Everyone,Simulation
+Call of Duty:Black Ops Zombies,GAME,4.2,13004,46M,100000,Paid,$6.99,Teen,Action
+Star Wars ™: DIRTY,GAME,4.5,38207,15M,100000,Paid,$9.99,Teen,Role Playing
+Monument Valley 2,GAME,4.6,9394,33M,100000,Paid,$4.99,Everyone,Puzzle
+DRAGON BALL LEGENDS,GAME,4.6,337913,48M,5000000,Free,0,Teen,Action
+ROBLOX,GAME,4.5,4449882,67M,100000000,Free,0,Everyone 10+,Adventure;Action & Adventure
+Candy Crush Saga,GAME,4.4,22429716,74M,500000000,Free,0,Everyone,Casual
+Angry Birds 2,GAME,4.6,3883589,57M,100000000,Free,0,Everyone,Casual
+8 Ball Pool,GAME,4.5,14200550,52M,100000000,Free,0,Everyone,Sports
+Fallout Shelter,GAME,4.6,2719142,25M,10000000,Free,0,Teen,Simulation
+Harry Potter: Hogwarts Mystery,GAME,4.4,1107197,Varies with device,10000000,Free,0,Teen,Adventure
+PUBG MOBILE,GAME,4.4,3716278,36M,50000000,Free,0,Teen,Action
+The Sims™ FreePlay,GAME,4.3,931595,31M,10000000,Free,0,Teen,Simulation
+MARVEL Strike Force,GAME,4.3,165928,91M,5000000,Free,0,Teen,Role Playing
+Best Fiends - Free Puzzle Game,GAME,4.6,1480189,Varies with device,10000000,Free,0,Everyone,Casual
+MARVEL Contest of Champions,GAME,4.3,2468063,92M,50000000,Free,0,Teen,Action
+Jurassic World™ Alive,GAME,4.3,309176,70M,5000000,Free,0,Everyone 10+,Simulation
+Choices: Stories You Play,GAME,4.6,807338,93M,10000000,Free,0,Teen,Simulation
+Solitaire TriPeaks,GAME,4.5,446434,52M,10000000,Free,0,Everyone,Card
+Merge Dragons!,GAME,4.5,214819,91M,5000000,Free,0,Everyone,Puzzle
+The Walking Dead: Road to Survival,GAME,4.2,522466,37M,10000000,Free,0,Mature 17+,Role Playing
+Hustle Castle: Fantasy Kingdom,GAME,4.7,584126,64M,10000000,Free,0,Everyone 10+,Role Playing
+Might & Magic: Elemental Guardians,GAME,4.3,32551,35M,500000,Free,0,Mature 17+,Role Playing
+Game of Thrones: Conquest™,GAME,4.0,90218,97M,1000000,Free,0,Teen,Strategy
+Love Nikki-Dress UP Queen,GAME,4.4,212524,93M,5000000,Free,0,Everyone,Role Playing
+Summoners War,GAME,4.3,2045554,28M,50000000,Free,0,Teen,Role Playing
+FINAL FANTASY BRAVE EXVIUS,GAME,4.6,745684,83M,5000000,Free,0,Teen,Role Playing
+Idle Heroes,GAME,4.7,416540,99M,10000000,Free,0,Everyone 10+,Role Playing
+Fate/Grand Order (English),GAME,4.4,16601,55M,500000,Free,0,Teen,Role Playing
+Honkai Impact 3rd,GAME,4.7,59017,82M,1000000,Free,0,Teen,Action
+Lords Mobile: Battle of the Empires - Strategy RPG,GAME,4.4,3057481,14M,50000000,Free,0,Teen,Strategy
+War and Order,GAME,4.3,224514,81M,5000000,Free,0,Teen,Strategy
+Dungeon Hunter Champions: Epic Online Action RPG,GAME,4.2,26247,Varies with device,1000000,Free,0,Teen,Role Playing
+Candy Crush Saga,GAME,4.4,22430188,74M,500000000,Free,0,Everyone,Casual
+ROBLOX,GAME,4.5,4449910,67M,100000000,Free,0,Everyone 10+,Adventure;Action & Adventure
+8 Ball Pool,GAME,4.5,14201891,52M,100000000,Free,0,Everyone,Sports
+Subway Surfers,GAME,4.5,27725352,76M,1000000000,Free,0,Everyone 10+,Arcade
+Candy Crush Soda Saga,GAME,4.4,6199095,67M,100000000,Free,0,Everyone,Casual
+Zombie Hunter King,GAME,4.3,10493,50M,1000000,Free,0,Mature 17+,Action
+Bubble Shooter,GAME,4.5,148945,46M,10000000,Free,0,Everyone,Casual
+Toon Blast,GAME,4.7,1351771,Varies with device,10000000,Free,0,Everyone,Puzzle
+Toy Blast,GAME,4.7,1889582,Varies with device,50000000,Free,0,Everyone,Puzzle
+Clash Royale,GAME,4.6,23136735,97M,100000000,Free,0,Everyone 10+,Strategy
+Clash of Clans,GAME,4.6,44893888,98M,100000000,Free,0,Everyone 10+,Strategy
+Farm Heroes Saga,GAME,4.4,7614415,70M,100000000,Free,0,Everyone,Casual
+Plants vs. Zombies FREE,GAME,4.4,4067651,69M,100000000,Free,0,Everyone 10+,Strategy
+Word Search,GAME,4.7,295576,3.9M,10000000,Free,0,Everyone,Word
+Block Puzzle,GAME,4.6,59907,7.8M,5000000,Free,0,Everyone,Puzzle
+Super Jim Jump - pixel 3d,GAME,4.5,10460,18M,1000000,Free,0,Everyone,Arcade
+Pou,GAME,4.3,10486018,24M,500000000,Free,0,Everyone,Casual
+Temple Run 2,GAME,4.3,8119151,62M,500000000,Free,0,Everyone,Action
+Flow Free,GAME,4.3,1295625,11M,100000000,Free,0,Everyone,Puzzle
+Homescapes,GAME,4.6,3093932,Varies with device,10000000,Free,0,Everyone,Casual
+Wordscapes,GAME,4.8,230849,87M,10000000,Free,0,Everyone,Word
+My Talking Angela,GAME,4.5,9883367,99M,100000000,Free,0,Everyone,Casual
+slither.io,GAME,4.4,5235294,Varies with device,100000000,Free,0,Everyone,Action
+Cooking Fever,GAME,4.5,3198176,82M,100000000,Free,0,Everyone,Arcade
+Yes day,GAME,4.5,10055521,94M,100000000,Free,0,Everyone,Casual
+Gardenscapes,GAME,4.6,4129665,Varies with device,50000000,Free,0,Everyone,Casual
+Fishdom,GAME,4.6,2158580,Varies with device,10000000,Free,0,Everyone,Puzzle
+Galaxy Attack: Alien Shooter,GAME,4.6,506593,Varies with device,10000000,Free,0,Everyone,Arcade
+Score! Hero,GAME,4.6,5419676,96M,100000000,Free,0,Everyone,Sports
+Zombie Catchers,GAME,4.7,990723,75M,10000000,Free,0,Everyone,Action
+Magic Tiles 3,GAME,4.5,592504,Varies with device,50000000,Free,0,Everyone,Music
+Jewels Star: OZ adventure,GAME,4.5,21892,14M,1000000,Free,0,Everyone,Puzzle
+Granny,GAME,4.5,1138239,59M,50000000,Free,0,Teen,Arcade
+Dream League Soccer 2018,GAME,4.6,9883806,74M,100000000,Free,0,Everyone,Sports
+Sweet Fruit Candy,GAME,4.5,197540,29M,10000000,Free,0,Everyone,Puzzle
+Fruits Bomb,GAME,4.4,74695,17M,10000000,Free,0,Everyone,Casual
+Angry Birds Classic,GAME,4.4,5566889,97M,100000000,Free,0,Everyone,Arcade
+Talking Tom Gold Run,GAME,4.6,2698882,78M,100000000,Free,0,Everyone,Action
+Bowmasters,GAME,4.7,1535973,Varies with device,50000000,Free,0,Teen,Action
+My Talking Tom,GAME,4.5,14892469,Varies with device,500000000,Free,0,Everyone,Casual
+Hill Climb Racing,GAME,4.4,8923818,63M,100000000,Free,0,Everyone,Racing
+Sniper 3D Gun Shooter: Free Shooting Games - FPS,GAME,4.6,7674252,Varies with device,100000000,Free,0,Mature 17+,Action
+Pixel Art: Color by Number Game,GAME,4.7,1125438,25M,10000000,Free,0,Everyone,Puzzle
+Shoot Bubble - Fruit Splash,GAME,4.6,29445,29M,5000000,Free,0,Everyone,Casual
+Rider,GAME,4.5,655145,72M,10000000,Free,0,Teen,Arcade
+Zombie Tsunami,GAME,4.4,4921451,Varies with device,100000000,Free,0,Everyone 10+,Arcade
+Garena Free Fire,GAME,4.5,5476569,53M,100000000,Free,0,Teen,Action
+Doodle Jump,GAME,4.3,1083571,Varies with device,50000000,Free,0,Everyone,Arcade
+Subway Surfers,GAME,4.5,27725352,76M,1000000000,Free,0,Everyone 10+,Arcade
+Helix Jump,GAME,4.2,1500999,33M,100000000,Free,0,Everyone,Action
+Crossy Road,GAME,4.5,4230886,60M,100000000,Free,0,Everyone,Action
+Temple Run 2,GAME,4.3,8119154,62M,500000000,Free,0,Everyone,Action
+slither.io,GAME,4.4,5235294,Varies with device,100000000,Free,0,Everyone,Action
+Bowmasters,GAME,4.7,1535973,Varies with device,50000000,Free,0,Teen,Action
+Talking Tom Gold Run,GAME,4.6,2698889,78M,100000000,Free,0,Everyone,Action
+Zombie Catchers,GAME,4.7,990663,75M,10000000,Free,0,Everyone,Action
+Sniper 3D Gun Shooter: Free Shooting Games - FPS,GAME,4.6,7674252,Varies with device,100000000,Free,0,Mature 17+,Action
+Swamp Attack,GAME,4.4,2119218,70M,50000000,Free,0,Everyone 10+,Action
+Earn to Die 2,GAME,4.6,1327265,99M,50000000,Free,0,Teen,Racing
+Miraculous Ladybug & Cat Noir - The Official Game,GAME,4.5,184210,99M,10000000,Free,0,Everyone,Action
+Kick the Buddy,GAME,4.3,1003269,Varies with device,50000000,Free,0,Teen,Action
+Hungry Shark World,GAME,4.5,1242855,27M,50000000,Free,0,Teen,Action
+Dude Perfect 2,GAME,4.5,401425,70M,10000000,Free,0,Everyone,Action
+Shadow Fight 2,GAME,4.6,10979062,88M,100000000,Free,0,Everyone 10+,Action
+Alto's Adventure,GAME,4.6,515657,63M,10000000,Free,0,Everyone,Action
+DEER HUNTER 2018,GAME,4.3,955656,82M,10000000,Free,0,Teen,Action
+DRAGON BALL LEGENDS,GAME,4.6,337913,48M,5000000,Free,0,Teen,Action
+DEAD TARGET: FPS Zombie Apocalypse Survival Games,GAME,4.5,1468591,Varies with device,50000000,Free,0,Mature 17+,Action
+Cover Fire: offline shooting games for free,GAME,4.7,725897,31M,10000000,Free,0,Teen,Action
+Anger of stick 5 : zombie,GAME,4.5,549039,23M,50000000,Free,0,Teen,Action
+CATS: Crash Arena Turbo Stars,GAME,4.7,1559650,Varies with device,50000000,Free,0,Everyone,Action
+Soul Knight,GAME,4.7,292164,59M,10000000,Free,0,Everyone 10+,Action
+Major Mayhem,GAME,4.6,520962,39M,10000000,Free,0,Teen,Action
+DINO HUNTER: DEADLY SHORES,GAME,4.4,1381820,54M,10000000,Free,0,Teen,Action
+Strawberry Shortcake BerryRush,GAME,4.3,525517,48M,10000000,Free,0,Everyone,Action;Action & Adventure
+Extreme Match,GAME,4.5,696,Varies with device,100000,Free,0,Everyone,Action
+Power Rangers Dino Charge,GAME,4.3,194969,30M,10000000,Free,0,Everyone 10+,Action
+Zombie Hunter: Post Apocalypse Survival Games,GAME,4.4,327599,66M,10000000,Free,0,Teen,Action
+Agar.io,GAME,4.2,3816799,32M,100000000,Free,0,Everyone,Action
+Zombie Hunter King,GAME,4.3,10538,50M,1000000,Free,0,Mature 17+,Action
+Garena Free Fire,GAME,4.5,5476569,53M,100000000,Free,0,Teen,Action
+Battlelands Royale,GAME,4.4,105620,61M,1000000,Free,0,Everyone 10+,Action
+Once Upon a Tower,GAME,4.7,37139,49M,1000000,Free,0,Everyone 10+,Action
+TEKKEN™,GAME,4.2,147791,38M,5000000,Free,0,Teen,Action
+diep.io,GAME,4.1,347883,20M,10000000,Free,0,Everyone,Action
+Arrow.io,GAME,4.5,343263,Varies with device,10000000,Free,0,Everyone 10+,Action
+BEYBLADE BURST app,GAME,4.5,216849,Varies with device,10000000,Free,0,Everyone,Action;Action & Adventure
+Dragon Hills,GAME,4.5,354373,66M,10000000,Free,0,Everyone 10+,Action
+Bus Rush: Subway Edition,GAME,4.1,753043,57M,100000000,Free,0,Teen,Action
+DC Super Hero Girls™,GAME,4.3,43055,95M,5000000,Free,0,Everyone,Action;Action & Adventure
+Tiny Archers,GAME,4.5,80678,Varies with device,5000000,Free,0,Mature 17+,Action
+Metal Soldiers 2,GAME,4.4,153381,Varies with device,10000000,Free,0,Teen,Action
+Runner 3d like,GAME,4.5,559,32M,100000,Free,0,Everyone 10+,Action
+War Robots,GAME,4.6,3073251,33M,50000000,Free,0,Everyone 10+,Action
+Dinosaur Simulator: Dino World,GAME,4.0,26649,66M,5000000,Free,0,Teen,Action
+GUNSHIP BATTLE: Helicopter 3D,GAME,4.3,2151039,75M,50000000,Free,0,Teen,Action
+Quiz: Logo game,GAME,4.5,306764,29M,10000000,Free,0,Everyone,Trivia
+Candy Crush Saga,GAME,4.4,22430188,74M,500000000,Free,0,Everyone,Casual
+Plants vs. Zombies FREE,GAME,4.4,4067651,69M,100000000,Free,0,Everyone 10+,Strategy
+Block Puzzle,GAME,4.6,59907,7.8M,5000000,Free,0,Everyone,Puzzle
+Helix Jump,GAME,4.2,1500622,33M,100000000,Free,0,Everyone,Action
+8 Ball Pool,GAME,4.5,14201604,52M,100000000,Free,0,Everyone,Sports
+Jewels Legend - Match 3 Puzzle,GAME,4.6,280098,50M,10000000,Free,0,Everyone,Arcade
+Bubble Shooter,GAME,4.5,148990,46M,10000000,Free,0,Everyone,Casual
+Solitaire,GAME,4.7,154264,12M,10000000,Free,0,Everyone,Card
+Bubble Shooter Genies,GAME,4.5,26985,41M,5000000,Free,0,Everyone,Casual
+Blossom Blast Saga,GAME,4.5,1125438,63M,10000000,Free,0,Everyone,Casual
+Traffic Racer,GAME,4.5,5387781,53M,100000000,Free,0,Everyone,Racing
+Hill Climb Racing,GAME,4.4,8923847,63M,100000000,Free,0,Everyone,Racing
+Earn to Die 2,GAME,4.6,1327269,99M,50000000,Free,0,Teen,Racing
+Bubble Shooter 2,GAME,4.3,23043,Varies with device,5000000,Free,0,Everyone,Arcade
+Candy Bomb,GAME,4.4,42145,20M,10000000,Free,0,Everyone,Casual;Brain Games
+Flow Free,GAME,4.3,1295625,11M,100000000,Free,0,Everyone,Puzzle
+Zombie Catchers,GAME,4.7,990796,75M,10000000,Free,0,Everyone,Action
+Gems or jewels ?,GAME,4.7,171448,13M,10000000,Free,0,Teen,Puzzle
+Angry Birds Rio,GAME,4.4,2610680,46M,100000000,Free,0,Everyone,Arcade
+Candy Crush Jelly Saga,GAME,4.3,1300619,78M,50000000,Free,0,Everyone,Puzzle
+Cut the Rope FULL FREE,GAME,4.4,2123793,49M,100000000,Free,0,Everyone,Puzzle
+Jewels Star: OZ adventure,GAME,4.5,21892,14M,1000000,Free,0,Everyone,Puzzle
+Hungry Shark Evolution,GAME,4.5,6074627,100M,100000000,Free,0,Teen,Arcade
+Power Pop Bubbles,GAME,4.4,104303,Varies with device,10000000,Free,0,Everyone,Arcade
+Angry Birds Classic,GAME,4.4,5566908,97M,100000000,Free,0,Everyone,Arcade
+Best Fiends - Free Puzzle Game,GAME,4.6,1480182,Varies with device,10000000,Free,0,Everyone,Casual
+Hill Climb Racing 2,GAME,4.6,2750645,Varies with device,100000000,Free,0,Everyone,Racing
+Jewels classic Prince,GAME,4.4,47644,15M,5000000,Free,0,Everyone,Puzzle
+Fruit Block - Puzzle Legend,GAME,4.6,125647,33M,10000000,Free,0,Everyone,Casual
+Bubble Shooter Space,GAME,4.2,4355,Varies with device,1000000,Free,0,Everyone,Casual
+Swamp Attack,GAME,4.4,2119235,70M,50000000,Free,0,Everyone 10+,Action
+1LINE – One Line with One Touch,GAME,4.6,214878,10M,10000000,Free,0,Everyone,Board
+Stick War: Legacy,GAME,4.6,811040,77M,10000000,Free,0,Teen,Strategy
+Bowmasters,GAME,4.7,1536349,Varies with device,50000000,Free,0,Teen,Action
+Magic Tiles 3,GAME,4.5,592504,Varies with device,50000000,Free,0,Everyone,Music
+Block Puzzle Classic Legend !,GAME,4.2,17044,4.9M,5000000,Free,0,Everyone,Puzzle
+Marble Woka Woka 2018 - Bubble Shooter Match 3,GAME,4.6,155186,Varies with device,10000000,Free,0,Everyone,Puzzle
+Pixel Art: Color by Number Game,GAME,4.7,1125566,25M,10000000,Free,0,Everyone,Puzzle
+Score! Hero,GAME,4.6,5419676,96M,100000000,Free,0,Everyone,Sports
+Super Jabber Jump 3,GAME,4.3,34494,23M,5000000,Free,0,Everyone 10+,Arcade
+Rush,GAME,4.6,260651,51M,10000000,Free,0,Everyone,Arcade
+Jetpack Joyride,GAME,4.4,4638163,96M,100000000,Free,0,Everyone 10+,Arcade
+Zombie Tsunami,GAME,4.4,4921409,Varies with device,100000000,Free,0,Everyone 10+,Arcade
+DEAD TARGET: FPS Zombie Apocalypse Survival Games,GAME,4.5,1468638,Varies with device,50000000,Free,0,Mature 17+,Action
+Word Search,GAME,4.2,344585,Varies with device,50000000,Free,0,Everyone,Word
+Farm Heroes Saga,GAME,4.4,7614407,70M,100000000,Free,0,Everyone,Casual
+Racing in Car 2,GAME,4.3,234110,38M,50000000,Free,0,Everyone,Racing
+Dog Run - Pet Dog Simulator,GAME,4.7,48615,24M,10000000,Free,0,Everyone,Simulation;Action & Adventure
+YouTube Kids,FAMILY,4.5,470694,Varies with device,50000000,Free,0,Everyone,Entertainment;Music & Video
+Candy Bomb,FAMILY,4.4,42145,20M,10000000,Free,0,Everyone,Casual;Brain Games
+ROBLOX,FAMILY,4.5,4449910,67M,100000000,Free,0,Everyone 10+,Adventure;Action & Adventure
+Jewels Crush- Match 3 Puzzle,FAMILY,4.4,14774,19M,1000000,Free,0,Everyone,Casual;Brain Games
+Coloring & Learn,FAMILY,4.4,12753,51M,5000000,Free,0,Everyone,Educational;Creativity
+Mahjong,FAMILY,4.5,33983,22M,5000000,Free,0,Everyone,Puzzle;Brain Games
+Super ABC! Learning games for kids! Preschool apps,FAMILY,4.6,20267,46M,1000000,Free,0,Everyone,Educational;Education
+Toy Pop Cubes,FAMILY,4.5,5761,21M,1000000,Free,0,Everyone,Casual;Brain Games
+Educational Games 4 Kids,FAMILY,4.3,11618,39M,5000000,Free,0,Everyone,Educational;Education
+Candy Pop Story,FAMILY,4.7,12948,23M,1000000,Free,0,Everyone,Casual;Brain Games
+Solitaire,FAMILY,4.4,685,26M,100000,Free,0,Everyone,Card;Brain Games
+Princess Coloring Book,FAMILY,4.5,9779,39M,5000000,Free,0,Everyone,Education;Creativity
+Hello Kitty Nail Salon,FAMILY,4.2,369378,24M,50000000,Free,0,Everyone,Casual;Pretend Play
+Candy Smash,FAMILY,4.5,11436,15M,1000000,Free,0,Everyone,Casual;Brain Games
+Happy Fruits Bomb - Cube Blast,FAMILY,4.5,2150,20M,500000,Free,0,Everyone,Casual;Brain Games
+Dog Run - Pet Dog Simulator,FAMILY,4.7,48615,24M,10000000,Free,0,Everyone,Simulation;Action & Adventure
+Princess Adventures Puzzles,FAMILY,4.4,382,44M,500000,Free,0,Everyone,Education;Creativity
+Kids Educational Game 3 Free,FAMILY,4.3,24936,38M,5000000,Free,0,Everyone,Educational;Education
+Puzzle Kids - Animals Shapes and Jigsaw Puzzles,FAMILY,4.6,1109,52M,1000000,Free,0,Everyone,Educational;Brain Games
+Coloring book moana,FAMILY,3.9,974,14M,500000,Free,0,Everyone,Art & Design;Pretend Play
+Baby Panda Care,FAMILY,4.2,108795,49M,10000000,Free,0,Everyone,Educational;Pretend Play
+Kids Educational :All in One,FAMILY,4.5,1455,8.9M,500000,Free,0,Everyone,Education;Education
+Number Counting games for toddler preschool kids,FAMILY,4.3,1024,Varies with device,1000000,Free,0,Everyone,Educational;Education
+Toca Kitchen 2,FAMILY,4.5,1014822,56M,50000000,Free,0,Everyone,Educational;Pretend Play
+PJ Masks: Moonlight Heroes,FAMILY,4.4,86961,99M,10000000,Free,0,Everyone,Casual;Action & Adventure
+Learn To Draw Glow Flower,FAMILY,4.4,7320,10M,1000000,Free,0,Everyone,Entertainment;Education
+"No. Color - Color by Number, Number Coloring",FAMILY,4.8,269194,6.9M,10000000,Free,0,Everyone,Entertainment;Brain Games
+Bubble Shooter,FAMILY,4.4,59843,20M,5000000,Free,0,Everyone,Puzzle;Brain Games
+Draw.ly - Color by Number Pixel Art Coloring,FAMILY,4.4,18616,10M,1000000,Free,0,Everyone,Casual;Education
+Baby puzzles,FAMILY,4.3,11950,19M,5000000,Free,0,Everyone,Educational;Education
+Garden Fruit Legend,FAMILY,4.6,4289,33M,500000,Free,0,Everyone,Casual;Brain Games
+Barbie™ Fashion Closet,FAMILY,4.1,68286,85M,10000000,Free,0,Everyone,Casual;Creativity
+Candy Day,FAMILY,4.5,11716,48M,1000000,Free,0,Everyone,Casual;Brain Games
+Learn To Draw Glow Princess,FAMILY,4.5,3323,9.6M,1000000,Free,0,Everyone,Casual;Pretend Play
+ABC Kids - Tracing & Phonics,FAMILY,4.5,36606,Varies with device,10000000,Free,0,Everyone,Educational;Education
+Barbie Magical Fashion,FAMILY,4.0,328619,15M,10000000,Free,0,Everyone,Casual;Creativity
+Minion Rush: Despicable Me Official Game,FAMILY,4.5,10216997,Varies with device,100000000,Free,0,Everyone 10+,Casual;Action & Adventure
+Piano Kids - Music & Songs,FAMILY,4.6,46741,50M,10000000,Free,0,Everyone,Music;Music & Video
+Farming Simulator 14,FAMILY,4.5,530854,51M,10000000,Free,0,Everyone,Simulation;Action & Adventure
+Educational Games for Kids,FAMILY,4.5,7050,24M,1000000,Free,0,Everyone,Educational;Education
+No.Draw - Colors by Number 2018,FAMILY,4.5,235906,13M,10000000,Free,0,Everyone,Entertainment;Brain Games
+Fruit Boom,FAMILY,4.4,17753,16M,1000000,Free,0,Everyone,Casual;Brain Games
+Duolingo: Learn Languages Free,FAMILY,4.7,6294400,Varies with device,100000000,Free,0,Everyone,Education;Education
+Hot Wheels: Race Off,FAMILY,4.5,520609,Varies with device,10000000,Free,0,Everyone,Racing;Action & Adventure
+Baby Tiger Care - My Cute Virtual Pet Friend,FAMILY,4.5,432,63M,100000,Free,0,Everyone 10+,Educational;Education
+Strawberry Shortcake Ice Cream Island,FAMILY,4.2,32029,15M,5000000,Free,0,Everyone,Casual;Pretend Play
+Rhythm Patrol,FAMILY,4.3,4207,26M,100000,Free,0,Everyone,Music;Music & Video
+Kiddopia - Preschool Learning Games,FAMILY,4.5,64,81M,10000,Free,0,Everyone,Educational;Education
+Toca Mystery House,FAMILY,4.2,96,79M,5000,Paid,$3.99,Everyone,Educational;Creativity
+DisneyNOW – TV Shows & Games,FAMILY,4.3,82471,Varies with device,5000000,Free,0,Everyone,Entertainment;Music & Video
+Papumba Academy - Fun Learning For Kids,FAMILY,4.4,496,94M,100000,Free,0,Everyone,Education;Education
+Super ABC! Learning games for kids! Preschool apps,FAMILY,4.6,20267,46M,1000000,Free,0,Everyone,Educational;Education
+Drawing for Kids Learning Games for Toddlers age 3,FAMILY,4.6,29436,43M,1000000,Free,0,Everyone,Educational;Education
+Baby Panda’s Juice Shop,FAMILY,4.5,19230,45M,5000000,Free,0,Everyone,Educational;Brain Games
+Dr. Panda Restaurant 3,FAMILY,4.2,11126,91M,1000000,Free,0,Everyone,Educational;Pretend Play
+LEGO® Friends: Heartlake Rush,FAMILY,4.5,23671,91M,1000000,Free,0,Everyone,Arcade;Pretend Play
+Baby ABC in box! Kids alphabet games for toddlers!,FAMILY,4.6,9652,53M,1000000,Free,0,Everyone,Educational;Education
+Henry Danger Crime Warp,FAMILY,4.6,9626,28M,1000000,Free,0,Everyone,Action;Action & Adventure
+Thomas & Friends: Race On!,FAMILY,4.1,29319,26M,5000000,Free,0,Everyone,Casual;Action & Adventure
+Super School: Educational Kids Games & Rhymes,FAMILY,4.5,1791,56M,500000,Free,0,Everyone,Education;Education
+Fruit Cube Blast,FAMILY,4.6,9199,80M,500000,Free,0,Everyone,Puzzle;Brain Games
+Toddler Kids Puzzles PUZZINGO,FAMILY,4.6,14014,60M,1000000,Free,0,Everyone,Education;Education
+Happy Street,FAMILY,4.5,110877,Varies with device,1000000,Free,0,Everyone 10+,Casual;Action & Adventure
+Intellijoy Early Learning Academy,FAMILY,4.3,160,67M,50000,Free,0,Everyone,Education;Education
+Dr. Panda Town: Vacation,FAMILY,3.8,10366,78M,1000000,Free,0,Everyone,Education;Pretend Play
+Leo and Tig,FAMILY,4.5,47644,27M,1000000,Free,0,Everyone,Adventure;Action & Adventure
+School of Dragons,FAMILY,4.1,530792,Varies with device,10000000,Free,0,Everyone,Role Playing;Action & Adventure
+Fuzzy Seasons: Animal Forest,FAMILY,4.8,12137,63M,100000,Free,0,Everyone 10+,Simulation;Pretend Play
+Montessori Preschool,FAMILY,3.9,237,26M,100000,Free,0,Everyone,Education;Education
+Kids Corner: Interactive Tales and Games for kids,FAMILY,4.5,6404,46M,500000,Free,0,Everyone,Educational;Brain Games
+Cutie Cubies,FAMILY,4.4,6356,83M,500000,Free,0,Everyone,Puzzle;Creativity
+My Little Princess : Stores,FAMILY,4.3,169,60M,5000,Paid,$2.99,Everyone,Educational;Pretend Play
+Sago Mini Big City,FAMILY,4.2,8,44M,1000,Paid,$3.99,Everyone,Education;Pretend Play
+Pinkalicious Party,FAMILY,3.0,2,82M,500,Paid,$2.99,Everyone,Educational;Creativity
+ROBLOX,FAMILY,4.5,4450855,67M,100000000,Free,0,Everyone 10+,Adventure;Action & Adventure
+PJ Masks: Moonlight Heroes,FAMILY,4.4,86961,99M,10000000,Free,0,Everyone,Casual;Action & Adventure
+Minion Rush: Despicable Me Official Game,FAMILY,4.5,10216997,Varies with device,100000000,Free,0,Everyone 10+,Casual;Action & Adventure
+Dog Run - Pet Dog Simulator,FAMILY,4.7,48701,24M,10000000,Free,0,Everyone,Simulation;Action & Adventure
+Moana Island Life,FAMILY,4.1,15246,78M,1000000,Free,0,Everyone,Simulation;Action & Adventure
+Hot Wheels: Race Off,FAMILY,4.5,520654,Varies with device,10000000,Free,0,Everyone,Racing;Action & Adventure
+Basketball FRVR - Shoot the Hoop and Slam Dunk!,FAMILY,4.5,4076,Varies with device,100000,Free,0,Everyone,Sports;Action & Adventure
+Farming Simulator 14,FAMILY,4.5,530904,51M,10000000,Free,0,Everyone,Simulation;Action & Adventure
+My Oasis - Calming and Relaxing Idle Clicker Game,FAMILY,4.6,106750,94M,1000000,Free,0,Everyone,Simulation;Action & Adventure
+My Little Pony Rainbow Runners,FAMILY,4.3,33785,16M,5000000,Free,0,Everyone,Casual;Action & Adventure
+Extreme Racing 2 - Real driving RC cars game!,FAMILY,4.3,4207,93M,500000,Free,0,Everyone,Racing;Action & Adventure
+Cars: Lightning League,FAMILY,4.5,58795,77M,10000000,Free,0,Everyone,Racing;Action & Adventure
+Little Panda Run,FAMILY,4.2,3235,32M,1000000,Free,0,Everyone,Educational;Action & Adventure
+Snoopy's Town Tale - City Building Simulator,FAMILY,4.2,47031,58M,1000000,Free,0,Everyone,Simulation;Action & Adventure
+Car Racing game for Kids - Beepzz Dogs 🐕,FAMILY,4.4,131,48M,100000,Free,0,Everyone,Racing;Action & Adventure
+Pony Friends 🦄 - Beepzz racing game for kids,FAMILY,4.5,114,69M,50000,Free,0,Everyone,Racing;Action & Adventure
+LEGO® Juniors Create & Cruise,FAMILY,4.1,673203,73M,50000000,Free,0,Everyone,Educational;Action & Adventure
+Xtreme Racing 2018 - Jeep & 4x4 off road simulator,FAMILY,4.2,2178,99M,500000,Free,0,Everyone,Racing;Action & Adventure
+Thomas & Friends: Go Go Thomas,FAMILY,4.1,175625,16M,10000000,Free,0,Everyone,Racing;Action & Adventure
+Ninja Dash - Ronin Jump RPG,FAMILY,4.7,8508,54M,500000,Free,0,Everyone 10+,Arcade;Action & Adventure
+Paw Patrol by ShuffleCards,FAMILY,4.3,3484,56M,1000000,Free,0,Everyone,Entertainment;Action & Adventure
+Plants vs. Zombies™ Heroes,FAMILY,4.4,379415,68M,10000000,Free,0,Everyone,Casual;Action & Adventure
+Transformers Rescue Bots: Disaster Dash,FAMILY,4.4,19245,25M,1000000,Free,0,Everyone,Casual;Action & Adventure
+Mcqueen Coloring pages,FAMILY,4.2,65,7.0M,100000,Free,0,Everyone,Art & Design;Action & Adventure
+PAC-MAN Pop,FAMILY,4.3,24877,54M,5000000,Free,0,Everyone,Puzzle;Action & Adventure
+Monster Truck Driver & Racing,FAMILY,4.4,765,51M,1000000,Free,0,Everyone,Education;Action & Adventure
+L.O.L. Surprise Ball Pop,FAMILY,4.3,10088,Varies with device,1000000,Free,0,Everyone,Casual;Action & Adventure
+Strawberry Shortcake BerryRush,FAMILY,4.3,525552,48M,10000000,Free,0,Everyone,Action;Action & Adventure
+Little Fire Station,FAMILY,4.2,3762,44M,1000000,Free,0,Everyone,Education;Action & Adventure
+Ice Cream Jump,FAMILY,4.2,141363,8.7M,10000000,Free,0,Everyone,Casual;Action & Adventure
+Disney Magic Kingdoms: Build Your Own Magical Park,FAMILY,4.3,472584,91M,10000000,Free,0,Everyone,Simulation;Action & Adventure
+Turbo FAST,FAMILY,4.3,1329192,97M,50000000,Free,0,Everyone,Racing;Action & Adventure
+My Little Pony: Harmony Quest,FAMILY,4.1,148295,26M,10000000,Free,0,Everyone,Casual;Action & Adventure
+Transformers Rescue Bots: Hero Adventures,FAMILY,4.2,41273,16M,5000000,Free,0,Everyone,Adventure;Action & Adventure
+Robots Vs Zombies: Transform To Race And Fight,FAMILY,4.5,278,Varies with device,100000,Free,0,Everyone,Racing;Action & Adventure
+Equestria Girls,FAMILY,4.3,392596,53M,10000000,Free,0,Everyone,Role Playing;Action & Adventure
+DC Super Hero Girls™,FAMILY,4.3,43060,95M,5000000,Free,0,Everyone,Action;Action & Adventure
+Disney Crossy Road,FAMILY,4.5,514088,83M,10000000,Free,0,Everyone,Arcade;Action & Adventure
+Touch Racing 2 - Mini RC Race,FAMILY,4.1,41867,78M,1000000,Free,0,Everyone,Racing;Action & Adventure
+Toca Kitchen 2,FAMILY,4.5,1014846,56M,50000000,Free,0,Everyone,Educational;Pretend Play
+Doctor Pets,FAMILY,4.2,23060,21M,1000000,Free,0,Everyone,Educational;Education
+Supermarket – Game for Kids,FAMILY,4.4,112080,26M,10000000,Free,0,Everyone,Casual;Pretend Play
+Supermarket Manager: Cashier Simulator Kids Games,FAMILY,4.0,15489,60M,1000000,Free,0,Everyone,Casual;Pretend Play
+Kids Animals Jigsaw Puzzles 😄,FAMILY,4.1,51895,22M,10000000,Free,0,Everyone,Educational;Brain Games
+DC Super Hero Girls™,FAMILY,4.3,43060,95M,5000000,Free,0,Everyone,Action;Action & Adventure
+Strawberry Shortcake BerryRush,FAMILY,4.3,525552,48M,10000000,Free,0,Everyone,Action;Action & Adventure
+Inside Out Thought Bubbles,FAMILY,4.4,623398,58M,10000000,Free,0,Everyone,Puzzle;Brain Games
+Disney Magic Kingdoms: Build Your Own Magical Park,FAMILY,4.3,472584,91M,10000000,Free,0,Everyone,Simulation;Action & Adventure
+Monster High™,FAMILY,4.1,66661,22M,5000000,Free,0,Everyone,Casual;Pretend Play
+Cute Pet Puppies,FAMILY,4.0,10447,36M,1000000,Free,0,Everyone,Simulation;Action & Adventure
+Frozen Free Fall,FAMILY,4.3,1574197,37M,50000000,Free,0,Everyone,Puzzle;Action & Adventure
+Monster High™ Minis Mania,FAMILY,4.6,19170,70M,1000000,Free,0,Everyone,Strategy;Action & Adventure
+Shopkins World!,FAMILY,4.3,169609,34M,10000000,Free,0,Everyone,Arcade;Action & Adventure
+Monica Toy TV,FAMILY,4.7,6188,49M,500000,Free,0,Everyone 10+,Entertainment;Music & Video
+Toy Guitar with songs for kids,FAMILY,4.3,1369,9.8M,500000,Free,0,Everyone,Music & Audio;Music & Video
+Endless Numbers,FAMILY,4.4,2952,37M,500000,Free,0,Everyone,Education;Education
+Toddler Learning Games - Little Kids Games,FAMILY,4.2,731,Varies with device,100000,Free,0,Everyone,Educational;Education
+Sworkit Kids - Fitness Meets Fun,FAMILY,4.7,9856,55M,100000,Free,0,Everyone,Health & Fitness;Education
+Earth to Luna! Watch and Play,FAMILY,3.9,10753,84M,1000000,Free,0,Everyone,Educational;Education
+Nancy Drew Codes and Clues,FAMILY,4.1,154,16M,10000,Free,0,Everyone,Educational;Education
+Masha and the Bear Child Games,FAMILY,4.1,288523,92M,10000000,Free,0,Everyone,Adventure;Education
+codeSpark Academy & The Foos,FAMILY,4.1,4522,57M,500000,Free,0,Everyone,Educational;Education
+Toca Builders,FAMILY,4.2,3328,Varies with device,100000,Paid,$3.99,Everyone,Education;Creativity
+Toca Life: City,FAMILY,4.7,31100,24M,500000,Paid,$3.99,Everyone,Education;Pretend Play
+LEGO® Friends,FAMILY,4.4,854,6.9M,10000,Paid,$4.99,Everyone,Casual;Pretend Play
+My Little Work – Garage,FAMILY,4.3,560,44M,10000,Paid,$3.99,Everyone,Casual;Education
+"Alizay, pirate girl",FAMILY,4.5,197,11M,1000,Paid,$2.99,Everyone,Casual;Action & Adventure
+Word Search Games in english,FAMILY,4.3,63186,16M,10000000,Free,0,Everyone,Puzzle;Brain Games
+Chess Free,FAMILY,4.3,23772,17M,5000000,Free,0,Everyone,Board;Brain Games
+Tic Tac Toe,FAMILY,4.1,6007,18M,1000000,Free,0,Everyone,Board;Action & Adventure
+Dominos Game ✔️,FAMILY,4.1,2903,16M,1000000,Free,0,Everyone,Board;Brain Games
+Checkers ✔️,FAMILY,4.1,3617,19M,1000000,Free,0,Everyone,Board;Brain Games
+Crazy Colors: Bubbles Matching,FAMILY,4.6,3063,1.6M,100000,Free,0,Everyone,Board;Brain Games
+Chess for Kids - Play & Learn,FAMILY,4.1,3234,47M,100000,Free,0,Everyone,Puzzle;Brain Games
+Block Puzzle : Night in Egypt,FAMILY,4.4,276,16M,50000,Free,0,Everyone,Puzzle;Brain Games
+Mosaic puzzles,FAMILY,4.4,1595,14M,500000,Free,0,Everyone,Puzzle;Brain Games
+Chess School for Beginners,FAMILY,4.3,879,Varies with device,100000,Free,0,Everyone,Board;Brain Games
+RISK: Global Domination,FAMILY,4.0,68559,75M,5000000,Free,0,Everyone,Board;Action & Adventure
+Pino chess,FAMILY,4.8,61,25M,1000,Free,0,Everyone,Casual;Brain Games
+Chess PRO Free,FAMILY,3.8,1123,5.7M,100000,Free,0,Everyone,Board;Brain Games
+Children Educational Game Full,FAMILY,4.7,30,Varies with device,1000,Paid,$7.49,Everyone,Educational;Education
+All-in-One Mahjong 3 FREE,FAMILY,4.5,566,17M,50000,Free,0,Everyone,Board;Brain Games
+Hactar Go,FAMILY,4.8,97,3.5M,1000,Paid,$2.99,Everyone,Board;Brain Games
+All-in-One Mahjong 3,FAMILY,4.4,38,16M,100,Paid,$0.99,Everyone,Board;Brain Games
+World Racers family board game,FAMILY,4.8,4,42M,100,Paid,$0.99,Everyone,Board;Pretend Play
+SweetLand — Family Board Game,FAMILY,4.2,38,47M,1000,Paid,$0.99,Everyone,Casual;Pretend Play
+Steam: Rails to Riches,FAMILY,4.2,214,67M,5000,Paid,$4.99,Everyone,Board;Brain Games
+Whoowasit? - Best kids game!,FAMILY,4.0,248,26M,5000,Paid,$2.99,Everyone,Board;Action & Adventure
+Lanterns: The Harvest Festival,FAMILY,4.7,185,72M,1000,Paid,$4.99,Everyone,Board;Brain Games
+Tsuro - The Game of the Path,FAMILY,4.7,2195,37M,10000,Paid,$2.99,Everyone,Board;Brain Games
+THE aMAZEing Labyrinth,FAMILY,3.9,1615,1.2M,10000,Paid,$4.99,Everyone,Board;Brain Games
+Chess and Mate,FAMILY,4.5,359,17M,5000,Paid,$4.99,Everyone,Board;Brain Games
+Kids Balloon Pop Game Free 🎈,FAMILY,4.1,38021,19M,10000000,Free,0,Everyone,Casual;Music & Video
+Sounds for Toddlers FREE,FAMILY,4.4,6190,23M,1000000,Free,0,Everyone,Educational;Education
+Elmo Calls by Sesame Street,FAMILY,3.9,6903,25M,1000000,Free,0,Everyone,Educational;Pretend Play
+Sago Mini Friends,FAMILY,4.4,13155,83M,1000000,Free,0,Everyone,Education;Pretend Play
+Papumba Academy - Fun Learning For Kids,FAMILY,4.4,496,94M,100000,Free,0,Everyone,Education;Education
+Tee and Mo Bath Time Free,FAMILY,3.6,418,97M,100000,Free,0,Everyone,Educational;Education
+Bita and the Animals - Pelos Ares,FAMILY,4.4,1160,37M,100000,Free,0,Everyone,Education;Music & Video
+TO-FU Oh!SUSHI,FAMILY,4.1,59917,92M,5000000,Free,0,Everyone,Education;Pretend Play
+DreamWorks Friends,FAMILY,3.6,1042,48M,100000,Free,0,Everyone,Role Playing;Pretend Play
+Avokiddo Emotions,FAMILY,4.6,73,12M,1000,Paid,$2.99,Everyone,Education;Pretend Play
+Nighty Night Circus,FAMILY,4.3,382,15M,10000,Paid,$2.99,Everyone,Education;Action & Adventure
+Sago Mini Babies,FAMILY,4.5,253,83M,10000,Paid,$3.99,Everyone,Education;Pretend Play
+Dr. Panda & Toto's Treehouse,FAMILY,4.4,3396,9.5M,50000,Paid,$3.99,Everyone,Casual;Pretend Play
+Kids Balloon Pop Game Free 🎈,FAMILY,4.1,38021,19M,10000000,Free,0,Everyone,Casual;Music & Video
+Sounds for Toddlers FREE,FAMILY,4.4,6190,23M,1000000,Free,0,Everyone,Educational;Education
+Elmo Calls by Sesame Street,FAMILY,3.9,6903,25M,1000000,Free,0,Everyone,Educational;Pretend Play
+Sago Mini Friends,FAMILY,4.4,13155,83M,1000000,Free,0,Everyone,Education;Pretend Play
+Papumba Academy - Fun Learning For Kids,FAMILY,4.4,496,94M,100000,Free,0,Everyone,Education;Education
+Tee and Mo Bath Time Free,FAMILY,3.6,418,97M,100000,Free,0,Everyone,Educational;Education
+Bita and the Animals - Pelos Ares,FAMILY,4.4,1160,37M,100000,Free,0,Everyone,Education;Music & Video
+TO-FU Oh!SUSHI,FAMILY,4.1,59917,92M,5000000,Free,0,Everyone,Education;Pretend Play
+DreamWorks Friends,FAMILY,3.6,1042,48M,100000,Free,0,Everyone,Role Playing;Pretend Play
+Avokiddo Emotions,FAMILY,4.6,73,12M,1000,Paid,$2.99,Everyone,Education;Pretend Play
+Nighty Night Circus,FAMILY,4.3,382,15M,10000,Paid,$2.99,Everyone,Education;Action & Adventure
+Sago Mini Babies,FAMILY,4.5,253,83M,10000,Paid,$3.99,Everyone,Education;Pretend Play
+Dr. Panda & Toto's Treehouse,FAMILY,4.4,3396,9.5M,50000,Paid,$3.99,Everyone,Casual;Pretend Play
+ROBLOX,FAMILY,4.5,4450890,67M,100000000,Free,0,Everyone 10+,Adventure;Action & Adventure
+PlayKids - Educational cartoons and games for kids,FAMILY,4.1,182173,Varies with device,10000000,Free,0,Everyone,Entertainment;Music & Video
+YouTube Kids,FAMILY,4.5,470713,Varies with device,50000000,Free,0,Everyone,Entertainment;Music & Video
+Fun Kid Racing - Motocross,FAMILY,4.1,59729,Varies with device,10000000,Free,0,Everyone,Racing;Action & Adventure
+Barbie Life™,FAMILY,3.9,133117,63M,5000000,Free,0,Everyone,Casual;Pretend Play
+Baby Panda Care,FAMILY,4.2,108795,49M,10000000,Free,0,Everyone,Educational;Pretend Play
+Palace Pets in Whisker Haven,FAMILY,4.1,47213,14M,5000000,Free,0,Everyone,Entertainment;Pretend Play
+Sweet Baby Girl - Dream House and Play Time,FAMILY,3.9,95537,58M,10000000,Free,0,Everyone,Educational;Education
+Monster High™,FAMILY,4.1,66660,22M,5000000,Free,0,Everyone,Casual;Pretend Play
+Hello Kitty Lunchbox,FAMILY,4.2,51838,15M,5000000,Free,0,Everyone,Casual;Creativity
+Duolingo: Learn Languages Free,FAMILY,4.7,6294397,Varies with device,100000000,Free,0,Everyone,Education;Education
+Sweet Baby Girl Newborn Baby,FAMILY,3.8,36028,50M,5000000,Free,0,Everyone,Educational;Education
+COOKING MAMA Let's Cook!,FAMILY,4.3,528745,59M,10000000,Free,0,Everyone,Educational;Pretend Play
+Shopkins World!,FAMILY,4.3,169609,34M,10000000,Free,0,Everyone,Arcade;Action & Adventure
+DisneyNOW – TV Shows & Games,FAMILY,4.3,82471,Varies with device,5000000,Free,0,Everyone,Entertainment;Music & Video
+Ever After High™ Charmed Style,FAMILY,3.9,44062,54M,1000000,Free,0,Everyone,Casual;Pretend Play
+Equestria Girls,FAMILY,4.3,392596,53M,10000000,Free,0,Everyone,Role Playing;Action & Adventure
+Fun Kid Racing,FAMILY,4.0,79667,Varies with device,10000000,Free,0,Everyone,Racing;Action & Adventure
+Learn to Read with Tommy Turtle,FAMILY,4.0,20763,Varies with device,5000000,Free,0,Everyone,Educational;Education
+Frozen Free Fall,FAMILY,4.3,1574204,37M,50000000,Free,0,Everyone,Puzzle;Action & Adventure
+Nick,FAMILY,4.2,123322,25M,10000000,Free,0,Everyone 10+,Entertainment;Music & Video
+Thomas & Friends: Race On!,FAMILY,4.1,29319,26M,5000000,Free,0,Everyone,Casual;Action & Adventure
+Mad Libs,FAMILY,4.0,8126,61M,1000000,Free,0,Everyone,Entertainment;Brain Games
+Inside Out Thought Bubbles,FAMILY,4.4,623398,58M,10000000,Free,0,Everyone,Puzzle;Brain Games
+ABCmouse.com,FAMILY,4.3,50887,91M,5000000,Free,0,Everyone,Education;Education
+My Little Pony Celebration,FAMILY,4.3,63160,17M,1000000,Free,0,Everyone,Simulation;Pretend Play
+Sago Mini Friends,FAMILY,4.4,13155,83M,1000000,Free,0,Everyone,Education;Pretend Play
+Thomas & Friends: Delivery,FAMILY,4.2,28737,17M,1000000,Free,0,Everyone,Casual;Action & Adventure
+School of Dragons,FAMILY,4.1,530792,Varies with device,10000000,Free,0,Everyone,Role Playing;Action & Adventure
+Nasty Goats,FAMILY,4.3,45579,64M,1000000,Free,0,Everyone,Arcade;Action & Adventure
+Starfall Free & Member,FAMILY,4.2,19720,41M,1000000,Free,0,Everyone,Education;Education
+Animal Jam - Play Wild!,FAMILY,4.6,361970,58M,5000000,Free,0,Everyone,Casual;Pretend Play
+Video Editor,FAMILY,4.1,159619,23M,5000000,Free,0,Everyone,Video Players & Editors;Creativity
+Real Racing 3,FAMILY,4.5,354384,71M,10000000,Free,0,Everyone,Racing;Action & Adventure
+Peak – Brain Games & Training,FAMILY,4.4,272321,Varies with device,10000000,Free,0,Everyone,Education;Brain Games
+Minecraft,FAMILY,4.5,2376564,Varies with device,10000000,Paid,$6.99,Everyone 10+,Arcade;Action & Adventure
+Card Wars - Adventure Time,FAMILY,4.3,129603,23M,1000000,Paid,$2.99,Everyone 10+,Card;Action & Adventure
+Monash Uni Low FODMAP Diet,MEDICAL,4.2,1135,12M,100000,Paid,$9.00,Everyone,Medical
+iBP Blood Pressure,MEDICAL,4.4,578,704k,10000,Paid,$0.99,Everyone,Medical
+Pedi STAT,MEDICAL,4.6,129,2.9M,10000,Paid,$5.49,Everyone,Medical
+ASCCP Mobile,MEDICAL,4.5,63,25M,10000,Paid,$9.99,Everyone,Medical
+Journal Club: Medicine,MEDICAL,4.8,216,Varies with device,10000,Paid,$6.99,Everyone,Medical
+Paramedic Protocol Provider,MEDICAL,4.5,171,20M,10000,Paid,$10.00,Everyone 10+,Medical
+MommyMeds,MEDICAL,3.2,45,21M,5000,Paid,$3.99,Everyone,Medical
+Medical ID - In Case of Emergency (ICE),MEDICAL,4.6,717,5.4M,5000,Paid,$5.99,Everyone,Medical
+Human Anatomy Atlas 2018: Complete 3D Human Body,MEDICAL,4.5,2921,25M,100000,Paid,$24.99,Everyone,Medical
+Essential Anatomy 3,MEDICAL,4.1,1533,42M,50000,Paid,$11.99,Mature 17+,Medical
+Vargo Anesthesia Mega App,MEDICAL,4.6,92,32M,1000,Paid,$79.99,Everyone,Medical
+EMT Review Plus,MEDICAL,4.5,199,1.8M,10000,Paid,$11.99,Everyone,Medical
+Muscle Trigger Point Anatomy,MEDICAL,4.4,1361,33M,50000,Paid,$2.99,Everyone,Medical
+2017 EMRA Antibiotic Guide,MEDICAL,4.4,12,3.8M,1000,Paid,$16.99,Everyone,Medical
+ASRA Coags,MEDICAL,4.4,15,5.8M,1000,Paid,$3.99,Everyone,Medical
+IBM Micromedex Drug Info,MEDICAL,3.8,206,9.5M,10000,Paid,$2.99,Everyone,Medical
+Diabetes & Diet Tracker,MEDICAL,4.6,395,19M,1000,Paid,$9.99,Everyone,Medical
+VeinSeek,MEDICAL,2.5,79,Varies with device,1000,Paid,$3.99,Everyone,Medical
+Block Buddy,MEDICAL,4.0,15,5.0M,1000,Paid,$14.99,Everyone,Medical
+Super Hearing Secret Voices Recorder PRO,MEDICAL,5.0,3,23M,100,Paid,$2.99,Everyone,Medical
+EMT Study - NREMT Test Prep,MEDICAL,4.3,35,862k,5000,Paid,$3.99,Everyone,Medical
+Calcium Pro,MEDICAL,3.4,77,9.9M,5000,Paid,$2.99,Everyone,Medical
+Arrhythmias and Dysrhythmias,MEDICAL,4.2,3,24M,500,Paid,$1.00,Everyone,Medical
+EMT PASS,MEDICAL,3.4,51,2.4M,1000,Paid,$29.99,Everyone,Medical
+Pocket Lab Values,MEDICAL,4.3,214,899k,10000,Paid,$2.99,Everyone,Medical
+Medical terms (OFFLINE),MEDICAL,4.4,104,38M,1000,Paid,$2.99,Teen,Medical
+"Cardiac diagnosis (heart rate, arrhythmia)",MEDICAL,4.4,8,6.5M,100,Paid,$12.99,Everyone,Medical
+ERres- Emergency Medicine,MEDICAL,4.2,45,14M,1000,Paid,$4.99,Everyone,Medical
+FHR 5-Tier 2.0,MEDICAL,5.0,2,1.2M,500,Paid,$2.99,Everyone,Medical
+AnatomyMapp,MEDICAL,4.1,80,48M,5000,Paid,$14.99,Everyone,Medical
+OptoDrum,MEDICAL,3.9,10,378k,1000,Paid,$5.99,Everyone,Medical
+"Migraine, Headache Diary HeadApp Pro",MEDICAL,4.6,156,22M,500,Paid,$3.49,Everyone,Medical
+Blood Pressure Companion,MEDICAL,4.2,178,4.8M,1000,Paid,$0.99,Everyone,Medical
+Visual Anatomy 2,MEDICAL,4.4,576,Varies with device,5000,Paid,$2.49,Everyone,Medical
+"Muscle Premium - Human Anatomy, Kinesiology, Bones",MEDICAL,4.2,168,25M,10000,Paid,$24.99,Everyone,Medical
+CCHT PREP,MEDICAL,3.6,25,266k,1000,Paid,$10.99,Everyone,Medical
+Paramedic Meds,MEDICAL,4.5,163,375k,10000,Paid,$1.99,Everyone,Medical
+Advanced Comprehension Therapy,MEDICAL,4.2,3,62M,100,Paid,$24.99,Everyone,Medical
+OmniMedix Medical Calculator,MEDICAL,4.7,25,1.2M,1000,Paid,$4.99,Everyone,Medical
+Breathing Zone,MEDICAL,4.6,319,Varies with device,5000,Paid,$3.99,Everyone,Medical
+Lab Values + Medical Reference,MEDICAL,4.5,133,2.8M,10000,Paid,$2.99,Everyone,Medical
+Recognise Foot,MEDICAL,4.2,9,95M,1000,Paid,$7.49,Everyone,Medical
+Anti Mosquito simulation,MEDICAL,4.2,74,2.6M,1000,Paid,$1.50,Everyone,Medical
+Pain Tracker & Diary,MEDICAL,4.3,3,4.6M,100,Paid,$2.99,Everyone,Medical
+Menstrual Calendar Premium,MEDICAL,4.4,4207,Varies with device,50000,Paid,$3.99,Everyone,Medical
+Whist - Tinnitus Relief,MEDICAL,4.1,12,5.1M,1000,Paid,$1.99,Everyone,Medical
+Critical Care Paramedic Review,MEDICAL,4.4,17,1.8M,1000,Paid,$9.99,Everyone 10+,Medical
+With Helper Pro Pill Reminder,MEDICAL,4.6,358,Varies with device,5000,Paid,$3.99,Everyone,Medical
+Manage My Pain Pro,MEDICAL,4.4,726,Varies with device,5000,Paid,$3.99,Everyone,Medical
+"End Anxiety Pro - Stress, Panic Attack Help",MEDICAL,4.2,33,53M,1000,Paid,$3.99,Everyone,Medical
+Acupuncture Assistant,MEDICAL,4.5,492,39M,10000,Paid,$7.99,Everyone,Medical
+Number Therapy,MEDICAL,4.2,0,5.3M,50,Paid,$14.99,Everyone,Medical
+InfantRisk Center HCP,MEDICAL,2.6,41,14M,1000,Paid,$9.99,Everyone,Medical
+EMT Tutor NREMT-B Study Guide,MEDICAL,4.6,625,8.4M,10000,Paid,$3.99,Everyone,Medical
+Hospitalist Handbook,MEDICAL,4.8,12,18M,1000,Paid,$19.99,Everyone,Medical
+PTA Content Master,MEDICAL,4.2,64,41M,1000,Paid,$29.99,Everyone,Medical
+Navi Radiography Pro,MEDICAL,4.7,11,100M,500,Paid,$15.99,Everyone,Medical
+Nursing Care Plan NANDA Tables,MEDICAL,3.0,4,3.4M,500,Paid,$0.99,Everyone,Medical
+A Manual of Acupuncture,MEDICAL,3.5,214,68M,1000,Paid,$33.99,Everyone,Medical
+palmPEDi: Pediatric Tape,MEDICAL,4.6,66,2.6M,5000,Paid,$0.99,Everyone,Medical
+GoodRx Drug Prices and Coupons,MEDICAL,4.8,59158,11M,1000000,Free,0,Everyone,Medical
+MyChart,MEDICAL,4.2,19473,Varies with device,1000000,Free,0,Everyone,Medical
+FollowMyHealth®,MEDICAL,4.6,73118,37M,1000000,Free,0,Everyone,Medical
+CareZone,MEDICAL,4.4,27524,Varies with device,1000000,Free,0,Everyone,Medical
+Ovia Pregnancy Tracker & Baby Countdown Calendar,MEDICAL,4.8,102858,9.8M,1000000,Free,0,Everyone,Medical
+Teladoc Member,MEDICAL,4.0,2094,23M,500000,Free,0,Everyone,Medical
+myAir™ for Air10™ by ResMed,MEDICAL,3.7,236,18M,50000,Free,0,Everyone,Medical
+Blood Pressure,MEDICAL,4.2,33033,7.4M,5000000,Free,0,Everyone,Medical
+Pregnancy Week By Week,MEDICAL,4.8,78825,11M,1000000,Free,0,Everyone,Medical
+Doctor On Demand,MEDICAL,4.7,18674,Varies with device,1000000,Free,0,Everyone,Medical
+BioLife Plasma Services,MEDICAL,3.5,250,23M,100000,Free,0,Everyone,Medical
+OneTouch Reveal,MEDICAL,3.9,6266,34M,500000,Free,0,Everyone,Medical
+To,MEDICAL,4.2,22,15M,10000,Free,0,Everyone,Medical
+Ovia Fertility Tracker & Ovulation Calculator,MEDICAL,4.8,53743,13M,1000000,Free,0,Everyone,Medical
+Anthem Anywhere,MEDICAL,2.7,2657,24M,500000,Free,0,Everyone,Medical
+Blood Donor,MEDICAL,4.2,4476,20M,500000,Free,0,Everyone,Medical
+My Calendar - Period Tracker,MEDICAL,4.7,156410,14M,5000000,Free,0,Everyone,Medical
+Youper - AI Therapy,MEDICAL,4.6,2006,69M,50000,Free,0,Everyone,Medical
+Zocdoc: Find Doctors & Book Appointments,MEDICAL,4.5,6099,38M,500000,Free,0,Everyone,Medical
+1800 Contacts - Lens Store,MEDICAL,4.7,23160,26M,1000000,Free,0,Everyone,Medical
+Blood Pressure Log - MyDiary,MEDICAL,4.7,8348,2.6M,500000,Free,0,Everyone,Medical
+PulsePoint Respond,MEDICAL,4.5,7837,21M,100000,Free,0,Everyone,Medical
+Ovia Parenting & Baby Development Tracker,MEDICAL,4.7,6185,38M,100000,Free,0,Everyone,Medical
+MyQuest for Patients,MEDICAL,4.0,3803,16M,100000,Free,0,Everyone,Medical
+OptumRx,MEDICAL,3.4,1838,21M,100000,Free,0,Everyone,Medical
+CVS Caremark,MEDICAL,3.5,3707,10M,500000,Free,0,Everyone,Medical
+fred's Pharmacy,MEDICAL,3.0,315,22M,100000,Free,0,Everyone,Medical
+Ada - Your Health Guide,MEDICAL,4.7,87418,14M,1000000,Free,0,Everyone,Medical
+mySugr: the blood sugar tracker made just for you,MEDICAL,4.6,21189,36M,1000000,Free,0,Everyone,Medical
+ClearCareGo Caregiver,MEDICAL,4.2,1746,16M,50000,Free,0,Everyone,Medical
+Pregnancy Calculator and Tracker app,MEDICAL,4.8,69126,61M,1000000,Free,0,Everyone,Medical
+All Mental disorders,MEDICAL,4.5,453,11M,100000,Free,0,Everyone,Medical
+DreamMapper,MEDICAL,4.2,10710,8.5M,100000,Free,0,Everyone,Medical
+ScriptSave WellRx Rx Discounts,MEDICAL,3.8,700,37M,100000,Free,0,Everyone,Medical
+Delta Dental,MEDICAL,3.0,914,Varies with device,100000,Free,0,Everyone,Medical
+Drugs.com Medication Guide,MEDICAL,4.4,15875,Varies with device,1000000,Free,0,Everyone,Medical
+MoodSpace,MEDICAL,4.5,503,22M,50000,Free,0,Everyone,Medical
+Pill Identifier and Drug list,MEDICAL,4.0,488,17M,100000,Free,0,Everyone,Medical
+HealtheLife,MEDICAL,3.6,190,7.7M,100000,Free,0,Everyone,Medical
+SonicCloud: Hearing App,MEDICAL,4.4,15,39M,1000,Free,0,Everyone,Medical
+Migraine Buddy - The Migraine and Headache tracker,MEDICAL,4.7,26862,30M,500000,Free,0,Everyone,Medical
+Period Tracker,MEDICAL,4.9,100082,3.7M,1000000,Free,0,Everyone,Medical
+LabCorp | Patient,MEDICAL,3.6,27,28M,10000,Free,0,Everyone,Medical
+Anatomy Learning - 3D Atlas,MEDICAL,4.5,72167,16M,1000000,Free,0,Everyone,Medical
+Super Hearing Super Ear Amplifier,MEDICAL,4.1,21,20M,1000,Free,0,Everyone,Medical
+Moodpath - Depression & Anxiety Test,MEDICAL,4.6,6035,8.9M,100000,Free,0,Everyone,Medical
+Teach Me Anatomy,MEDICAL,4.7,9945,97M,500000,Free,0,Everyone,Medical
+Baritastic - Bariatric Tracker,MEDICAL,4.7,4318,12M,100000,Free,0,Everyone,Medical
+Brilliant Distinctions®,MEDICAL,2.8,78,72M,50000,Free,0,Everyone,Medical
+Mayo Clinic,MEDICAL,4.3,2218,Varies with device,500000,Free,0,Everyone,Medical
+98point6,MEDICAL,4.6,47,21M,10000,Free,0,Everyone,Medical
+Epocrates Plus,MEDICAL,4.3,23889,Varies with device,1000000,Free,0,Everyone,Medical
+MDLIVE: Talk to a Doctor 24/7,MEDICAL,3.4,650,27M,100000,Free,0,Everyone,Medical
+Free Blood Pressure,MEDICAL,4.2,7,5.7M,5000,Free,0,Everyone,Medical
+Super Ear,MEDICAL,4.0,3498,6.6M,100000,Free,0,Everyone,Medical
+VitusVet: Pet Health Care App,MEDICAL,4.8,3052,12M,100000,Free,0,Everyone,Medical
+Banfield Pet Health Tracker,MEDICAL,4.2,1747,5.9M,100000,Free,0,Everyone,Medical
+Dexcom G6,MEDICAL,3.0,45,20M,5000,Free,0,Everyone,Medical
+Nurse Grid,MEDICAL,4.5,1686,15M,100000,Free,0,Everyone,Medical
+Castlight Mobile,MEDICAL,3.7,529,26M,100000,Free,0,Everyone,Medical
+Sanford Guide:Antimicrobial Rx,MEDICAL,4.5,1388,3.3M,100000,Free,0,Everyone,Medical
+Davis's Drug Guide for Nurses,MEDICAL,4.5,572,44M,50000,Free,0,Everyone,Medical
+Vargo Anesthesia Mega App,MEDICAL,4.6,92,32M,1000,Paid,$79.99,Everyone,Medical
+Monash Uni Low FODMAP Diet,MEDICAL,4.2,1135,12M,100000,Paid,$9.00,Everyone,Medical
+mySugr: the blood sugar tracker made just for you,MEDICAL,4.6,21189,36M,1000000,Free,0,Everyone,Medical
+live Point,MEDICAL,3.6,54,17M,5000,Free,0,Mature 17+,Medical
+Tarascon Pharmacopoeia,MEDICAL,4.4,275,5.8M,10000,Free,0,Everyone 10+,Medical
+Official NBSTSA CST Exam Prep,MEDICAL,4.4,2159,11M,10000,Free,0,Everyone,Medical
+EMT-B Pocket Prep,MEDICAL,4.5,2951,16M,50000,Free,0,Everyone,Medical
+Human Anatomy Atlas 2018: Complete 3D Human Body,MEDICAL,4.5,2921,25M,100000,Paid,$24.99,Everyone,Medical
+5-Minute Clinical Consult,MEDICAL,4.1,84,6.1M,10000,Free,0,Everyone,Medical
+Diabetes:M,MEDICAL,4.6,15545,Varies with device,100000,Free,0,Everyone,Medical
+"Pzizz - Sleep, Nap, Focus",MEDICAL,4.3,5521,22M,100000,Free,0,Everyone,Medical
+HESI A2 Pocket Prep,MEDICAL,4.3,2108,28M,50000,Free,0,Everyone,Medical
+Johns Hopkins Guides ABX...,MEDICAL,4.7,73,6.3M,10000,Free,0,Everyone,Medical
+ASCCP Mobile,MEDICAL,4.5,63,25M,10000,Paid,$9.99,Everyone,Medical
+FP Notebook,MEDICAL,4.5,408,60M,50000,Free,0,Everyone,Medical
+Paramedic Protocol Provider,MEDICAL,4.5,171,20M,10000,Paid,$10.00,Everyone 10+,Medical
+5 Minute Clinical Consult 2019 - #1 for 25 years,MEDICAL,4.2,33,8.0M,10000,Free,0,Everyone,Medical
+Open Sesame - Touch Free Control,MEDICAL,4.4,197,20M,10000,Free,0,Everyone,Medical
+Davis's Drug Guide,MEDICAL,3.9,272,6.4M,50000,Free,0,Everyone,Medical
+Deep Sleep and Relax Hypnosis,MEDICAL,4.2,4852,34M,100000,Free,0,Everyone,Medical
+2017 EMRA Antibiotic Guide,MEDICAL,4.4,12,3.8M,1000,Paid,$16.99,Everyone,Medical
+Essential Anatomy 3,MEDICAL,4.1,1533,42M,50000,Paid,$11.99,Mature 17+,Medical
+EMT PASS,MEDICAL,3.4,51,2.4M,1000,Paid,$29.99,Everyone,Medical
+Christella VoiceUp,MEDICAL,4.1,38,70M,5000,Free,0,Everyone,Medical
+Block Buddy,MEDICAL,4.0,15,5.0M,1000,Paid,$14.99,Everyone,Medical
+Language Therapy: Aphasia,MEDICAL,4.2,10,28M,1000,Paid,$74.99,Everyone,Medical
+Complete Anatomy for Android,MEDICAL,4.1,90,21M,1000,Free,0,Everyone,Medical
+GlassesOff,MEDICAL,3.5,1288,38M,100000,Free,0,Everyone,Medical
+Free Hypnosis,MEDICAL,4.2,4303,Varies with device,100000,Free,0,Everyone,Medical
+e-Anatomy,MEDICAL,4.0,1545,74M,100000,Free,0,Everyone,Medical
+EMT Review Plus,MEDICAL,4.5,199,1.8M,10000,Paid,$11.99,Everyone,Medical
+Registered Dietitian Pocket Prep,MEDICAL,4.3,283,12M,5000,Free,0,Everyone,Medical
+Paramedic Pocket Prep,MEDICAL,4.3,460,13M,10000,Free,0,Everyone,Medical
+Journal Club: Medicine,MEDICAL,4.8,216,Varies with device,10000,Paid,$6.99,Everyone,Medical
+Pedi STAT,MEDICAL,4.6,129,2.9M,10000,Paid,$5.49,Everyone,Medical
+AnatomyMapp,MEDICAL,4.1,80,48M,5000,Paid,$14.99,Everyone,Medical
+Diabetes & Diet Tracker,MEDICAL,4.6,395,19M,1000,Paid,$9.99,Everyone,Medical
+A Manual of Acupuncture,MEDICAL,3.5,214,68M,1000,Paid,$33.99,Everyone,Medical
+5 Minute Veterinary Consult: Canine & Feline,MEDICAL,2.3,17,6.8M,1000,Free,0,Everyone,Medical
+Wide address pocket prep,MEDICAL,4.5,513,12M,5000,Free,0,Everyone,Medical
+Nursing Central,MEDICAL,4.3,168,5.8M,10000,Free,0,Everyone,Medical
+PTA Content Master,MEDICAL,4.2,64,41M,1000,Paid,$29.99,Everyone,Medical
+"Muscle Premium - Human Anatomy, Kinesiology, Bones",MEDICAL,4.2,168,25M,10000,Paid,$24.99,Everyone,Medical
+Tinnitus Alleviator,MEDICAL,3.1,82,42M,5000,Free,0,Everyone,Medical
+"Cardiac diagnosis (heart rate, arrhythmia)",MEDICAL,4.4,8,6.5M,100,Paid,$12.99,Everyone,Medical
+PMHNP-BC Pocket Prep,MEDICAL,4.4,112,13M,1000,Free,0,Everyone,Medical
+Dialysis of Drugs,MEDICAL,2.9,92,1.5M,10000,Free,0,Everyone,Medical
+abeoCoder,MEDICAL,3.1,83,3.2M,10000,Free,0,Everyone,Medical
+Saunders Comprehensive Review NCLEX-PN Examination,MEDICAL,3.7,3,7.7M,5000,Free,0,Everyone,Medical
+LTC AS Legal,MEDICAL,4.0,6,1.3M,100,Paid,$39.99,Everyone,Medical
+Lippincott Nursing Advisor,MEDICAL,3.8,343,26M,50000,Free,0,Everyone,Medical
+Medical ID - In Case of Emergency (ICE),MEDICAL,4.6,717,5.4M,5000,Paid,$5.99,Everyone,Medical
+Official NBSTSA CSFA Exam Prep,MEDICAL,4.4,137,11M,1000,Free,0,Everyone,Medical
+IBM Micromedex Drug Info,MEDICAL,3.8,206,9.5M,10000,Paid,$2.99,Everyone,Medical
+Advanced Comprehension Therapy,MEDICAL,4.2,3,62M,100,Paid,$24.99,Everyone,Medical
+Hospitalist Handbook,MEDICAL,4.8,12,18M,1000,Paid,$19.99,Everyone,Medical
+Dosecast - Medication Reminder,MEDICAL,4.3,4107,Varies with device,100000,Free,0,Everyone,Medical
+Visualmed,MEDICAL,4.2,0,3.1M,1,Paid,$2.99,Everyone,Medical
+ABG Master,MEDICAL,4.2,2,1.8M,50,Paid,$0.99,Everyone,Medical
+OrthoFlow,MEDICAL,4.2,0,66M,10,Paid,$5.99,Everyone,Medical
+Be the Expert in Phlebotomy - Professional Nursing,MEDICAL,4.2,0,5.0M,1,Paid,$0.99,Everyone,Medical
+JH Blood Pressure Monitor,MEDICAL,3.7,9,2.9M,500,Free,0,Everyone,Medical
+Sway Medical,MEDICAL,5.0,3,22M,100,Free,0,Everyone,Medical
+Exposure Ed,MEDICAL,3.0,2,16M,500,Free,0,Everyone,Medical
+Nucleus Smart,MEDICAL,3.7,20,19M,1000,Free,0,Everyone,Medical
+Penn State Health OnDemand,MEDICAL,4.2,0,40M,50,Free,0,Everyone,Medical
+Breastfeeding Tracker Baby Log,MEDICAL,4.2,6,23M,100,Free,0,Everyone,Medical
+Lego Ninjago Wallpaper,MEDICAL,4.2,2,15M,100,Free,0,Everyone,Medical
+RT 516 VET,MEDICAL,4.2,0,29M,10,Free,0,Everyone,Medical
+EXOGEN Connects (US),MEDICAL,4.2,0,16M,10,Free,0,Everyone,Medical
+Full Code - Emergency Medicine Simulation,MEDICAL,4.2,0,65M,100,Free,0,Everyone,Medical
+Maricopa AH,MEDICAL,4.2,0,29M,100,Free,0,Everyone,Medical
+Dare EMS Protocols,MEDICAL,4.2,0,20M,10,Free,0,Everyone 10+,Medical
+Pediatric Emergency Guide,MEDICAL,4.2,0,3.8M,100,Free,0,Everyone,Medical
+Weill Cornell Medicine,MEDICAL,4.2,0,19M,50,Free,0,Everyone,Medical
+Doctors Care,MEDICAL,4.2,0,25M,10,Free,0,Everyone,Medical
+PCOS Guide - Fight PCOS naturally,MEDICAL,4.2,0,5.1M,100,Free,0,Everyone,Medical
+EVA - Menstrual calendar and fertility,MEDICAL,4.2,25,16M,1000,Free,0,Everyone,Medical
+Hello Face,MEDICAL,4.2,0,1.5M,10,Free,0,Everyone,Medical
+Cochrane Library,MEDICAL,3.7,3,10.0M,100,Free,0,Everyone,Medical
+Labs on Demand,MEDICAL,5.0,1,22M,10,Free,0,Everyone,Medical
+Diabetes Testing,MEDICAL,4.2,1,3.6M,500,Free,0,Mature 17+,Medical
+GGDE: Prevent & Beat Depression Symptoms,MEDICAL,4.2,2,20M,50,Free,0,Everyone,Medical
+Dermatology Atlas (Colored & Illustrative),MEDICAL,5.0,3,20M,100,Free,0,Everyone,Medical
+Jaylex,MEDICAL,4.2,0,13M,10,Free,0,Everyone,Medical
+Tablet Reminder,MEDICAL,5.0,4,2.5M,5,Free,0,Everyone,Medical
+Clinical Pharmacology,MEDICAL,4.2,0,3.6M,10,Free,0,Everyone,Medical
+Galaxies of Hope,MEDICAL,5.0,2,24M,50,Free,0,Everyone,Medical
+Smartshading AI,MEDICAL,4.2,0,10M,10,Free,0,Everyone,Medical
+KBA-EZ Health Guide,MEDICAL,5.0,4,25M,1,Free,0,Everyone,Medical
+FoothillsVet,MEDICAL,5.0,2,29M,50,Free,0,Everyone,Medical
+Eversense,MEDICAL,4.2,3,17M,100,Free,0,Everyone,Medical
+PrimeDelivery,MEDICAL,5.0,3,53M,10,Free,0,Everyone,Medical
+You're an Anime,MEDICAL,5.0,2,83M,10,Free,0,Everyone,Medical
+Anatomy & Physiology Vocabulary Exam Review App,MEDICAL,5.0,1,4.6M,5,Free,0,Everyone,Medical
+Drug Calculator,MEDICAL,4.2,0,4.6M,10,Free,0,Everyone,Medical
+HACH Cares,MEDICAL,4.2,0,28M,10,Free,0,Everyone,Medical
+WAH 247,MEDICAL,4.2,0,29M,1,Free,0,Everyone,Medical
+CT Scan Cross Sectional Anatomy,MEDICAL,4.3,10,46M,100,Free,0,Everyone,Medical
+VetCode,MEDICAL,4.9,28,5.7M,5000,Free,0,Everyone,Medical
+ear super hearing,MEDICAL,4.2,0,1.4M,5,Free,0,Everyone,Medical
+Traditional Chinese Medicine Fangfang Liangfang Daquan - Practical and ancient Chinese medicine and old prescriptions for the treatment of various incurable diseases,MEDICAL,4.2,1,12M,10,Free,0,Everyone,Medical
+COPD GOLD 2017,MEDICAL,4.2,5,2.2M,10,Free,0,Everyone,Medical
+Summit Medical Video Visits,MEDICAL,4.2,0,27M,10,Free,0,Everyone,Medical
+ExtendedCare Virtual Care Room,MEDICAL,4.2,0,18M,5,Free,0,Everyone,Medical
+Lord Fairfax EMS Council,MEDICAL,4.2,0,30M,50,Free,0,Everyone,Medical
+MyWoundDoctor - Provider,MEDICAL,4.2,0,3.5M,1,Free,0,Everyone,Medical
+NCLEX Multi-topic Nursing Exam Review-Quiz & notes,MEDICAL,5.0,1,4.2M,10,Free,0,Everyone,Medical
+Warfarin Dose Calculator,MEDICAL,4.2,0,6.9M,50,Free,0,Everyone,Medical
+Renesas PMA,MEDICAL,4.2,0,6.6M,5,Free,0,Everyone,Medical
+Pediatric Nursing,MEDICAL,4.9,14,7.0M,100,Free,0,Everyone,Medical
+Interpret Chest X-Ray With 100 Cases,MEDICAL,4.6,5,11M,100,Free,0,Everyone,Medical
+Basics of Orthopaedics,MEDICAL,5.0,1,5.6M,10,Free,0,Everyone,Medical
+4 Paws PH,MEDICAL,4.2,1,29M,5,Free,0,Everyone,Medical
+high cholesterol levels,MEDICAL,4.2,0,3.3M,100,Free,0,Everyone,Medical
+Thyroid Nodules,MEDICAL,4.2,0,20M,10,Free,0,Everyone,Medical
+Training course: Learn Nursing,MEDICAL,4.2,0,7.0M,100,Free,0,Everyone,Medical
+Familyfirst Messenger,MEDICAL,4.0,1,3.3M,10,Free,0,Everyone,Medical
+14thStreetVet,MEDICAL,4.2,0,29M,5,Free,0,Everyone,Medical
+Clinic Doctor EHr,MEDICAL,5.0,2,7.1M,5,Free,0,Everyone,Medical
+OMD Protocols,MEDICAL,4.2,0,Varies with device,10,Free,0,Everyone,Medical
+Teladoc Member,MEDICAL,4.0,2094,23M,500000,Free,0,Everyone,Medical
+Anthem BC Anywhere,MEDICAL,2.6,496,24M,100000,Free,0,Everyone,Medical
+Ada - Your Health Guide,MEDICAL,4.7,87418,14M,1000000,Free,0,Everyone,Medical
+Ovia Fertility Tracker & Ovulation Calculator,MEDICAL,4.8,53747,13M,1000000,Free,0,Everyone,Medical
+My Cancer Coach,MEDICAL,4.3,44,34M,10000,Free,0,Everyone,Medical
+IHSS Help,MEDICAL,4.7,10,4.3M,1000,Free,0,Everyone,Medical
+mobileRx Pharmacy,MEDICAL,2.5,124,43M,10000,Free,0,Everyone,Medical
+Youper - AI Therapy,MEDICAL,4.6,2014,69M,50000,Free,0,Everyone,Medical
+MoodSpace,MEDICAL,4.5,503,22M,50000,Free,0,Everyone,Medical
+Super Hearing Super Ear Amplifier,MEDICAL,4.1,21,20M,1000,Free,0,Everyone,Medical
+BURST Professionals,MEDICAL,4.5,11,25M,1000,Free,0,Everyone,Medical
+LactMed,MEDICAL,4.3,573,2.0M,100000,Free,0,Everyone,Medical
+Penn State Health OnDemand,MEDICAL,4.2,0,40M,50,Free,0,Everyone,Medical
+ScriptSave WellRx Rx Discounts,MEDICAL,3.8,700,37M,100000,Free,0,Everyone,Medical
+Blue CareOnDemand,MEDICAL,4.4,163,40M,10000,Free,0,Everyone,Medical
+HHS,MEDICAL,4.2,0,4.3M,500,Free,0,Everyone,Medical
+Free Blood Pressure,MEDICAL,4.2,7,5.7M,5000,Free,0,Everyone,Medical
+Every disease has a drug without internet,MEDICAL,4.2,44,4.0M,10000,Free,0,Everyone,Medical
+PulsePoint AED,MEDICAL,4.5,330,17M,50000,Free,0,Everyone,Medical
+All Mental disorders,MEDICAL,4.5,453,11M,100000,Free,0,Everyone,Medical
+Deaf Interpreter,MEDICAL,3.8,24,4.4M,1000,Free,0,Everyone,Medical
+Nurse Grid,MEDICAL,4.5,1686,15M,100000,Free,0,Everyone,Medical
+High Blood Pressure Symptoms,MEDICAL,4.0,531,2.3M,100000,Free,0,Everyone,Medical
+MedStar eVisit,MEDICAL,4.5,20,40M,5000,Free,0,Everyone,Medical
+Blood Pressure(BP) Diary,MEDICAL,3.7,3596,8.4M,1000000,Free,0,Everyone,Medical
+REDCap Mobile App,MEDICAL,4.3,56,11M,10000,Free,0,Everyone,Medical
+JH Blood Pressure Monitor,MEDICAL,3.7,9,2.9M,500,Free,0,Everyone,Medical
+Blood Pressure,MEDICAL,4.2,10,2.4M,1000,Free,0,Everyone,Medical
+VITAS Hospice Referral App for Healthcare Pros,MEDICAL,4.4,27,15M,5000,Free,0,Everyone,Medical
+AAFP,MEDICAL,3.8,63,24M,10000,Free,0,Everyone,Medical
+RT 516 VET,MEDICAL,4.2,0,29M,10,Free,0,Everyone,Medical
+Anthem Anywhere,MEDICAL,2.7,2657,24M,500000,Free,0,Everyone,Medical
+Sway Medical,MEDICAL,5.0,3,22M,100,Free,0,Everyone,Medical
+Airway Ex - Intubate. Anesthetize. Train.,MEDICAL,4.3,123,86M,10000,Free,0,Everyone,Medical
+myvi by,MEDICAL,3.8,122,Varies with device,10000,Free,0,Everyone,Medical
+fred's Pharmacy,MEDICAL,3.0,315,22M,100000,Free,0,Everyone,Medical
+420 BZ Budeze Delivery,MEDICAL,5.0,2,11M,100,Free,0,Mature 17+,Medical
+Fever Meter,MEDICAL,3.6,26,975k,5000,Free,0,Everyone,Medical
+Super Ear Super Hearing,MEDICAL,4.0,122,980k,10000,Free,0,Everyone,Medical
+Blood Pressure Monitor,MEDICAL,4.3,17,6.0M,10000,Free,0,Everyone,Medical
+BELONG Beating Cancer Together,MEDICAL,4.7,623,20M,50000,Free,0,Teen,Medical
+BP Journal - Blood Pressure Diary,MEDICAL,5.0,6,26M,1000,Free,0,Everyone,Medical
+TelaDoc,MEDICAL,4.7,6,13M,1000,Free,0,Everyone,Medical
+Breastfeeding Tracker Baby Log,MEDICAL,4.2,6,23M,100,Free,0,Everyone,Medical
+Blood Pressure - Stay Healthy,MEDICAL,4.6,7,2.7M,1000,Free,0,Everyone,Medical
+ConnectLine,MEDICAL,3.1,253,4.2M,50000,Free,0,Everyone,Medical
+Club,MEDICAL,4.4,3786,28M,50000,Free,0,Everyone,Medical
+Zen Leaf,MEDICAL,5.0,1,6.1M,100,Free,0,Mature 17+,Medical
+Homeopathic Medicine Finder,MEDICAL,3.6,10,15M,1000,Free,0,Everyone,Medical
+Patient Portal,MEDICAL,2.8,66,1.2M,50000,Free,0,Everyone,Medical
+Nemours CareConnect,MEDICAL,4.4,65,37M,10000,Free,0,Everyone,Medical
+Banfield Pet Health Tracker,MEDICAL,4.2,1747,5.9M,100000,Free,0,Everyone,Medical
+tökr,MEDICAL,4.6,17,14M,1000,Free,0,Everyone,Medical
+Low Blood Pressure Symptoms,MEDICAL,4.2,28,2.3M,10000,Free,0,Everyone,Medical
+PatientPORTAL by InteliChart,MEDICAL,4.2,1,32M,500,Free,0,Everyone,Medical
+Hypertension High blood pressure,MEDICAL,3.8,292,2.7M,100000,Free,0,Everyone,Medical
+Fever Care,MEDICAL,3.5,19,2.2M,5000,Free,0,Everyone,Medical
+1800 Contacts - Lens Store,MEDICAL,4.7,23160,26M,1000000,Free,0,Everyone,Medical
+Facebook,SOCIAL,4.1,78158306,Varies with device,1000000000,Free,0,Teen,Social
+Instagram,SOCIAL,4.5,66577313,Varies with device,1000000000,Free,0,Teen,Social
+Facebook Lite,SOCIAL,4.3,8606259,Varies with device,500000000,Free,0,Teen,Social
+"Messages, Text and Video Chat for Messenger",SOCIAL,4.4,49173,4.0M,10000000,Free,0,Everyone,Social
+Tumblr,SOCIAL,4.4,2955326,Varies with device,100000000,Free,0,Mature 17+,Social
+All Social Networks,SOCIAL,4.2,22492,1.5M,1000000,Free,0,Everyone,Social
+Snapchat,SOCIAL,4.0,17014787,Varies with device,500000000,Free,0,Teen,Social
+Social network all in one 2018,SOCIAL,4.3,1403,3.7M,100000,Free,0,Everyone,Social
+Pinterest,SOCIAL,4.6,4305441,Varies with device,100000000,Free,0,Teen,Social
+TextNow - free text + calls,SOCIAL,4.4,441189,Varies with device,10000000,Free,0,Everyone,Social
+Google+,SOCIAL,4.2,4831125,Varies with device,1000000000,Free,0,Teen,Social
+The Messenger App,SOCIAL,4.4,4919,2.8M,1000000,Free,0,Everyone,Social
+Messenger Pro,SOCIAL,4.4,13762,3.9M,1000000,Free,0,Everyone,Social
+"Free Messages, Video, Chat,Text for Messenger Plus",SOCIAL,4.3,6086,3.1M,1000000,Free,0,Teen,Social
+Telegram X,SOCIAL,4.6,70616,Varies with device,5000000,Free,0,Teen,Social
+The Video Messenger App,SOCIAL,4.4,1200,2.8M,100000,Free,0,Everyone,Social
+Jodel - The Hyperlocal App,SOCIAL,4.5,76480,20M,1000000,Free,0,Mature 17+,Social
+Who Viewed My Facebook Profile - Stalkers Visitors,SOCIAL,4.6,271445,9.9M,5000000,Free,0,Everyone,Social
+"Hide Something - Photo, Video",SOCIAL,4.6,225103,5.3M,5000000,Free,0,Everyone,Social
+Love Sticker,SOCIAL,4.6,33177,10M,1000000,Free,0,Everyone,Social
+Web Browser & Fast Explorer,SOCIAL,4.4,54768,2.6M,5000000,Free,0,Everyone,Social
+"LiveMe - Video chat, new friends, and make money",SOCIAL,4.5,457197,Varies with device,10000000,Free,0,Teen,Social
+VidStatus app - Status Videos & Status Downloader,SOCIAL,4.5,25562,31M,5000000,Free,0,Teen,Social
+Love Images,SOCIAL,4.3,16404,2.3M,1000000,Free,0,Everyone,Social
+Web Browser ( Fast & Secure Web Explorer),SOCIAL,4.4,2508,6.0M,500000,Free,0,Everyone,Social
+SPARK - Live random video chat & meet new people,SOCIAL,4.6,79658,17M,5000000,Free,0,Mature 17+,Social
+Golden telegram,SOCIAL,4.3,374,20M,50000,Free,0,Everyone,Social
+Amino: Communities and Chats,SOCIAL,4.8,1259075,62M,10000000,Free,0,Teen,Social
+Facebook Local,SOCIAL,4.2,4751,Varies with device,1000000,Free,0,Teen,Social
+Meet – Talk to Strangers Using Random Video Chat,SOCIAL,4.6,60562,15M,5000000,Free,0,Mature 17+,Social
+MobilePatrol Public Safety App,SOCIAL,4.0,22695,Varies with device,1000000,Free,0,Everyone 10+,Social
+"💘 WhatsLov: Smileys of love, stickers and GIF",SOCIAL,4.6,22098,18M,1000000,Free,0,Everyone,Social
+Phone Tracker : Family Locator,SOCIAL,4.3,231325,5.4M,10000000,Free,0,Everyone,Social
+HTC Social Plugin - Facebook,SOCIAL,3.6,13223,2.8M,10000000,Free,0,Mature 17+,Social
+Periscope - Live Video,SOCIAL,4.0,479908,15M,10000000,Free,0,Mature 17+,Social
+Quora,SOCIAL,4.5,313633,Varies with device,10000000,Free,0,Teen,Social
+Kate Mobile for VK,SOCIAL,4.4,540930,5.3M,10000000,Free,0,Teen,Social
+Family GPS tracker KidControl + GPS by SMS Locator,SOCIAL,4.5,57146,Varies with device,1000000,Free,0,Everyone,Social
+LinkedIn,SOCIAL,4.2,1225339,Varies with device,100000000,Free,0,Everyone,Social
+Moment,SOCIAL,4.5,19583,37M,1000000,Free,0,Teen,Social
+"Text Me: Text Free, Call Free, Second Phone Number",SOCIAL,4.3,344921,Varies with device,10000000,Free,0,Everyone,Social
+Meetup,SOCIAL,4.2,79129,23M,5000000,Free,0,Teen,Social
+Text Free: WiFi Calling App,SOCIAL,4.2,83488,Varies with device,5000000,Free,0,Everyone,Social
+TextNow - free text + calls,SOCIAL,4.4,441189,Varies with device,10000000,Free,0,Everyone,Social
+Badoo - Free Chat & Dating App,SOCIAL,4.3,3781770,Varies with device,100000000,Free,0,Mature 17+,Social
+Text free - Free Text + Call,SOCIAL,4.3,315441,Varies with device,10000000,Free,0,Everyone,Social
+textPlus: Free Text & Calls,SOCIAL,4.1,382120,28M,10000000,Free,0,Everyone,Social
+"Free phone calls, free texting SMS on free number",SOCIAL,4.5,412725,35M,10000000,Free,0,Everyone,Social
+Tango - Live Video Broadcast,SOCIAL,4.3,3806669,Varies with device,100000000,Free,0,Mature 17+,Social
+MeetMe: Chat & Meet New People,SOCIAL,4.2,1259849,76M,50000000,Free,0,Mature 17+,Social
+"Tagged - Meet, Chat & Dating",SOCIAL,4.1,486824,Varies with device,10000000,Free,0,Mature 17+,Social
+"ooVoo Video Calls, Messaging & Stories",SOCIAL,4.3,1157004,34M,50000000,Free,0,Everyone,Social
+"SayHi Chat, Meet New People",SOCIAL,4.2,423105,Varies with device,10000000,Free,0,Mature 17+,Social
+Whisper,SOCIAL,4.1,205803,Varies with device,5000000,Free,0,Teen,Social
+"Tapatalk - 100,000+ Forums",SOCIAL,4.1,285816,Varies with device,10000000,Free,0,Mature 17+,Social
+Tumblr,SOCIAL,4.4,2955325,Varies with device,100000000,Free,0,Mature 17+,Social
+Blogger,SOCIAL,3.7,138026,2.7M,5000000,Free,0,Mature 17+,Social
+Bloglovin',SOCIAL,3.9,8936,Varies with device,500000,Free,0,Everyone,Social
+Blogaway for Android (Blogger),SOCIAL,3.7,4253,4.1M,100000,Free,0,Teen,Social
+Snapchat,SOCIAL,4.0,17014705,Varies with device,500000000,Free,0,Teen,Social
+Instagram,SOCIAL,4.5,66577446,Varies with device,1000000000,Free,0,Teen,Social
+TwitCasting Live,SOCIAL,3.6,14835,Varies with device,1000000,Free,0,Teen,Social
+Stream - Live Video Community,SOCIAL,4.1,6388,Varies with device,500000,Free,0,Teen,Social
+YouNow: Live Stream Video Chat,SOCIAL,4.1,309872,85M,10000000,Free,0,Teen,Social
+Periscope - Live Video,SOCIAL,4.0,479909,15M,10000000,Free,0,Mature 17+,Social
+Mirrativ: Live Stream Any App,SOCIAL,4.1,17955,89M,500000,Free,0,Teen,Social
+Snapchat,SOCIAL,4.0,17015352,Varies with device,500000000,Free,0,Teen,Social
+Instagram,SOCIAL,4.5,66577313,Varies with device,1000000000,Free,0,Teen,Social
+Pinterest,SOCIAL,4.6,4305441,Varies with device,100000000,Free,0,Teen,Social
+Nextdoor - Local neighborhood news & classifieds,SOCIAL,4.3,51502,20M,5000000,Free,0,Teen,Social
+"SKOUT - Meet, Chat, Go Live",SOCIAL,4.3,1064049,Varies with device,50000000,Free,0,Mature 17+,Social
+Banjo,SOCIAL,4.2,58341,9.3M,1000000,Free,0,Everyone,Social
+We Heart It,SOCIAL,4.5,637309,Varies with device,10000000,Free,0,Teen,Social
+MeetMe: Chat & Meet New People,SOCIAL,4.2,1259894,76M,50000000,Free,0,Mature 17+,Social
+"ooVoo Video Calls, Messaging & Stories",SOCIAL,4.3,1157003,34M,50000000,Free,0,Everyone,Social
+Timehop,SOCIAL,4.1,161610,16M,5000000,Free,0,Teen,Social
+Frontback - Social Photos,SOCIAL,3.8,19446,Varies with device,1000000,Free,0,Mature 17+,Social
+LinkedIn,SOCIAL,4.2,1225367,Varies with device,100000000,Free,0,Everyone,Social
+Path,SOCIAL,4.4,1520959,Varies with device,10000000,Free,0,Teen,Social
+Tango - Live Video Broadcast,SOCIAL,4.3,3806669,Varies with device,100000000,Free,0,Mature 17+,Social
+"SayHi Chat, Meet New People",SOCIAL,4.2,423138,Varies with device,10000000,Free,0,Mature 17+,Social
+"Tapatalk - 100,000+ Forums",SOCIAL,4.1,285820,Varies with device,10000000,Free,0,Mature 17+,Social
+Couple - Relationship App,SOCIAL,4.0,33249,8.4M,1000000,Free,0,Everyone,Social
+Badoo - Free Chat & Dating App,SOCIAL,4.3,3781770,Varies with device,100000000,Free,0,Mature 17+,Social
+Nextdoor - Local neighborhood news & classifieds,SOCIAL,4.3,51504,20M,5000000,Free,0,Teen,Social
+POF Free Dating App,SOCIAL,4.2,1175794,Varies with device,50000000,Free,0,Mature 17+,Social
+MeetMe: Chat & Meet New People,SOCIAL,4.2,1259894,76M,50000000,Free,0,Mature 17+,Social
+LOVOO,SOCIAL,4.0,852455,68M,10000000,Free,0,Mature 17+,Social
+"Jaumo Dating, Flirt & Live Video",SOCIAL,4.4,900064,13M,10000000,Free,0,Mature 17+,Social
+Patook - make platonic friends,SOCIAL,4.0,3677,50M,100000,Free,0,Mature 17+,Social
+Meetup,SOCIAL,4.2,79129,23M,5000000,Free,0,Teen,Social
+Text Free: WiFi Calling App,SOCIAL,4.2,83488,Varies with device,5000000,Free,0,Everyone,Social
+Zello PTT Walkie Talkie,SOCIAL,4.4,695613,Varies with device,50000000,Free,0,Everyone,Social
+textPlus: Free Text & Calls,SOCIAL,4.1,382121,28M,10000000,Free,0,Everyone,Social
+magicApp Calling & Messaging,SOCIAL,4.1,207712,Varies with device,10000000,Free,0,Everyone,Social
+"Dating App, Flirt & Chat : W-Match",SOCIAL,4.3,175722,Varies with device,10000000,Free,0,Mature 17+,Social
+uCiC- Videos and Photos on demand,SOCIAL,4.0,2052,7.0M,100000,Free,0,Teen,Social
+Meetup,SOCIAL,4.2,79130,23M,5000000,Free,0,Teen,Social
+POF Free Dating App,SOCIAL,4.2,1175815,Varies with device,50000000,Free,0,Mature 17+,Social
+MeetMe: Chat & Meet New People,SOCIAL,4.2,1259894,76M,50000000,Free,0,Mature 17+,Social
+"Tagged - Meet, Chat & Dating",SOCIAL,4.1,486830,Varies with device,10000000,Free,0,Mature 17+,Social
+LOVOO,SOCIAL,4.0,852455,68M,10000000,Free,0,Mature 17+,Social
+"SKOUT - Meet, Chat, Go Live",SOCIAL,4.3,1064076,Varies with device,50000000,Free,0,Mature 17+,Social
+Badoo - Free Chat & Dating App,SOCIAL,4.3,3781770,Varies with device,100000000,Free,0,Mature 17+,Social
+"Jaumo Dating, Flirt & Live Video",SOCIAL,4.4,900064,13M,10000000,Free,0,Mature 17+,Social
+"Mico- Stranger Chat Random video Chat, Live, Meet",SOCIAL,4.4,624557,56M,10000000,Free,0,Mature 17+,Social
+"SayHi Chat, Meet New People",SOCIAL,4.2,423138,Varies with device,10000000,Free,0,Mature 17+,Social
+"Waplog - Free Chat, Dating App, Meet Singles",SOCIAL,4.2,522018,Varies with device,10000000,Free,0,Mature 17+,Social
+Couple - Relationship App,SOCIAL,4.0,33249,8.4M,1000000,Free,0,Everyone,Social
+Meetup,SOCIAL,4.2,79130,23M,5000000,Free,0,Teen,Social
+Amazon for Tablets,SHOPPING,4.0,141613,22M,10000000,Free,0,Teen,Shopping
+Wish - Shopping Made Fun,SHOPPING,4.5,6210998,15M,100000000,Free,0,Everyone,Shopping
+OfferUp - Buy. Sell. Offer Up,SHOPPING,4.6,591312,Varies with device,10000000,Free,0,Everyone,Shopping
+Shopee - No. 1 Online Shopping,SHOPPING,4.3,94294,30M,10000000,Free,0,Everyone,Shopping
+Shopee: No.1 Online Shopping,SHOPPING,4.2,608753,30M,10000000,Free,0,Everyone,Shopping
+Kroger,SHOPPING,4.3,38961,27M,5000000,Free,0,Everyone,Shopping
+"AliExpress - Smarter Shopping, Better Living",SHOPPING,4.6,5916606,Varies with device,100000000,Free,0,Teen,Shopping
+Walmart,SHOPPING,4.4,441473,Varies with device,10000000,Free,0,Everyone,Shopping
+eBay: Buy & Sell this Summer - Discover Deals Now!,SHOPPING,4.4,2788923,Varies with device,100000000,Free,0,Teen,Shopping
+"letgo: Buy & Sell Used Stuff, Cars & Real Estate",SHOPPING,4.5,973270,20M,50000000,Free,0,Teen,Shopping
+Amazon Shopping,SHOPPING,4.3,909226,42M,100000000,Free,0,Teen,Shopping
+Lazada - Online Shopping & Deals,SHOPPING,4.2,1573054,Varies with device,50000000,Free,0,Everyone,Shopping
+OLX - Buy and Sell,SHOPPING,4.2,857923,18M,50000000,Free,0,Everyone,Shopping
+The wall,SHOPPING,4.4,35563,4.2M,1000000,Free,0,Everyone,Shopping
+Flipp - Weekly Shopping,SHOPPING,4.6,85858,Varies with device,10000000,Free,0,Everyone,Shopping
+"Shrimp skin shopping: spend less, buy better",SHOPPING,4.2,106798,30M,5000000,Free,0,Everyone,Shopping
+Lotte Home Shopping LOTTE Homeshopping,SHOPPING,3.6,8820,33M,5000000,Free,0,Everyone,Shopping
+"Horn, free country requirements",SHOPPING,4.5,37186,7.9M,1000000,Free,0,Everyone,Shopping
+Jiji.ng,SHOPPING,4.4,25714,12M,1000000,Free,0,Everyone,Shopping
+GS SHOP,SHOPPING,3.8,44255,15M,10000000,Free,0,Everyone,Shopping
+The birth,SHOPPING,4.7,1084945,Varies with device,50000000,Free,0,Teen,Shopping
+CJmall,SHOPPING,3.6,18252,10M,10000000,Free,0,Everyone,Shopping
+Home & Shopping - Only in apps. 10% off + 10% off,SHOPPING,4.2,42750,9.9M,10000000,Free,0,Everyone,Shopping
+EHS Dongsen Shopping,SHOPPING,3.6,3656,9.0M,1000000,Free,0,Teen,Shopping
+bigbasket - online grocery,SHOPPING,4.3,216741,Varies with device,5000000,Free,0,Everyone,Shopping
+Bukalapak - Buy and Sell Online,SHOPPING,4.4,662287,21M,10000000,Free,0,Everyone,Shopping
+Life market,SHOPPING,4.5,30834,13M,1000000,Free,0,Everyone,Shopping
+Jabong Online Shopping App,SHOPPING,4.1,367290,11M,10000000,Free,0,Everyone,Shopping
+Family Dollar,SHOPPING,4.3,2588,21M,1000000,Free,0,Everyone,Shopping
+Jumia online shopping,SHOPPING,4.3,162655,8.1M,10000000,Free,0,Teen,Shopping
+Mercado Libre: Find your favorite brands,SHOPPING,4.7,3860225,Varies with device,50000000,Free,0,Everyone,Shopping
+"Carousell: Snap-Sell, Chat-Buy",SHOPPING,4.3,125783,Varies with device,10000000,Free,0,Teen,Shopping
+Blibli.com Online Shopping,SHOPPING,4.2,171584,12M,10000000,Free,0,Everyone,Shopping
+"Club Factory Everything, Unbeaten Price",SHOPPING,4.2,244141,7.3M,10000000,Free,0,Everyone,Shopping
+"Real Estate, Car, Shopping and Others",SHOPPING,4.3,568273,Varies with device,10000000,Free,0,Everyone,Shopping
+ZALORA Fashion Shopping,SHOPPING,4.2,142512,15M,10000000,Free,0,Everyone,Shopping
+Magazine Luiza Online Shopping,SHOPPING,4.3,109124,22M,10000000,Free,0,Everyone,Shopping
+ROMWE - Women's Fashion,SHOPPING,4.6,135043,11M,10000000,Free,0,Everyone,Shopping
+Buscapé - Offers and discounts,SHOPPING,4.4,108592,8.3M,10000000,Free,0,Everyone,Shopping
+Myntra Online Shopping App,SHOPPING,4.3,1315242,Varies with device,50000000,Free,0,Everyone,Shopping
+11st,SHOPPING,3.8,48732,20M,10000000,Free,0,Everyone,Shopping
+Coupang,SHOPPING,4.6,308234,38M,10000000,Free,0,Everyone,Shopping
+Wemep - Special price representative (special / shopping / shopping app / coupon / shipping),SHOPPING,4.5,178497,9.1M,10000000,Free,0,Everyone,Shopping
+Target - now with Cartwheel,SHOPPING,4.1,68406,24M,10000000,Free,0,Everyone,Shopping
+Flipkart Online Shopping App,SHOPPING,4.4,6012719,Varies with device,100000000,Free,0,Teen,Shopping
+Sam's Club: Wholesale Shopping & Instant Savings,SHOPPING,4.3,45362,Varies with device,5000000,Free,0,Everyone,Shopping
+Chilindo,SHOPPING,3.8,18364,29M,1000000,Free,0,Everyone,Shopping
+Rossmann PL,SHOPPING,4.0,15867,Varies with device,5000000,Free,0,Everyone,Shopping
+"Jingdong - pick good things, go to Jingdong",SHOPPING,3.3,9189,98M,1000000,Free,0,Teen,Shopping
+CheckPoints 🏆 Rewards App,SHOPPING,4.1,23187,25M,1000000,Free,0,Everyone,Shopping
+Extreme Coupon Finder,SHOPPING,4.1,11798,Varies with device,1000000,Free,0,Everyone,Shopping
+SnipSnap Coupon App,SHOPPING,4.2,9975,18M,1000000,Free,0,Everyone,Shopping
+Checkout 51: Grocery coupons,SHOPPING,4.1,52896,Varies with device,10000000,Free,0,Everyone,Shopping
+Coupon Sherpa,SHOPPING,4.4,7793,6.1M,500000,Free,0,Everyone,Shopping
+Gyft - Mobile Gift Card Wallet,SHOPPING,4.1,9701,14M,500000,Free,0,Everyone,Shopping
+SavingStar - Grocery Coupons,SHOPPING,4.2,31519,21M,1000000,Free,0,Everyone,Shopping
+The Coupons App,SHOPPING,4.5,181990,Varies with device,10000000,Free,0,Everyone,Shopping
+"Shopkick: Free Gift Cards, Shop Rewards & Deals",SHOPPING,4.3,213735,43M,10000000,Free,0,Everyone,Shopping
+Wish - Shopping Made Fun,SHOPPING,4.5,6211039,15M,100000000,Free,0,Everyone,Shopping
+Key Ring: Cards Coupon & Sales,SHOPPING,4.1,42871,23M,1000000,Free,0,Everyone,Shopping
+"Ibotta: Cash Back Savings, Rewards & Coupons App",SHOPPING,4.5,315908,52M,10000000,Free,0,Everyone,Shopping
+"RetailMeNot - Coupons, Deals & Discount Shopping",SHOPPING,4.4,210208,Varies with device,10000000,Free,0,Everyone,Shopping
+"Groupon - Shop Deals, Discounts & Coupons",SHOPPING,4.6,1370749,Varies with device,50000000,Free,0,Teen,Shopping
+"Kohl's: Scan, Shop, Pay & Save",SHOPPING,4.5,79261,57M,5000000,Free,0,Everyone,Shopping
+Stocard - Rewards Cards Wallet,SHOPPING,4.6,284725,20M,10000000,Free,0,Everyone,Shopping
+Nike,SHOPPING,4.7,67071,40M,1000000,Free,0,Everyone,Shopping
+Poshmark - Buy & Sell Fashion,SHOPPING,4.3,46153,17M,10000000,Free,0,Everyone,Shopping
+Mercari: The Selling App,SHOPPING,4.4,101883,13M,10000000,Free,0,Everyone,Shopping
+Blidz - Hunt Free Deals On Trending Items!,SHOPPING,4.4,1659,33M,50000,Free,0,Everyone,Shopping
+SnipSnap Coupon App,SHOPPING,4.2,9975,18M,1000000,Free,0,Everyone,Shopping
+Extreme Coupon Finder,SHOPPING,4.1,11798,Varies with device,1000000,Free,0,Everyone,Shopping
+Checkout 51: Grocery coupons,SHOPPING,4.1,52896,Varies with device,10000000,Free,0,Everyone,Shopping
+The Coupons App,SHOPPING,4.5,181990,Varies with device,10000000,Free,0,Everyone,Shopping
+"Shopular: Coupons, Weekly Ads & Shopping Deals",SHOPPING,4.7,57920,Varies with device,1000000,Free,0,Everyone,Shopping
+LivingSocial - Local Deals,SHOPPING,4.1,28523,29M,5000000,Free,0,Everyone,Shopping
+Coupons.com – Grocery Coupons & Cash Back Savings,SHOPPING,4.2,24953,Varies with device,1000000,Free,0,Everyone,Shopping
+"Ebates: Cash Back, Coupons, Rewards & Savings",SHOPPING,4.5,37253,31M,1000000,Free,0,Everyone,Shopping
+"RetailMeNot - Coupons, Deals & Discount Shopping",SHOPPING,4.4,210208,Varies with device,10000000,Free,0,Everyone,Shopping
+"Groupon - Shop Deals, Discounts & Coupons",SHOPPING,4.6,1370749,Varies with device,50000000,Free,0,Teen,Shopping
+FidMe Loyalty Cards & Deals at Grocery Supermarket,SHOPPING,4.2,33758,Varies with device,1000000,Free,0,Everyone,Shopping
+Stocard - Rewards Cards Wallet,SHOPPING,4.6,284721,20M,10000000,Free,0,Everyone,Shopping
+Ratings by Consumer Reports,SHOPPING,4.3,3420,13M,100000,Free,0,Everyone,Shopping
+HauteLook,SHOPPING,4.1,7193,7.3M,500000,Free,0,Everyone,Shopping
+Extreme Coupon Finder,SHOPPING,4.1,11798,Varies with device,1000000,Free,0,Everyone,Shopping
+eBay: Buy & Sell this Summer - Discover Deals Now!,SHOPPING,4.4,2788923,Varies with device,100000000,Free,0,Teen,Shopping
+Checkout 51: Grocery coupons,SHOPPING,4.1,52896,Varies with device,10000000,Free,0,Everyone,Shopping
+Nordstrom,SHOPPING,4.6,2278,12M,500000,Free,0,Everyone,Shopping
+Modcloth – Unique Indie Women's Fashion & Style,SHOPPING,4.2,5121,8.8M,500000,Free,0,Everyone,Shopping
+Fancy,SHOPPING,4.2,39735,18M,5000000,Free,0,Teen,Shopping
+Gyft - Mobile Gift Card Wallet,SHOPPING,4.1,9701,14M,500000,Free,0,Everyone,Shopping
+"Twice: Buy, Sell Clothing",SHOPPING,4.2,1558,21M,100000,Free,0,Everyone,Shopping
+"Shopkick: Free Gift Cards, Shop Rewards & Deals",SHOPPING,4.3,213735,43M,10000000,Free,0,Everyone,Shopping
+Slice: Package Tracker,SHOPPING,4.2,16966,34M,1000000,Free,0,Everyone,Shopping
+The Coupons App,SHOPPING,4.5,181990,Varies with device,10000000,Free,0,Everyone,Shopping
+"Shopular: Coupons, Weekly Ads & Shopping Deals",SHOPPING,4.7,57920,Varies with device,1000000,Free,0,Everyone,Shopping
+Wish - Shopping Made Fun,SHOPPING,4.5,6211039,15M,100000000,Free,0,Everyone,Shopping
+"Carousell: Snap-Sell, Chat-Buy",SHOPPING,4.3,125783,Varies with device,10000000,Free,0,Teen,Shopping
+LightInTheBox Online Shopping,SHOPPING,4.0,41986,26M,5000000,Free,0,Teen,Shopping
+Walmart,SHOPPING,4.4,441473,Varies with device,10000000,Free,0,Everyone,Shopping
+Best Buy,SHOPPING,4.4,186116,34M,5000000,Free,0,Everyone,Shopping
+JackThreads: Men's Shopping,SHOPPING,4.0,13085,2.7M,1000000,Free,0,Teen,Shopping
+"Ibotta: Cash Back Savings, Rewards & Coupons App",SHOPPING,4.5,315908,52M,10000000,Free,0,Everyone,Shopping
+"AliExpress - Smarter Shopping, Better Living",SHOPPING,4.6,5916569,Varies with device,100000000,Free,0,Teen,Shopping
+LivingSocial - Local Deals,SHOPPING,4.1,28523,29M,5000000,Free,0,Everyone,Shopping
+zulily - Shop Daily Deals in Fashion and Home,SHOPPING,4.5,28560,Varies with device,1000000,Free,0,Everyone,Shopping
+MiniInTheBox Online Shopping,SHOPPING,3.9,34171,Varies with device,1000000,Free,0,Everyone,Shopping
+Zappos – Shoe shopping made simple,SHOPPING,4.5,44588,20M,5000000,Free,0,Everyone,Shopping
+Urban Outfitters,SHOPPING,4.2,4158,23M,500000,Free,0,Teen,Shopping
+Tophatter - 90 Second Auctions,SHOPPING,4.3,105773,Varies with device,10000000,Free,0,Everyone,Shopping
+Amazon Shopping,SHOPPING,4.3,909204,42M,100000000,Free,0,Teen,Shopping
+Shopfully - Weekly Ads & Deals,SHOPPING,4.4,279428,16M,10000000,Free,0,Everyone,Shopping
+Slickdeals: Coupons & Shopping,SHOPPING,4.5,33583,12M,1000000,Free,0,Everyone,Shopping
+Wanelo Shopping,SHOPPING,4.6,94205,6.5M,1000000,Free,0,Everyone,Shopping
+"RetailMeNot - Coupons, Deals & Discount Shopping",SHOPPING,4.4,210208,Varies with device,10000000,Free,0,Everyone,Shopping
+Etsy: Handmade & Vintage Goods,SHOPPING,4.3,95520,15M,10000000,Free,0,Teen,Shopping
+Poshmark - Buy & Sell Fashion,SHOPPING,4.3,46153,17M,10000000,Free,0,Everyone,Shopping
+Target - now with Cartwheel,SHOPPING,4.1,68406,24M,10000000,Free,0,Everyone,Shopping
+ASOS,SHOPPING,4.7,181798,22M,10000000,Free,0,Everyone,Shopping
+"Overstock – Home Decor, Furniture Shopping",SHOPPING,4.4,25719,Varies with device,1000000,Free,0,Teen,Shopping
+ZALORA Fashion Shopping,SHOPPING,4.2,142512,15M,10000000,Free,0,Everyone,Shopping
+eBay: Buy & Sell this Summer - Discover Deals Now!,SHOPPING,4.4,2788923,Varies with device,100000000,Free,0,Teen,Shopping
+Fancy,SHOPPING,4.2,39735,18M,5000000,Free,0,Teen,Shopping
+Modcloth – Unique Indie Women's Fashion & Style,SHOPPING,4.2,5121,8.8M,500000,Free,0,Everyone,Shopping
+Gyft - Mobile Gift Card Wallet,SHOPPING,4.1,9701,14M,500000,Free,0,Everyone,Shopping
+JackThreads: Men's Shopping,SHOPPING,4.0,13085,2.7M,1000000,Free,0,Teen,Shopping
+LivingSocial - Local Deals,SHOPPING,4.1,28523,29M,5000000,Free,0,Everyone,Shopping
+Zappos – Shoe shopping made simple,SHOPPING,4.5,44588,20M,5000000,Free,0,Everyone,Shopping
+Wanelo Shopping,SHOPPING,4.6,94205,6.5M,1000000,Free,0,Everyone,Shopping
+Etsy: Handmade & Vintage Goods,SHOPPING,4.3,95520,15M,10000000,Free,0,Teen,Shopping
+"Groupon - Shop Deals, Discounts & Coupons",SHOPPING,4.6,1370749,Varies with device,50000000,Free,0,Teen,Shopping
+eBay: Buy & Sell this Summer - Discover Deals Now!,SHOPPING,4.4,2788923,Varies with device,100000000,Free,0,Teen,Shopping
+Find&Save - Local Shopping,SHOPPING,4.0,4602,6.2M,500000,Free,0,Everyone,Shopping
+Receipt Hog - Receipts to Cash,SHOPPING,4.5,72596,19M,1000000,Free,0,Teen,Shopping
+ShopSavvy Barcode & QR Scanner,SHOPPING,4.1,110425,27M,10000000,Free,0,Everyone,Shopping
+"Savory - Deals,Freebies,Sales",SHOPPING,4.4,2375,1.1M,100000,Free,0,Everyone,Shopping
+JackThreads: Men's Shopping,SHOPPING,4.0,13085,2.7M,1000000,Free,0,Teen,Shopping
+"AliExpress - Smarter Shopping, Better Living",SHOPPING,4.6,5917485,Varies with device,100000000,Free,0,Teen,Shopping
+Newegg Mobile,SHOPPING,4.5,35497,16M,1000000,Free,0,Everyone,Shopping
+REI – Shop Outdoor Gear,SHOPPING,4.4,3878,8.8M,100000,Free,0,Everyone,Shopping
+Slickdeals: Coupons & Shopping,SHOPPING,4.5,33583,12M,1000000,Free,0,Everyone,Shopping
+Target - now with Cartwheel,SHOPPING,4.1,68406,24M,10000000,Free,0,Everyone,Shopping
+The Home Depot,SHOPPING,4.3,44071,56M,5000000,Free,0,Everyone,Shopping
+Wish - Shopping Made Fun,SHOPPING,4.5,6212081,15M,100000000,Free,0,Everyone,Shopping
+Fancy,SHOPPING,4.2,39735,18M,5000000,Free,0,Teen,Shopping
+Boxed Wholesale,SHOPPING,3.8,6380,Varies with device,1000000,Free,0,Everyone,Shopping
+La La-Shop Designer Brands Street,SHOPPING,4.5,5123,14M,500000,Free,0,Everyone,Shopping
+ASOS,SHOPPING,4.7,181823,22M,10000000,Free,0,Everyone,Shopping
+TouchNote: Cards & Gifts,PHOTOGRAPHY,4.1,19232,28M,1000000,Free,0,Everyone,Photography
+"Shutterfly: Free Prints, Photo Books, Cards, Gifts",PHOTOGRAPHY,4.6,98716,59M,5000000,Free,0,Everyone,Photography
+FreePrints – Free Photos Delivered,PHOTOGRAPHY,4.8,109500,37M,1000000,Free,0,Everyone,Photography
+Groovebook Photo Books & Gifts,PHOTOGRAPHY,4.0,21159,36M,500000,Free,0,Everyone,Photography
+"Moony Lab - Print Photos, Books & Magnets ™",PHOTOGRAPHY,4.7,1320,9.5M,50000,Free,0,Everyone,Photography
+"LALALAB prints your photos, photobooks and magnets",PHOTOGRAPHY,4.7,50424,82M,1000000,Free,0,Everyone,Photography
+Snapfish,PHOTOGRAPHY,4.1,32398,28M,1000000,Free,0,Everyone,Photography
+Google Photos,PHOTOGRAPHY,4.5,10858556,Varies with device,1000000000,Free,0,Everyone,Photography
+Motorola Camera,PHOTOGRAPHY,3.6,219745,Varies with device,50000000,Free,0,Everyone,Photography
+HD Camera - Best Cam with filters & panorama,PHOTOGRAPHY,4.5,38953,9.7M,5000000,Free,0,Everyone,Photography
+"Face Filter, Selfie Editor - Sweet Camera",PHOTOGRAPHY,4.7,142634,22M,10000000,Free,0,Everyone,Photography
+LightX Photo Editor & Photo Effects,PHOTOGRAPHY,4.7,259450,17M,10000000,Free,0,Everyone,Photography
+"Sweet Snap - live filter, Selfie photo edit",PHOTOGRAPHY,4.5,123029,Varies with device,10000000,Free,0,Everyone,Photography
+Adobe Photoshop Express:Photo Editor Collage Maker,PHOTOGRAPHY,4.2,914804,Varies with device,50000000,Free,0,Everyone,Photography
+HD Camera - Quick Snap Photo & Video,PHOTOGRAPHY,4.5,21841,7.7M,1000000,Free,0,Everyone,Photography
+B612 - Beauty & Filter Camera,PHOTOGRAPHY,4.4,5282578,Varies with device,100000000,Free,0,Everyone,Photography
+Waterfall Photo Frames,PHOTOGRAPHY,4.5,10349,11M,1000000,Free,0,Everyone,Photography
+Photo frame,PHOTOGRAPHY,4.5,859,21M,100000,Free,0,Everyone,Photography
+Huji Cam,PHOTOGRAPHY,4.4,40289,19M,5000000,Free,0,Everyone,Photography
+Unicorn Photo,PHOTOGRAPHY,3.7,3362,Varies with device,1000000,Free,0,Everyone,Photography
+HD Camera,PHOTOGRAPHY,4.3,49680,8.7M,5000000,Free,0,Everyone,Photography
+Makeup Editor -Beauty Photo Editor & Selfie Camera,PHOTOGRAPHY,4.5,3378,30M,1000000,Free,0,Mature 17+,Photography
+Makeup Photo Editor: Makeup Camera & Makeup Editor,PHOTOGRAPHY,4.4,10525,25M,1000000,Free,0,Everyone,Photography
+Moto Photo Editor,PHOTOGRAPHY,3.3,3492,17M,5000000,Free,0,Everyone,Photography
+InstaBeauty -Makeup Selfie Cam,PHOTOGRAPHY,4.3,654419,Varies with device,50000000,Free,0,Everyone,Photography
+Garden Photo Frames - Garden Photo Editor,PHOTOGRAPHY,4.4,1864,13M,500000,Free,0,Everyone,Photography
+Photo Frame,PHOTOGRAPHY,4.5,74476,23M,10000000,Free,0,Everyone,Photography
+Camera360 Lite - Selfie Camera,PHOTOGRAPHY,4.4,221858,Varies with device,10000000,Free,0,Everyone,Photography
+Selfie Camera - Photo Editor & Filter & Sticker,PHOTOGRAPHY,4.2,401820,Varies with device,50000000,Free,0,Everyone,Photography
+"Sweet Snap Lite - live filter, Selfie photo editor",PHOTOGRAPHY,4.5,3116,22M,500000,Free,0,Everyone,Photography
+"Selfie Camera: Beauty Camera, Photo Editor,Collage",PHOTOGRAPHY,4.7,31985,9.1M,1000000,Free,0,Everyone,Photography
+Night Photo Frame,PHOTOGRAPHY,4.5,4400,8.3M,1000000,Free,0,Everyone,Photography
+YouCam Makeup - Magic Selfie Makeovers,PHOTOGRAPHY,4.6,3337956,Varies with device,100000000,Free,0,Everyone,Photography
+Selfie Photo Editor,PHOTOGRAPHY,4.6,11677,19M,1000000,Free,0,Everyone,Photography
+BeautyPlus - Easy Photo Editor & Selfie Camera,PHOTOGRAPHY,4.4,3158047,53M,100000000,Free,0,Everyone,Photography
+ASUS Gallery,PHOTOGRAPHY,4.3,125259,Varies with device,50000000,Free,0,Everyone,Photography
+My Photo Keyboard,PHOTOGRAPHY,4.3,56114,17M,10000000,Free,0,Everyone,Photography
+Kids Photo Frames,PHOTOGRAPHY,4.6,15700,10M,1000000,Free,0,Everyone,Photography
+Pencil Photo Sketch-Sketching Drawing Photo Editor,PHOTOGRAPHY,4.4,16523,Varies with device,1000000,Free,0,Everyone,Photography
+"Pretty Makeup, Beauty Photo Editor & Snappy Camera",PHOTOGRAPHY,4.5,26361,29M,5000000,Free,0,Everyone,Photography
+Photo Collage - Layout Editor,PHOTOGRAPHY,4.5,285788,46M,10000000,Free,0,Everyone,Photography
+DSLR Camera Hd Ultra Professional,PHOTOGRAPHY,4.2,4410,4.5M,1000000,Free,0,Everyone,Photography
+Snap Cat Face Camera,PHOTOGRAPHY,4.0,5855,4.9M,1000000,Free,0,Everyone,Photography
+Silent Camera [High Quality],PHOTOGRAPHY,4.4,47090,Varies with device,5000000,Free,0,Everyone,Photography
+"Sweet Camera - Selfie Filters, Beauty Camera",PHOTOGRAPHY,4.7,233039,24M,10000000,Free,0,Everyone,Photography
+Photo Frames,PHOTOGRAPHY,4.3,28578,23M,10000000,Free,0,Everyone,Photography
+"Sweet Selfie - selfie camera, beauty cam, photo edit",PHOTOGRAPHY,4.6,1159058,25M,100000000,Free,0,Everyone,Photography
+"Candy selfie - photo editor, live filter camera",PHOTOGRAPHY,4.4,53421,26M,10000000,Free,0,Everyone,Photography
+YouCam Perfect - Selfie Photo Editor,PHOTOGRAPHY,4.5,1579287,Varies with device,100000000,Free,0,Everyone,Photography
+Open Camera,PHOTOGRAPHY,4.3,116880,2.0M,10000000,Free,0,Everyone,Photography
+Beauty Makeup – Photo Makeover,PHOTOGRAPHY,4.3,21730,19M,1000000,Free,0,Everyone,Photography
+Blur Image Background Editor (Blur Photo Editor),PHOTOGRAPHY,4.4,62421,9.6M,5000000,Free,0,Everyone,Photography
+Google Photos,PHOTOGRAPHY,4.5,10858538,Varies with device,1000000000,Free,0,Everyone,Photography
+Muzy - Share photos & collages,PHOTOGRAPHY,4.4,70189,13M,5000000,Free,0,Teen,Photography
+QuickPic - Photo Gallery with Google Drive Support,PHOTOGRAPHY,4.6,847159,4.2M,10000000,Free,0,Everyone,Photography
+Flickr,PHOTOGRAPHY,4.3,251951,16M,10000000,Free,0,Mature 17+,Photography
+"Shutterfly: Free Prints, Photo Books, Cards, Gifts",PHOTOGRAPHY,4.6,98716,59M,5000000,Free,0,Everyone,Photography
+InstaBeauty -Makeup Selfie Cam,PHOTOGRAPHY,4.3,654418,Varies with device,50000000,Free,0,Everyone,Photography
+B612 - Beauty & Filter Camera,PHOTOGRAPHY,4.4,5282558,Varies with device,100000000,Free,0,Everyone,Photography
+Camera for Android,PHOTOGRAPHY,4.2,240475,9.5M,10000000,Free,0,Everyone,Photography
+Photo Editor Selfie Camera Filter & Mirror Image,PHOTOGRAPHY,4.3,527247,Varies with device,50000000,Free,0,Everyone,Photography
+BeautyPlus - Easy Photo Editor & Selfie Camera,PHOTOGRAPHY,4.4,3157936,53M,100000000,Free,0,Everyone,Photography
+Photo Mixer,PHOTOGRAPHY,3.9,55427,6.6M,10000000,Free,0,Everyone,Photography
+Photo Editor-,PHOTOGRAPHY,4.3,68070,Varies with device,5000000,Free,0,Everyone,Photography
+"Cymera Camera- Photo Editor, Filter,Collage,Layout",PHOTOGRAPHY,4.4,2418135,Varies with device,100000000,Free,0,Everyone,Photography
+Wondershare PowerCam,PHOTOGRAPHY,4.2,329160,27M,10000000,Free,0,Everyone,Photography
+YouCam Perfect - Selfie Photo Editor,PHOTOGRAPHY,4.5,1579287,Varies with device,100000000,Free,0,Everyone,Photography
+love,PHOTOGRAPHY,4.3,42677,22M,1000000,Free,0,Everyone,Photography
+LINE Camera - Photo editor,PHOTOGRAPHY,4.3,1517369,Varies with device,100000000,Free,0,Everyone,Photography
+InstaSize Photo Filters & Collage Editor,PHOTOGRAPHY,4.3,811693,50M,50000000,Free,0,Everyone,Photography
+"KVAD Camera +: Selfie, Photo Filter, Grids",PHOTOGRAPHY,4.1,23440,30M,1000000,Free,0,Everyone,Photography
+"Candy Camera - selfie, beauty camera, photo editor",PHOTOGRAPHY,4.4,3368649,Varies with device,100000000,Free,0,Everyone,Photography
+Photo Editor,PHOTOGRAPHY,4.3,42079,17M,1000000,Free,0,Everyone,Photography
+Camera51 - a smarter camera,PHOTOGRAPHY,4.0,29707,18M,1000000,Free,0,Everyone,Photography
+InstaCam - Camera for Selfie,PHOTOGRAPHY,4.0,15098,10.0M,1000000,Free,0,Everyone,Photography
+"Phogy, 3D Camera",PHOTOGRAPHY,4.0,35724,9.9M,1000000,Free,0,Everyone,Photography
+Sweet Camera,PHOTOGRAPHY,4.4,71898,23M,5000000,Free,0,Everyone,Photography
+Camera360: Selfie Photo Editor with Funny Sticker,PHOTOGRAPHY,4.3,4865093,51M,100000000,Free,0,Everyone,Photography
+RetroSelfie - Selfie Editor,PHOTOGRAPHY,4.1,106080,35M,10000000,Free,0,Everyone,Photography
+Mega Photo,PHOTOGRAPHY,4.2,44941,16M,1000000,Free,0,Everyone,Photography
+Blur Image Background,PHOTOGRAPHY,3.9,129272,11M,10000000,Free,0,Everyone,Photography
+MIX by Camera360,PHOTOGRAPHY,4.4,111066,74M,5000000,Free,0,Everyone,Photography
+Facetune - For Free,PHOTOGRAPHY,4.4,49553,48M,1000000,Paid,$5.99,Everyone,Photography
+Google Photos,PHOTOGRAPHY,4.5,10859051,Varies with device,1000000000,Free,0,Everyone,Photography
+Muzy - Share photos & collages,PHOTOGRAPHY,4.4,70189,13M,5000000,Free,0,Teen,Photography
+QuickPic - Photo Gallery with Google Drive Support,PHOTOGRAPHY,4.6,847159,4.2M,10000000,Free,0,Everyone,Photography
+Flickr,PHOTOGRAPHY,4.3,251951,16M,10000000,Free,0,Mature 17+,Photography
+"Shutterfly: Free Prints, Photo Books, Cards, Gifts",PHOTOGRAPHY,4.6,98716,59M,5000000,Free,0,Everyone,Photography
+SuperPhoto - Effects & Filters,PHOTOGRAPHY,4.1,43296,Varies with device,5000000,Free,0,Everyone,Photography
+Camera FV-5 Lite,PHOTOGRAPHY,4.0,130081,5.6M,10000000,Free,0,Everyone,Photography
+HD Camera Ultra,PHOTOGRAPHY,4.3,462152,1.5M,10000000,Free,0,Everyone,Photography
+Cameringo Lite. Filters Camera,PHOTOGRAPHY,4.2,140917,5.7M,10000000,Free,0,Everyone,Photography
+Camera ZOOM FX - FREE,PHOTOGRAPHY,4.0,88860,6.1M,5000000,Free,0,Everyone,Photography
+HD Camera Pro for Android,PHOTOGRAPHY,4.1,49211,1.9M,1000000,Free,0,Everyone,Photography
+HD Camera for Android,PHOTOGRAPHY,4.1,351254,4.0M,10000000,Free,0,Everyone,Photography
+GoPro (formerly Capture),PHOTOGRAPHY,4.0,157506,47M,10000000,Free,0,Everyone,Photography
+Photo Editor Pro,PHOTOGRAPHY,4.3,1871416,Varies with device,100000000,Free,0,Everyone,Photography
+Open Camera,PHOTOGRAPHY,4.3,116880,2.0M,10000000,Free,0,Everyone,Photography
+Camera for Android,PHOTOGRAPHY,4.2,240475,9.5M,10000000,Free,0,Everyone,Photography
+Beauty Makeup Snappy Collage Photo Editor - Lidow,PHOTOGRAPHY,4.5,420973,Varies with device,10000000,Free,0,Everyone,Photography
+Samsung SMART CAMERA App,PHOTOGRAPHY,4.0,34753,22M,1000000,Free,0,Everyone,Photography
+Square InPic - Photo Editor & Collage Maker,PHOTOGRAPHY,4.4,635846,14M,50000000,Free,0,Everyone,Photography
+"High-Speed Camera (GIF,Burst)",PHOTOGRAPHY,4.1,78140,10M,5000000,Free,0,Everyone,Photography
+"Cymera Camera- Photo Editor, Filter,Collage,Layout",PHOTOGRAPHY,4.4,2418135,Varies with device,100000000,Free,0,Everyone,Photography
+Camera MX - Free Photo & Video Camera,PHOTOGRAPHY,4.3,244371,Varies with device,10000000,Free,0,Everyone,Photography
+Lapse It • Time Lapse • Pro,PHOTOGRAPHY,4.3,12865,6.9M,100000,Paid,$2.99,Everyone,Photography
+EyeEm - Camera & Photo Filter,PHOTOGRAPHY,4.2,215343,44M,10000000,Free,0,Everyone,Photography
+Retrica,PHOTOGRAPHY,4.3,6120977,Varies with device,100000000,Free,0,Everyone,Photography
+"Candy Camera - selfie, beauty camera, photo editor",PHOTOGRAPHY,4.4,3368646,Varies with device,100000000,Free,0,Everyone,Photography
+VSCO,PHOTOGRAPHY,4.4,753115,Varies with device,50000000,Free,0,Everyone,Photography
+Camera360: Selfie Photo Editor with Funny Sticker,PHOTOGRAPHY,4.3,4865107,51M,100000000,Free,0,Everyone,Photography
+Facetune - For Free,PHOTOGRAPHY,4.4,49553,48M,1000000,Paid,$5.99,Everyone,Photography
+Camera FV-5,PHOTOGRAPHY,3.8,16320,Varies with device,100000,Paid,$3.95,Everyone,Photography
+PhotoWonder: Pro Beauty Photo Editor Collage Maker,PHOTOGRAPHY,4.4,852649,43M,50000000,Free,0,Teen,Photography
+Photo Effects Pro,PHOTOGRAPHY,4.4,1494491,21M,50000000,Free,0,Everyone,Photography
+Photo Editor Selfie Camera Filter & Mirror Image,PHOTOGRAPHY,4.3,527248,Varies with device,50000000,Free,0,Everyone,Photography
+No Crop & Square for Instagram,PHOTOGRAPHY,4.6,819774,25M,10000000,Free,0,Everyone,Photography
+Picture Grid Builder,PHOTOGRAPHY,4.0,33439,3.9M,5000000,Free,0,Everyone,Photography
+HD Camera for Android,PHOTOGRAPHY,4.1,351255,4.0M,10000000,Free,0,Everyone,Photography
+Photo Studio,PHOTOGRAPHY,4.2,477831,51M,10000000,Free,0,Everyone,Photography
+Photo Editor Pro,PHOTOGRAPHY,4.3,1871421,Varies with device,100000000,Free,0,Everyone,Photography
+YouCam Makeup - Magic Selfie Makeovers,PHOTOGRAPHY,4.6,3337952,Varies with device,100000000,Free,0,Everyone,Photography
+FilterGrid - Cam&Photo Editor,PHOTOGRAPHY,4.6,126337,9.6M,1000000,Free,0,Everyone,Photography
+Photo Editor-,PHOTOGRAPHY,4.3,68071,Varies with device,5000000,Free,0,Everyone,Photography
+Camera for Android,PHOTOGRAPHY,4.2,240475,9.5M,10000000,Free,0,Everyone,Photography
+Mirror Photo:Editor Collage (HD),PHOTOGRAPHY,4.1,373606,Varies with device,10000000,Free,0,Everyone,Photography
+Pic Stitch - #1 Collage Maker,PHOTOGRAPHY,4.2,15426,50M,1000000,Free,0,Everyone,Photography
+PhotoDirector Photo Editor App,PHOTOGRAPHY,4.6,714340,Varies with device,10000000,Free,0,Everyone,Photography
+Pic Collage - Photo Editor,PHOTOGRAPHY,4.6,1451000,Varies with device,50000000,Free,0,Everyone,Photography
+Photo Editor by Aviary,PHOTOGRAPHY,4.4,1490732,21M,50000000,Free,0,Everyone,Photography
+"Video Editor Music,Cut,No Crop",PHOTOGRAPHY,4.7,2163282,Varies with device,50000000,Free,0,Everyone,Photography
+Pixlr – Free Photo Editor,PHOTOGRAPHY,4.4,1163232,31M,50000000,Free,0,Everyone,Photography
+Photo Editor,PHOTOGRAPHY,4.1,114680,27M,10000000,Free,0,Everyone,Photography
+Photo Collage Maker,PHOTOGRAPHY,4.3,751766,Varies with device,10000000,Free,0,Everyone,Photography
+"Cymera Camera- Photo Editor, Filter,Collage,Layout",PHOTOGRAPHY,4.4,2418158,Varies with device,100000000,Free,0,Everyone,Photography
+Adobe Photoshop Express:Photo Editor Collage Maker,PHOTOGRAPHY,4.2,914917,Varies with device,50000000,Free,0,Everyone,Photography
+BeautyPlus - Easy Photo Editor & Selfie Camera,PHOTOGRAPHY,4.4,3158151,53M,100000000,Free,0,Everyone,Photography
+PicsArt Photo Studio: Collage Maker & Pic Editor,PHOTOGRAPHY,4.5,7594559,34M,100000000,Free,0,Teen,Photography
+Photo Collage Editor,PHOTOGRAPHY,4.2,1028637,Varies with device,100000000,Free,0,Everyone,Photography
+Color Touch Effects,PHOTOGRAPHY,3.8,167652,12M,10000000,Free,0,Everyone,Photography
+InstaSize Photo Filters & Collage Editor,PHOTOGRAPHY,4.3,811714,50M,50000000,Free,0,Everyone,Photography
+"Z Camera - Photo Editor, Beauty Selfie, Collage",PHOTOGRAPHY,4.4,1075277,47M,100000000,Free,0,Mature 17+,Photography
+"PhotoGrid: Video & Pic Collage Maker, Photo Editor",PHOTOGRAPHY,4.6,7529865,Varies with device,100000000,Free,0,Everyone,Photography
+"Candy Camera - selfie, beauty camera, photo editor",PHOTOGRAPHY,4.4,3368705,Varies with device,100000000,Free,0,Everyone,Photography
+YouCam Perfect - Selfie Photo Editor,PHOTOGRAPHY,4.5,1579343,Varies with device,100000000,Free,0,Everyone,Photography
+Pixgram- video photo slideshow,PHOTOGRAPHY,4.2,93726,9.2M,5000000,Free,0,Everyone,Photography
+Fotor Photo Editor - Photo Collage & Photo Effects,PHOTOGRAPHY,4.5,597068,Varies with device,10000000,Free,0,Everyone,Photography
+Snapseed,PHOTOGRAPHY,4.5,823109,Varies with device,50000000,Free,0,Everyone,Photography
+Camera360: Selfie Photo Editor with Funny Sticker,PHOTOGRAPHY,4.3,4865132,51M,100000000,Free,0,Everyone,Photography
+Facetune - For Free,PHOTOGRAPHY,4.4,49553,48M,1000000,Paid,$5.99,Everyone,Photography
+Font Studio- Photo Texts Image,PHOTOGRAPHY,4.2,197295,24M,10000000,Free,0,Everyone,Photography
+Add Text To Photo,PHOTOGRAPHY,4.1,21578,1.6M,1000000,Free,0,Everyone,Photography
+Phonto - Text on Photos,PHOTOGRAPHY,4.3,307453,17M,10000000,Free,0,Everyone,Photography
+Collage&Add Stickers papelook,PHOTOGRAPHY,4.0,32896,31M,5000000,Free,0,Everyone,Photography
+"Shutterfly: Free Prints, Photo Books, Cards, Gifts",PHOTOGRAPHY,4.6,98717,59M,5000000,Free,0,Everyone,Photography
+Photo Collage - InstaMag,PHOTOGRAPHY,4.3,542561,46M,10000000,Free,0,Everyone,Photography
+BeautyPlus - Easy Photo Editor & Selfie Camera,PHOTOGRAPHY,4.4,3158151,53M,100000000,Free,0,Everyone,Photography
+"Meitu – Beauty Cam, Easy Photo Editor",PHOTOGRAPHY,4.5,462702,45M,10000000,Free,0,Everyone,Photography
+ESPN,SPORTS,4.2,521138,Varies with device,10000000,Free,0,Everyone 10+,Sports
+Free Sports TV,SPORTS,4.3,1802,9.8M,100000,Free,0,Everyone,Sports
+LiveScore: Live Sport Updates,SPORTS,4.4,283662,Varies with device,10000000,Free,0,Everyone,Sports
+MLB At Bat,SPORTS,4.2,82882,Varies with device,5000000,Free,0,Everyone,Sports
+NFL,SPORTS,4.1,459795,Varies with device,50000000,Free,0,Everyone,Sports
+"theScore: Live Sports Scores, News, Stats & Videos",SPORTS,4.4,133825,34M,10000000,Free,0,Everyone 10+,Sports
+Onefootball - Soccer Scores,SPORTS,4.7,911995,20M,10000000,Free,0,Everyone,Sports
+Cristiano Ronaldo Wallpaper,SPORTS,4.6,1733,19M,500000,Free,0,Everyone,Sports
+"FIFA - Tournaments, Soccer News & Live Scores",SPORTS,4.2,342909,6.0M,10000000,Free,0,Everyone,Sports
+Futbol24,SPORTS,4.3,31908,Varies with device,1000000,Free,0,Everyone,Sports
+kicker football news,SPORTS,4.3,56270,15M,5000000,Free,0,Everyone,Sports
+Football Live Scores,SPORTS,4.5,107724,6.5M,5000000,Free,0,Everyone,Sports
+Pro 2018 - Series A and B,SPORTS,4.6,101455,6.2M,5000000,Free,0,Everyone,Sports
+BeSoccer - Soccer Live Score,SPORTS,4.5,152780,Varies with device,10000000,Free,0,Everyone,Sports
+Sport.pl LIVE,SPORTS,4.4,21733,Varies with device,1000000,Free,0,Mature 17+,Sports
+FotMob - Live Soccer Scores,SPORTS,4.7,410384,Varies with device,10000000,Free,0,Everyone,Sports
+Yahoo Fantasy Sports - #1 Rated Fantasy App,SPORTS,4.2,277902,Varies with device,5000000,Free,0,Mature 17+,Sports
+"CBS Sports App - Scores, News, Stats & Watch Live",SPORTS,4.3,91031,Varies with device,5000000,Free,0,Everyone,Sports
+"The Team - Live Sport: football, tennis, rugby ..",SPORTS,4.2,112725,Varies with device,5000000,Free,0,Everyone,Sports
+MARCA - Sports Leader Diary,SPORTS,3.9,76346,14M,5000000,Free,0,Everyone,Sports
+Sahadan Live Scores,SPORTS,3.9,63938,Varies with device,5000000,Free,0,Everyone,Sports
+BBC Sport,SPORTS,4.2,18678,Varies with device,1000000,Free,0,Everyone,Sports
+"Foot Mercato: transfers, results, news, live",SPORTS,4.3,39878,6.1M,1000000,Free,0,Everyone,Sports
+All Football - Latest News & Videos,SPORTS,4.6,152867,17M,10000000,Free,0,Everyone,Sports
+Premier League - Official App,SPORTS,4.3,63580,24M,5000000,Free,0,Everyone,Sports
+Eurosport,SPORTS,4.0,121003,Varies with device,10000000,Free,0,Everyone,Sports
+beIN SPORTS TR,SPORTS,4.0,135763,13M,10000000,Free,0,Everyone,Sports
+ESPN Fantasy Sports,SPORTS,4.0,176448,10M,5000000,Free,0,Everyone,Sports
+"All Football GO- Live Score, Games",SPORTS,4.6,1981,10M,100000,Free,0,Everyone,Sports
+Top Mercato: football news,SPORTS,4.3,16016,6.9M,1000000,Free,0,Everyone,Sports
+GollerCepte Live Score,SPORTS,4.2,9992,31M,1000000,Free,0,Everyone,Sports
+Championat,SPORTS,4.3,36490,Varies with device,1000000,Free,0,Everyone,Sports
+"Bleacher Report: sports news, scores, & highlights",SPORTS,4.4,122282,Varies with device,5000000,Free,0,Everyone 10+,Sports
+Hovercraft Racer,SPORTS,4.0,218,28M,100000,Free,0,Everyone,Sports
+World Cup 2018,SPORTS,4.6,4011,2.6M,500000,Free,0,Teen,Sports
+GollerCepte 1903,SPORTS,4.7,25172,30M,500000,Free,0,Everyone,Sports
+League18,SPORTS,4.3,14123,13M,500000,Free,0,Everyone,Sports
+Speed Boat Racing,SPORTS,4.0,2487,27M,1000000,Free,0,Everyone,Sports
+La Liga - Spanish Soccer League Official,SPORTS,4.5,180938,29M,10000000,Free,0,Everyone,Sports
+Lionel Messi Wallpapers,SPORTS,4.7,950,18M,100000,Free,0,Everyone,Sports
+Goal Live Scores,SPORTS,4.4,232423,35M,5000000,Free,0,Everyone,Sports
+The 5th Stand,SPORTS,4.8,1664,17M,100000,Free,0,Everyone,Sports
+NUsport,SPORTS,3.3,1391,Varies with device,100000,Free,0,Everyone,Sports
+U + professional baseball,SPORTS,4.3,2486,18M,500000,Free,0,Everyone,Sports
+Mackolik Live Results,SPORTS,3.9,188834,Varies with device,10000000,Free,0,Everyone,Sports
+Mercato foot by Maxifoot,SPORTS,4.4,697,3.0M,100000,Free,0,Everyone,Sports
+MLB Ballpark,SPORTS,3.9,5510,32M,1000000,Free,0,Everyone,Sports
+MUTV - Manchester United TV,SPORTS,4.4,4549,24M,500000,Free,0,Everyone,Sports
+"CBS Sports App - Scores, News, Stats & Watch Live",SPORTS,4.3,91031,Varies with device,5000000,Free,0,Everyone,Sports
+"Hole19: Golf GPS App, Rangefinder & Scorecard",SPORTS,4.4,6106,Varies with device,100000,Free,0,Everyone,Sports
+Yahoo Fantasy Sports - #1 Rated Fantasy App,SPORTS,4.2,277900,Varies with device,5000000,Free,0,Mature 17+,Sports
+ESPN,SPORTS,4.2,521138,Varies with device,10000000,Free,0,Everyone 10+,Sports
+NFL,SPORTS,4.1,459795,Varies with device,50000000,Free,0,Everyone,Sports
+"Bleacher Report: sports news, scores, & highlights",SPORTS,4.4,122282,Varies with device,5000000,Free,0,Everyone 10+,Sports
+ESPN Fantasy Sports,SPORTS,4.0,176448,10M,5000000,Free,0,Everyone,Sports
+"theScore: Live Sports Scores, News, Stats & Videos",SPORTS,4.4,133825,34M,10000000,Free,0,Everyone 10+,Sports
+"CBS Sports App - Scores, News, Stats & Watch Live",SPORTS,4.3,91031,Varies with device,5000000,Free,0,Everyone,Sports
+WatchESPN,SPORTS,4.1,288809,6.6M,10000000,Free,0,Everyone,Sports
+CBS Sports Fantasy,SPORTS,4.0,43611,27M,1000000,Free,0,Everyone,Sports
+ESPN,SPORTS,4.2,521138,Varies with device,10000000,Free,0,Everyone 10+,Sports
+MLB At Bat,SPORTS,4.2,82882,Varies with device,5000000,Free,0,Everyone,Sports
+"CBS Sports App - Scores, News, Stats & Watch Live",SPORTS,4.3,91031,Varies with device,5000000,Free,0,Everyone,Sports
+NBC Sports,SPORTS,3.1,78442,25M,5000000,Free,0,Everyone,Sports
+WatchESPN,SPORTS,4.1,288809,6.6M,10000000,Free,0,Everyone,Sports
+NBC Sports Gold,SPORTS,2.9,3017,24M,100000,Free,0,Everyone,Sports
+UFC,SPORTS,4.0,30840,Varies with device,1000000,Free,0,Teen,Sports
+Telemundo Deportes - Live,SPORTS,4.5,36255,25M,1000000,Free,0,Everyone,Sports
+SwingAid - Level up Golf,SPORTS,4.3,752,33M,100000,Free,0,Everyone,Sports
+Golf Channel,SPORTS,4.1,19230,88M,1000000,Free,0,Everyone,Sports
+The Rules of Golf,SPORTS,4.3,926,9.3M,100000,Free,0,Everyone,Sports
+"GolfNow: Tee Time Deals at Golf Courses, Golf GPS",SPORTS,4.5,26102,Varies with device,1000000,Free,0,Everyone,Sports
+Golf GPS by SwingxSwing,SPORTS,4.6,37167,Varies with device,1000000,Free,0,Everyone,Sports
+Zepp Golf Swing Analyzer,SPORTS,4.4,2020,84M,100000,Free,0,Everyone,Sports
+Live Golf Scores - US & European Golf,SPORTS,4.2,798,4.7M,50000,Free,0,Everyone 10+,Sports
+Golfshot: Golf GPS + Tee Times,SPORTS,4.3,7543,25M,500000,Free,0,Everyone,Sports
+PGA TOUR LIVE,SPORTS,3.4,1845,12M,100000,Free,0,Everyone,Sports
+Golf GPS Rangefinder: Golf Pad,SPORTS,4.6,13098,Varies with device,1000000,Free,0,Everyone,Sports
+Mobitee GPS Golf Free,SPORTS,4.2,1904,9.9M,100000,Free,0,Everyone,Sports
+"Hole19: Golf GPS App, Rangefinder & Scorecard",SPORTS,4.4,6106,Varies with device,100000,Free,0,Everyone,Sports
+GolfLogix GPS + Putt Breaks,SPORTS,4.0,11085,61M,1000000,Free,0,Everyone,Sports
+Golfshot Plus: Golf GPS,SPORTS,4.1,3387,25M,50000,Paid,$29.99,Everyone,Sports
+PGA TOUR,SPORTS,4.0,11151,52M,1000000,Free,0,Everyone,Sports
+FanDuel: Daily Fantasy Sports,SPORTS,4.6,29673,57M,1000000,Free,0,Mature 17+,Sports
+Yahoo Fantasy Sports - #1 Rated Fantasy App,SPORTS,4.2,277904,Varies with device,5000000,Free,0,Mature 17+,Sports
+DraftKings - Daily Fantasy Sports,SPORTS,4.5,50017,41M,1000000,Free,0,Adults only 18+,Sports
+Fantasy Football Manager (FPL),SPORTS,4.4,63650,4.6M,1000000,Free,0,Everyone,Sports
+ESPN Fantasy Sports,SPORTS,4.0,176450,10M,5000000,Free,0,Everyone,Sports
+Fantasy Football,SPORTS,3.5,50179,23M,1000000,Free,0,Everyone,Sports
+CBS Sports Fantasy,SPORTS,4.0,43611,27M,1000000,Free,0,Everyone,Sports
+ESPN,SPORTS,4.2,521140,Varies with device,10000000,Free,0,Everyone 10+,Sports
+US Open Tennis Championships 2018,SPORTS,4.0,9971,33M,1000000,Free,0,Everyone,Sports
+"Bleacher Report: sports news, scores, & highlights",SPORTS,4.4,122283,Varies with device,5000000,Free,0,Everyone 10+,Sports
+Live Tennis Rankings / LTR,SPORTS,4.8,1660,4.7M,10000,Free,0,Everyone,Sports
+Tennis Livescore Widget,SPORTS,4.1,361,2.2M,50000,Free,0,Everyone,Sports
+Tennis Temple - Live Scores,SPORTS,4.6,5305,Varies with device,100000,Free,0,Everyone,Sports
+"The Championships, Wimbledon 2018",SPORTS,4.3,24082,95M,1000000,Free,0,Everyone,Sports
+"theScore: Live Sports Scores, News, Stats & Videos",SPORTS,4.4,133833,34M,10000000,Free,0,Everyone 10+,Sports
+"CBS Sports App - Scores, News, Stats & Watch Live",SPORTS,4.3,91033,Varies with device,5000000,Free,0,Everyone,Sports
+Tennis 24 - tennis live scores,SPORTS,4.6,990,9.4M,100000,Free,0,Everyone,Sports
+"Yahoo Sports - scores, stats, news, & highlights",SPORTS,4.5,32386,19M,1000000,Free,0,Everyone,Sports
+Tennis News and Scores,SPORTS,4.3,101,3.9M,10000,Free,0,Everyone,Sports
+ESPN,SPORTS,4.2,521140,Varies with device,10000000,Free,0,Everyone 10+,Sports
+"Bleacher Report: sports news, scores, & highlights",SPORTS,4.4,122283,Varies with device,5000000,Free,0,Everyone 10+,Sports
+MLB At Bat,SPORTS,4.2,82883,Varies with device,5000000,Free,0,Everyone,Sports
+"theScore: Live Sports Scores, News, Stats & Videos",SPORTS,4.4,133833,34M,10000000,Free,0,Everyone 10+,Sports
+"CBS Sports App - Scores, News, Stats & Watch Live",SPORTS,4.3,91033,Varies with device,5000000,Free,0,Everyone,Sports
+MSN Sports - Scores & Schedule,SPORTS,4.5,35394,21M,500000,Free,0,Everyone,Sports
+"Yahoo Sports - scores, stats, news, & highlights",SPORTS,4.5,32386,19M,1000000,Free,0,Everyone,Sports
+WatchESPN,SPORTS,4.1,288809,6.6M,10000000,Free,0,Everyone,Sports
+"FOX Sports: Live Streaming, Scores & News",SPORTS,4.0,28895,82M,5000000,Free,0,Teen,Sports
+FotMob - Live Soccer Scores,SPORTS,4.7,410395,Varies with device,10000000,Free,0,Everyone,Sports
+Sports Alerts - NFL edition,SPORTS,4.6,11549,Varies with device,100000,Free,0,Everyone,Sports
+Yahoo Fantasy Sports - #1 Rated Fantasy App,SPORTS,4.2,277904,Varies with device,5000000,Free,0,Mature 17+,Sports
+ESPN,SPORTS,4.2,521140,Varies with device,10000000,Free,0,Everyone 10+,Sports
+NCAA March Madness Live,SPORTS,4.1,34123,19M,5000000,Free,0,Everyone,Sports
+NFL,SPORTS,4.1,459797,Varies with device,50000000,Free,0,Everyone,Sports
+SportsManias Fantasy Team News,SPORTS,3.5,4057,26M,500000,Free,0,Everyone,Sports
+Thuuz Sports,SPORTS,4.5,5517,5.2M,500000,Free,0,Everyone,Sports
+NCAA Sports,SPORTS,3.9,4272,16M,500000,Free,0,Everyone,Sports
+850 Sports News Digest,SPORTS,4.6,539,Varies with device,10000,Free,0,Everyone,Sports
+US Open Tennis Championships 2018,SPORTS,4.0,9971,33M,1000000,Free,0,Everyone,Sports
+"Bleacher Report: sports news, scores, & highlights",SPORTS,4.4,122283,Varies with device,5000000,Free,0,Everyone 10+,Sports
+MLB At Bat,SPORTS,4.2,82883,Varies with device,5000000,Free,0,Everyone,Sports
+"FIFA - Tournaments, Soccer News & Live Scores",SPORTS,4.2,342912,6.0M,10000000,Free,0,Everyone,Sports
+365Scores - Live Scores,SPORTS,4.6,666521,25M,10000000,Free,0,Everyone,Sports
+Cricbuzz - Live Cricket Scores & News,SPORTS,4.5,838765,Varies with device,50000000,Free,0,Everyone,Sports
+"theScore: Live Sports Scores, News, Stats & Videos",SPORTS,4.4,133833,34M,10000000,Free,0,Everyone 10+,Sports
+Fantasy Football & NFL News,SPORTS,4.5,2943,8.1M,100000,Free,0,Everyone,Sports
+NBA,SPORTS,4.4,108318,35M,10000000,Free,0,Everyone,Sports
+Golfshot: Golf GPS + Tee Times,SPORTS,4.3,7543,25M,500000,Free,0,Everyone,Sports
+BBC Sport,SPORTS,4.2,18679,Varies with device,1000000,Free,0,Everyone,Sports
+"CBS Sports App - Scores, News, Stats & Watch Live",SPORTS,4.3,91033,Varies with device,5000000,Free,0,Everyone,Sports
+"Yahoo Sports - scores, stats, news, & highlights",SPORTS,4.5,32386,19M,1000000,Free,0,Everyone,Sports
+NHL,SPORTS,4.0,68935,48M,5000000,Free,0,Everyone,Sports
+NASCAR MOBILE,SPORTS,4.2,80900,21M,1000000,Free,0,Everyone,Sports
+WatchESPN,SPORTS,4.1,288809,6.6M,10000000,Free,0,Everyone,Sports
+MLB Ballpark,SPORTS,3.9,5511,32M,1000000,Free,0,Everyone,Sports
+"Univision Deportes: Liga MX, MLS, Fútbol Live",SPORTS,4.2,75545,Varies with device,5000000,Free,0,Everyone,Sports
+"FOX Sports: Live Streaming, Scores & News",SPORTS,4.0,28895,82M,5000000,Free,0,Teen,Sports
+Fantasy Football,SPORTS,3.5,50179,23M,1000000,Free,0,Everyone,Sports
+PGA TOUR,SPORTS,4.0,11151,52M,1000000,Free,0,Everyone,Sports
+UFC,SPORTS,4.0,30840,Varies with device,1000000,Free,0,Teen,Sports
+Real Basketball,SPORTS,4.5,1605267,Varies with device,10000000,Free,0,Everyone,Sports
+"Expedia Hotels, Flights & Car Rental Travel Deals",TRAVEL_AND_LOCAL,4.1,136626,14M,10000000,Free,0,Everyone,Travel & Local
+trivago: Hotels & Travel,TRAVEL_AND_LOCAL,4.2,219848,Varies with device,50000000,Free,0,Everyone,Travel & Local
+Hopper - Watch & Book Flights,TRAVEL_AND_LOCAL,4.4,52029,Varies with device,5000000,Free,0,Everyone,Travel & Local
+TripIt: Travel Organizer,TRAVEL_AND_LOCAL,4.4,49190,25M,1000000,Free,0,Everyone,Travel & Local
+Trip by Skyscanner - City & Travel Guide,TRAVEL_AND_LOCAL,4.1,5150,Varies with device,500000,Free,0,Everyone,Travel & Local
+CityMaps2Go Plan Trips Travel Guide Offline Maps,TRAVEL_AND_LOCAL,4.3,64713,58M,1000000,Free,0,Everyone,Travel & Local
+"KAYAK Flights, Hotels & Cars",TRAVEL_AND_LOCAL,4.5,216388,19M,10000000,Free,0,Everyone,Travel & Local
+Skyscanner,TRAVEL_AND_LOCAL,4.5,481545,29M,10000000,Free,0,Everyone,Travel & Local
+World Travel Guide by Triposo,TRAVEL_AND_LOCAL,4.4,6012,81M,500000,Free,0,Everyone,Travel & Local
+Hotels.com: Book Hotel Rooms & Find Vacation Deals,TRAVEL_AND_LOCAL,4.5,260121,Varies with device,10000000,Free,0,Everyone,Travel & Local
+Booking.com Travel Deals,TRAVEL_AND_LOCAL,4.7,1830388,Varies with device,100000000,Free,0,Everyone,Travel & Local
+Hostelworld: Hostels & Cheap Hotels Travel App,TRAVEL_AND_LOCAL,4.4,17878,28M,1000000,Free,0,Everyone,Travel & Local
+Google Trips - Travel Planner,TRAVEL_AND_LOCAL,4.1,26871,Varies with device,5000000,Free,0,Everyone,Travel & Local
+TripAdvisor Hotels Flights Restaurants Attractions,TRAVEL_AND_LOCAL,4.4,1162837,Varies with device,100000000,Free,0,Everyone,Travel & Local
+Airbnb,TRAVEL_AND_LOCAL,4.4,359403,Varies with device,10000000,Free,0,Everyone,Travel & Local
+Maps - Navigate & Explore,TRAVEL_AND_LOCAL,4.3,9235155,Varies with device,1000000000,Free,0,Everyone,Travel & Local
+trivago: Hotels & Travel,TRAVEL_AND_LOCAL,4.2,219848,Varies with device,50000000,Free,0,Everyone,Travel & Local
+GPS Map Free,TRAVEL_AND_LOCAL,4.0,33782,7.6M,5000000,Free,0,Everyone,Travel & Local
+Offline Maps & Navigation,TRAVEL_AND_LOCAL,4.7,192641,33M,5000000,Free,0,Everyone,Travel & Local
+Google Earth,TRAVEL_AND_LOCAL,4.3,2338655,Varies with device,100000000,Free,0,Everyone,Travel & Local
+GasBuddy: Find Cheap Gas,TRAVEL_AND_LOCAL,4.6,751551,42M,10000000,Free,0,Mature 17+,Travel & Local
+Southwest Airlines,TRAVEL_AND_LOCAL,3.9,24781,8.3M,5000000,Free,0,Everyone,Travel & Local
+"AT&T Navigator: Maps, Traffic",TRAVEL_AND_LOCAL,3.6,32862,14M,10000000,Free,0,Everyone,Travel & Local
+VZ Navigator,TRAVEL_AND_LOCAL,4.0,16101,Varies with device,50000000,Free,0,Everyone,Travel & Local
+KakaoMap - Map / Navigation,TRAVEL_AND_LOCAL,4.1,76779,Varies with device,10000000,Free,0,Everyone,Travel & Local
+Google Street View,TRAVEL_AND_LOCAL,4.2,2129689,Varies with device,1000000000,Free,0,Everyone,Travel & Local
+AirAsia,TRAVEL_AND_LOCAL,3.9,98585,37M,10000000,Free,0,Everyone,Travel & Local
+"Expedia Hotels, Flights & Car Rental Travel Deals",TRAVEL_AND_LOCAL,4.1,136633,14M,10000000,Free,0,Everyone,Travel & Local
+Goibibo - Flight Hotel Bus Car IRCTC Booking App,TRAVEL_AND_LOCAL,4.3,459851,Varies with device,10000000,Free,0,Everyone,Travel & Local
+Allegiant,TRAVEL_AND_LOCAL,3.1,5572,21M,1000000,Free,0,Everyone,Travel & Local
+Amtrak,TRAVEL_AND_LOCAL,3.7,16815,28M,1000000,Free,0,Everyone,Travel & Local
+JAL (Domestic and international flights),TRAVEL_AND_LOCAL,3.4,2277,27M,1000000,Free,0,Everyone,Travel & Local
+Flight & Hotel Booking App - ixigo,TRAVEL_AND_LOCAL,4.4,45562,Varies with device,5000000,Free,0,Everyone,Travel & Local
+VZ Navigator for Tablets,TRAVEL_AND_LOCAL,3.6,285,39M,500000,Free,0,Everyone,Travel & Local
+TripAdvisor Hotels Flights Restaurants Attractions,TRAVEL_AND_LOCAL,4.4,1162838,Varies with device,100000000,Free,0,Everyone,Travel & Local
+"HSL - Tickets, route planner and information",TRAVEL_AND_LOCAL,3.3,256,17M,100000,Free,0,Everyone,Travel & Local
+Wisepilot for XPERIA™,TRAVEL_AND_LOCAL,3.7,21443,Varies with device,5000000,Free,0,Everyone,Travel & Local
+VZ Navigator for Galaxy S4,TRAVEL_AND_LOCAL,3.0,2750,39M,5000000,Free,0,Everyone,Travel & Local
+MAIN,TRAVEL_AND_LOCAL,3.6,7081,51M,1000000,Free,0,Everyone,Travel & Local
+"Yoriza Pension - travel, lodging, pension, camping, caravan, pool villas accommodation discount",TRAVEL_AND_LOCAL,4.8,17882,86M,1000000,Free,0,Everyone,Travel & Local
+Foursquare Swarm: Check In,TRAVEL_AND_LOCAL,3.9,421800,Varies with device,10000000,Free,0,Teen,Travel & Local
+PagesJaunes - local search,TRAVEL_AND_LOCAL,3.8,43935,Varies with device,10000000,Free,0,Everyone,Travel & Local
+Flightradar24 Flight Tracker,TRAVEL_AND_LOCAL,4.3,171889,Varies with device,10000000,Free,0,Everyone,Travel & Local
+"Yatra - Flights, Hotels, Bus, Trains & Cabs",TRAVEL_AND_LOCAL,4.5,251037,26M,10000000,Free,0,Everyone,Travel & Local
+SNCF,TRAVEL_AND_LOCAL,3.4,15750,Varies with device,5000000,Free,0,Everyone,Travel & Local
+Fly Delta,TRAVEL_AND_LOCAL,3.7,27560,46M,5000000,Free,0,Everyone,Travel & Local
+Skyscanner,TRAVEL_AND_LOCAL,4.5,481546,29M,10000000,Free,0,Everyone,Travel & Local
+Despegar.com Hotels and Flights,TRAVEL_AND_LOCAL,4.4,150932,27M,10000000,Free,0,Everyone,Travel & Local
+Navigation Plus,TRAVEL_AND_LOCAL,4.1,928,14M,1000000,Free,0,Everyone,Travel & Local
+2GIS: directory & navigator,TRAVEL_AND_LOCAL,4.5,768833,Varies with device,50000000,Free,0,Everyone,Travel & Local
+Poynt,TRAVEL_AND_LOCAL,4.0,26665,10M,5000000,Free,0,Everyone,Travel & Local
+Gaode Map,TRAVEL_AND_LOCAL,3.9,13275,71M,1000000,Free,0,Everyone,Travel & Local
+"Priceline Hotel Deals, Rental Cars & Flights",TRAVEL_AND_LOCAL,4.4,48930,15M,5000000,Free,0,Everyone,Travel & Local
+TravelPirates,TRAVEL_AND_LOCAL,4.8,43054,Varies with device,1000000,Free,0,Everyone,Travel & Local
+Booking.com Travel Deals,TRAVEL_AND_LOCAL,4.7,1830387,Varies with device,100000000,Free,0,Everyone,Travel & Local
+Free Radar Detector,TRAVEL_AND_LOCAL,4.3,15680,11M,1000000,Free,0,Everyone,Travel & Local
+American Airlines,TRAVEL_AND_LOCAL,3.7,16980,Varies with device,5000000,Free,0,Everyone,Travel & Local
+Where to travel - ticket. hotel. train ticket. car ticket. travel. tickets,TRAVEL_AND_LOCAL,4.2,5112,62M,1000000,Free,0,Everyone,Travel & Local
+United Airlines,TRAVEL_AND_LOCAL,3.5,30447,80M,5000000,Free,0,Everyone,Travel & Local
+NTES,TRAVEL_AND_LOCAL,4.3,165299,5.4M,10000000,Free,0,Everyone,Travel & Local
+Where is my Train : Indian Railway & PNR Status,TRAVEL_AND_LOCAL,4.7,620534,9.8M,10000000,Free,0,Everyone,Travel & Local
+MakeMyTrip-Flight Hotel Bus Cab IRCTC Rail Booking,TRAVEL_AND_LOCAL,4.3,599872,Varies with device,10000000,Free,0,Everyone,Travel & Local
+Restaurant Finder,TRAVEL_AND_LOCAL,4.1,12564,Varies with device,1000000,Free,0,Everyone,Travel & Local
+Zagat,TRAVEL_AND_LOCAL,3.1,2528,Varies with device,100000,Free,0,Everyone,Travel & Local
+Gormey: Find Best Restaurants,TRAVEL_AND_LOCAL,4.3,34,7.6M,1000,Free,0,Everyone,Travel & Local
+Find Dining Restaurant Finder,TRAVEL_AND_LOCAL,4.1,427,26M,100000,Free,0,Everyone,Travel & Local
+Urbanspoon Restaurant Reviews,TRAVEL_AND_LOCAL,4.2,35560,13M,5000000,Free,0,Everyone,Travel & Local
+"Yelp: Food, Shopping, Services Nearby",TRAVEL_AND_LOCAL,4.3,397422,Varies with device,10000000,Free,0,Teen,Travel & Local
+TripAdvisor Hotels Flights Restaurants Attractions,TRAVEL_AND_LOCAL,4.4,1162837,Varies with device,100000000,Free,0,Everyone,Travel & Local
+Qatar Airways,TRAVEL_AND_LOCAL,4.3,11182,62M,1000000,Free,0,Everyone,Travel & Local
+Hipmunk Hotels & Flights,TRAVEL_AND_LOCAL,4.3,16734,10.0M,1000000,Free,0,Everyone,Travel & Local
+"Priceline Hotel Deals, Rental Cars & Flights",TRAVEL_AND_LOCAL,4.4,48930,15M,5000000,Free,0,Everyone,Travel & Local
+United Airlines,TRAVEL_AND_LOCAL,3.5,30447,80M,5000000,Free,0,Everyone,Travel & Local
+"Expedia Hotels, Flights & Car Rental Travel Deals",TRAVEL_AND_LOCAL,4.1,136626,14M,10000000,Free,0,Everyone,Travel & Local
+Skiplagged — Exclusive Flights & Hotels,TRAVEL_AND_LOCAL,4.6,10035,Varies with device,1000000,Free,0,Everyone,Travel & Local
+CWT To Go,TRAVEL_AND_LOCAL,4.4,20313,57M,100000,Free,0,Everyone,Travel & Local
+British Airways,TRAVEL_AND_LOCAL,4.2,25740,51M,1000000,Free,0,Everyone,Travel & Local
+Southwest Airlines,TRAVEL_AND_LOCAL,3.9,24781,8.3M,5000000,Free,0,Everyone,Travel & Local
+Cheap Flights & Hotels momondo,TRAVEL_AND_LOCAL,4.2,42546,24M,5000000,Free,0,Everyone,Travel & Local
+"CheapTickets – Hotels, Flights & Travel Deals",TRAVEL_AND_LOCAL,4.4,6925,Varies with device,1000000,Free,0,Everyone,Travel & Local
+JetBlue,TRAVEL_AND_LOCAL,4.4,24281,29M,1000000,Free,0,Everyone,Travel & Local
+Hopper - Watch & Book Flights,TRAVEL_AND_LOCAL,4.4,52028,Varies with device,5000000,Free,0,Everyone,Travel & Local
+Flights,TRAVEL_AND_LOCAL,4.4,18039,3.1M,1000000,Free,0,Everyone,Travel & Local
+Fly Delta,TRAVEL_AND_LOCAL,3.7,27560,46M,5000000,Free,0,Everyone,Travel & Local
+The Emirates App,TRAVEL_AND_LOCAL,4.4,22748,55M,1000000,Free,0,Everyone,Travel & Local
+"KAYAK Flights, Hotels & Cars",TRAVEL_AND_LOCAL,4.5,216388,19M,10000000,Free,0,Everyone,Travel & Local
+American Airlines,TRAVEL_AND_LOCAL,3.7,16980,Varies with device,5000000,Free,0,Everyone,Travel & Local
+Cheapflights – Flight Search,TRAVEL_AND_LOCAL,4.4,47780,19M,5000000,Free,0,Everyone,Travel & Local
+KLM - Royal Dutch Airlines,TRAVEL_AND_LOCAL,3.7,7705,40M,1000000,Free,0,Everyone,Travel & Local
+"Orbitz - Hotels, Flights & Package Deals",TRAVEL_AND_LOCAL,4.4,33256,Varies with device,1000000,Free,0,Everyone,Travel & Local
+Skyscanner,TRAVEL_AND_LOCAL,4.5,481546,29M,10000000,Free,0,Everyone,Travel & Local
+Lufthansa,TRAVEL_AND_LOCAL,3.6,14544,43M,1000000,Free,0,Everyone,Travel & Local
+easyJet: Travel App,TRAVEL_AND_LOCAL,4.4,134895,50M,10000000,Free,0,Everyone,Travel & Local
+IndiGo,TRAVEL_AND_LOCAL,4.0,48082,Varies with device,5000000,Free,0,Everyone,Travel & Local
+LateRooms: Find Hotel Deals,TRAVEL_AND_LOCAL,4.1,2419,13M,1000000,Free,0,Everyone,Travel & Local
+Choice Hotels,TRAVEL_AND_LOCAL,4.4,17915,Varies with device,1000000,Free,0,Everyone,Travel & Local
+Couchsurfing Travel App,TRAVEL_AND_LOCAL,4.4,61776,Varies with device,1000000,Free,0,Teen,Travel & Local
+Hotwire Hotel & Car Rental App,TRAVEL_AND_LOCAL,4.3,10323,Varies with device,1000000,Free,0,Everyone,Travel & Local
+"Priceline Hotel Deals, Rental Cars & Flights",TRAVEL_AND_LOCAL,4.4,48930,15M,5000000,Free,0,Everyone,Travel & Local
+HOTEL DEALS,TRAVEL_AND_LOCAL,4.2,1609,4.0M,100000,Free,0,Everyone,Travel & Local
+trivago: Hotels & Travel,TRAVEL_AND_LOCAL,4.2,219848,Varies with device,50000000,Free,0,Everyone,Travel & Local
+"Expedia Hotels, Flights & Car Rental Travel Deals",TRAVEL_AND_LOCAL,4.1,136626,14M,10000000,Free,0,Everyone,Travel & Local
+HomeAway Vacation Rentals,TRAVEL_AND_LOCAL,4.3,30403,Varies with device,5000000,Free,0,Everyone,Travel & Local
+"KAYAK Flights, Hotels & Cars",TRAVEL_AND_LOCAL,4.5,216388,19M,10000000,Free,0,Everyone,Travel & Local
+"Orbitz - Hotels, Flights & Package Deals",TRAVEL_AND_LOCAL,4.4,33256,Varies with device,1000000,Free,0,Everyone,Travel & Local
+Skyscanner,TRAVEL_AND_LOCAL,4.5,481546,29M,10000000,Free,0,Everyone,Travel & Local
+IHG®: Hotel Deals & Rewards,TRAVEL_AND_LOCAL,4.3,18622,44M,1000000,Free,0,Everyone,Travel & Local
+SPG: Starwood Hotels & Resorts,TRAVEL_AND_LOCAL,4.2,8258,22M,1000000,Free,0,Everyone,Travel & Local
+Hotels.com: Book Hotel Rooms & Find Vacation Deals,TRAVEL_AND_LOCAL,4.5,260133,Varies with device,10000000,Free,0,Everyone,Travel & Local
+Booking.com Travel Deals,TRAVEL_AND_LOCAL,4.7,1830388,Varies with device,100000000,Free,0,Everyone,Travel & Local
+HotelTonight: Book amazing deals at great hotels,TRAVEL_AND_LOCAL,4.4,57573,Varies with device,5000000,Free,0,Everyone,Travel & Local
+Hostelworld: Hostels & Cheap Hotels Travel App,TRAVEL_AND_LOCAL,4.4,17878,28M,1000000,Free,0,Everyone,Travel & Local
+TripAdvisor Hotels Flights Restaurants Attractions,TRAVEL_AND_LOCAL,4.4,1162837,Varies with device,100000000,Free,0,Everyone,Travel & Local
+Airbnb,TRAVEL_AND_LOCAL,4.4,359560,Varies with device,10000000,Free,0,Everyone,Travel & Local
+Hotels Combined - Cheap deals,TRAVEL_AND_LOCAL,4.1,17202,12M,5000000,Free,0,Everyone,Travel & Local
+Agoda – Hotel Booking Deals,TRAVEL_AND_LOCAL,4.6,263525,Varies with device,10000000,Free,0,Everyone,Travel & Local
+Turo - Better Than Car Rental,TRAVEL_AND_LOCAL,4.4,14114,46M,1000000,Free,0,Everyone,Travel & Local
+Ascape VR: 360° Virtual Travel,TRAVEL_AND_LOCAL,4.1,890,7.6M,100000,Free,0,Everyone,Travel & Local;Action & Adventure
+Cheap hotel deals and discounts — Hotellook,TRAVEL_AND_LOCAL,4.5,7153,Varies with device,1000000,Free,0,Everyone,Travel & Local
+Skyscanner,TRAVEL_AND_LOCAL,4.5,481546,29M,10000000,Free,0,Everyone,Travel & Local
+HotelTonight: Book amazing deals at great hotels,TRAVEL_AND_LOCAL,4.4,57573,Varies with device,5000000,Free,0,Everyone,Travel & Local
+Maps - Navigate & Explore,TRAVEL_AND_LOCAL,4.3,9235373,Varies with device,1000000000,Free,0,Everyone,Travel & Local
+GPS Status & Toolbox,TRAVEL_AND_LOCAL,4.5,149723,4.1M,10000000,Free,0,Everyone,Travel & Local
+Airport + Flight Tracker Radar,TRAVEL_AND_LOCAL,4.2,6762,8.5M,1000000,Free,0,Everyone,Travel & Local
+Scout GPS Navigation & Meet Up,TRAVEL_AND_LOCAL,4.2,120373,31M,5000000,Free,0,Everyone,Travel & Local
+Street Panorama View,TRAVEL_AND_LOCAL,4.2,40225,4.1M,1000000,Free,0,Everyone,Travel & Local
+Geo Tracker - GPS tracker,TRAVEL_AND_LOCAL,4.5,42849,Varies with device,1000000,Free,0,Everyone,Travel & Local
+DreamTrips,TRAVEL_AND_LOCAL,4.7,9971,22M,500000,Free,0,Teen,Travel & Local
+Navmii GPS USA (Navfree),TRAVEL_AND_LOCAL,4.0,5960,Varies with device,500000,Free,0,Everyone,Travel & Local
+Sygic Truck GPS Navigation,TRAVEL_AND_LOCAL,4.2,18294,28M,1000000,Free,0,Everyone,Travel & Local
+Google Street View,TRAVEL_AND_LOCAL,4.2,2129707,Varies with device,1000000000,Free,0,Everyone,Travel & Local
+Moto File Manager,TOOLS,4.1,38655,5.9M,10000000,Free,0,Everyone,Tools
+Google,TOOLS,4.4,8033493,Varies with device,1000000000,Free,0,Everyone,Tools
+Google Translate,TOOLS,4.4,5745093,Varies with device,500000000,Free,0,Everyone,Tools
+Moto Display,TOOLS,4.2,18239,Varies with device,10000000,Free,0,Everyone,Tools
+Motorola Alert,TOOLS,4.2,24199,3.9M,50000000,Free,0,Everyone,Tools
+Motorola Assist,TOOLS,4.1,37333,Varies with device,50000000,Free,0,Everyone,Tools
+Cache Cleaner-DU Speed Booster (booster & cleaner),TOOLS,4.5,12759663,15M,100000000,Free,0,Everyone,Tools
+Moto Suggestions ™,TOOLS,4.6,308,4.3M,1000000,Free,0,Everyone,Tools
+Moto Voice,TOOLS,4.1,33216,Varies with device,10000000,Free,0,Everyone,Tools
+Calculator,TOOLS,4.3,40770,Varies with device,100000000,Free,0,Everyone,Tools
+Device Help,TOOLS,4.2,28860,Varies with device,100000000,Free,0,Everyone,Tools
+Account Manager,TOOLS,4.1,76604,Varies with device,100000000,Free,0,Everyone,Tools
+myMetro,TOOLS,4.0,26189,5.3M,10000000,Free,0,Everyone,Tools
+File Manager,TOOLS,4.6,739329,Varies with device,50000000,Free,0,Everyone,Tools
+My Telcel,TOOLS,3.1,45838,16M,50000000,Free,0,Everyone,Tools
+"Calculator - free calculator, multi calculator app",TOOLS,4.6,25592,7.5M,10000000,Free,0,Everyone,Tools
+ASUS Sound Recorder,TOOLS,4.5,34126,Varies with device,10000000,Free,0,Everyone,Tools
+iWnn IME for Nexus,TOOLS,3.2,2394,Varies with device,5000000,Free,0,Everyone,Tools
+Samsung Max - Data Savings & Privacy Protection,TOOLS,4.3,330468,Varies with device,10000000,Free,0,Everyone,Tools
+Android TV Remote Service,TOOLS,4.0,1,3.7M,1000000,Free,0,Everyone,Tools
+ZenUI Help,TOOLS,4.6,136874,Varies with device,10000000,Free,0,Everyone,Tools
+"Calculator - free calculator ,multi calculator app",TOOLS,4.4,1236,5.8M,100000,Free,0,Everyone,Tools
+SHAREit - Transfer & Share,TOOLS,4.6,7790693,17M,500000000,Free,0,Everyone,Tools
+"ZenUI Keyboard – Emoji, Theme",TOOLS,4.5,537554,Varies with device,10000000,Free,0,Everyone,Tools
+Files Go by Google: Free up space on your phone,TOOLS,4.6,315585,8.5M,10000000,Free,0,Everyone,Tools
+SD card backup,TOOLS,4.0,142,Varies with device,1000000,Free,0,Everyone,Tools
+Nokia mobile support,TOOLS,4.4,12215,9.1M,5000000,Free,0,Everyone,Tools
+File Manager -- Take Command of Your Files Easily,TOOLS,4.2,127223,7.6M,10000000,Free,0,Everyone,Tools
+Samsung Calculator,TOOLS,4.4,9602,2.5M,100000000,Free,0,Everyone,Tools
+Clear,TOOLS,3.1,24151,15M,10000000,Free,0,Everyone,Tools
+Phone,TOOLS,3.6,45483,Varies with device,10000000,Free,0,Everyone,Tools
+HTC Lock Screen,TOOLS,4.1,28250,Varies with device,10000000,Free,0,Everyone,Tools
+Gboard - the Google Keyboard,TOOLS,4.2,1859115,Varies with device,500000000,Free,0,Everyone,Tools
+Google Korean Input,TOOLS,3.5,74819,Varies with device,100000000,Free,0,Everyone,Tools
+AT&T Smart Wi-Fi,TOOLS,3.9,18513,6.1M,10000000,Free,0,Everyone,Tools
+Google app for Android TV,TOOLS,3.0,66,Varies with device,10000000,Free,0,Everyone,Tools
+Sound Recorder: Recorder & Voice Changer Free,TOOLS,3.9,14552,17M,10000000,Free,0,Everyone,Tools
+Remote Link (PC Remote),TOOLS,4.5,87055,Varies with device,10000000,Free,0,Everyone,Tools
+HTC Sense Input,TOOLS,3.4,17030,Varies with device,10000000,Free,0,Everyone,Tools
+Share Music & Transfer Files - Xender,TOOLS,4.4,1280423,Varies with device,100000000,Free,0,Everyone,Tools
+App vault,TOOLS,3.4,25094,Varies with device,10000000,Free,0,Everyone,Tools
+TouchPal Keyboard for vivo,TOOLS,4.3,357,58M,1000000,Free,0,Everyone,Tools
+Google Assistant Go,TOOLS,3.7,315,4.6M,500000,Free,0,Everyone,Tools
+My love,TOOLS,3.5,163997,16M,10000000,Free,0,Everyone,Tools
+DuraSpeed,TOOLS,3.8,5431,1.3M,10000000,Free,0,Everyone,Tools
+HTC Sense Input-LV,TOOLS,3.6,59,2.3M,50000,Free,0,Everyone,Tools
+HTC Sense Input-CA,TOOLS,3.1,124,1.9M,100000,Free,0,Everyone,Tools
+HTC Sense Input-AR,TOOLS,3.8,1420,2.7M,100000,Free,0,Everyone,Tools
+Digital Alarm Clock,TOOLS,4.2,118439,16M,10000000,Free,0,Everyone,Tools
+Alarm Clock Free,TOOLS,4.0,59973,11M,10000000,Free,0,Everyone,Tools
+Puzzle Alarm Clock ⏰,TOOLS,4.3,32111,5.3M,1000000,Free,0,Everyone,Tools
+Alarm Clock,TOOLS,4.3,114788,Varies with device,5000000,Free,0,Everyone,Tools
+I Can't Wake Up! Alarm Clock,TOOLS,4.5,70404,4.2M,1000000,Free,0,Everyone,Tools
+High-Powered Flashlight,TOOLS,4.5,429580,Varies with device,10000000,Free,0,Everyone,Tools
+Brightest Flashlight - LED Light,TOOLS,4.5,876866,9.1M,50000000,Free,0,Everyone,Tools
+LED Flashlight,TOOLS,4.4,207706,4.3M,10000000,Free,0,Everyone,Tools
+Tiny Flashlight + LED,TOOLS,4.4,4254879,Varies with device,100000000,Free,0,Everyone,Tools
+Flashlight & LED Torch,TOOLS,4.3,111507,Varies with device,10000000,Free,0,Everyone,Tools
+Color Flashlight,TOOLS,4.2,472904,Varies with device,50000000,Free,0,Everyone,Tools
+Flashlight,TOOLS,4.7,115409,Varies with device,10000000,Free,0,Everyone,Tools
+"CM Flashlight (Compass, SOS)",TOOLS,4.4,166367,1.8M,5000000,Free,0,Everyone,Tools
+Flashlight HD LED,TOOLS,4.3,618918,Varies with device,50000000,Free,0,Everyone,Tools
+Flashlight - Torch LED Light,TOOLS,4.4,192661,8.5M,10000000,Free,0,Everyone,Tools
+Super Flashlight + LED,TOOLS,4.3,54207,4.4M,5000000,Free,0,Everyone,Tools
+Brightest LED Flashlight,TOOLS,4.5,60571,Varies with device,5000000,Free,0,Everyone,Tools
+Brightest Flashlight Free ®,TOOLS,4.7,1335799,3.8M,50000000,Free,0,Everyone,Tools
+Fraction Calculator Plus Free,TOOLS,4.5,148506,11M,5000000,Free,0,Everyone,Tools
+Calculator Plus Free,TOOLS,4.6,679912,Varies with device,10000000,Free,0,Everyone,Tools
+CALCU™ Stylish Calculator Free,TOOLS,4.7,152692,11M,5000000,Free,0,Everyone,Tools
+Mobi Calculator free & AD free!,TOOLS,4.6,77311,Varies with device,5000000,Free,0,Everyone,Tools
+Calculator with Percent (Free),TOOLS,4.8,48211,7.4M,1000000,Free,0,Everyone,Tools
+Graphing Calculator,TOOLS,3.9,12388,5.3M,1000000,Free,0,Everyone,Tools
+Unit Converter,TOOLS,4.5,85387,5.4M,1000000,Free,0,Everyone,Tools
+Calculator ++,TOOLS,4.6,33509,3.6M,1000000,Free,0,Everyone,Tools
+MyScript Calculator,TOOLS,4.5,342336,Varies with device,10000000,Free,0,Everyone,Tools;Education
+ConvertPad - Unit Converter,TOOLS,4.4,90831,4.3M,10000000,Free,0,Everyone,Tools
+Unit Converter Pro,TOOLS,4.5,12718,Varies with device,1000000,Free,0,Everyone,Tools
+Classic Calculator,TOOLS,4.0,85659,27M,5000000,Free,0,Everyone,Tools
+Scientific Calculator Free,TOOLS,4.3,16395,Varies with device,1000000,Free,0,Everyone,Tools
+weight conversion calculator,TOOLS,4.0,807,1.8M,100000,Free,0,Everyone,Tools
+Age Calculator,TOOLS,4.4,24265,3.3M,1000000,Free,0,Everyone,Tools
+EzCalculator,TOOLS,4.1,1657,2.0M,100000,Free,0,Everyone,Tools
+SuperVPN Free VPN Client,TOOLS,4.3,576454,6.1M,50000000,Free,0,Everyone,Tools
+Hideman VPN,TOOLS,4.1,88675,9.6M,5000000,Free,0,Everyone,Tools
+Fast Secure VPN,TOOLS,4.3,56848,9.6M,1000000,Free,0,Everyone,Tools
+Free & Premium VPN - FinchVPN,TOOLS,4.2,19096,10M,1000000,Free,0,Everyone,Tools
+Hotspot Shield Free VPN Proxy & Wi-Fi Security,TOOLS,4.2,1116393,8.2M,50000000,Free,0,Everyone,Tools
+OpenVPN Connect – Fast & Safe SSL VPN Client,TOOLS,4.2,154578,14M,10000000,Free,0,Everyone,Tools
+"VPN - Fast, Secure & Unlimited WiFi with VyprVPN",TOOLS,4.2,40676,25M,1000000,Free,0,Everyone,Tools
+FREEDOME VPN Unlimited anonymous Wifi Security,TOOLS,4.3,39833,9.9M,1000000,Free,0,Everyone,Tools
+SurfEasy Secure Android VPN,TOOLS,4.5,273283,22M,5000000,Free,0,Everyone,Tools
+TunnelBear VPN,TOOLS,4.4,139480,Varies with device,5000000,Free,0,Everyone,Tools
+VPN Free - Betternet Hotspot VPN & Private Browser,TOOLS,4.5,801054,8.9M,10000000,Free,0,Everyone,Tools
+Gboard - the Google Keyboard,TOOLS,4.2,1859109,Varies with device,500000000,Free,0,Everyone,Tools
+Smart Keyboard Trial,TOOLS,4.1,65597,2.4M,10000000,Free,0,Everyone,Tools
+"Emoji keyboard - Cute Emoticons, GIF, Stickers",TOOLS,4.4,1107320,25M,50000000,Free,0,Everyone,Tools
+"GO Keyboard - Cute Emojis, Themes and GIFs",TOOLS,4.5,4594198,Varies with device,100000000,Free,0,Everyone,Tools
+Google Handwriting Input,TOOLS,4.3,94427,Varies with device,10000000,Free,0,Everyone,Tools
+Wifi Analyzer,TOOLS,4.4,335115,1.8M,10000000,Free,0,Everyone,Tools
+Network Signal Info,TOOLS,4.1,33926,17M,1000000,Free,0,Everyone,Tools
+Speedtest by Ookla,TOOLS,4.4,1028794,Varies with device,100000000,Free,0,Everyone,Tools
+osmino Wi-Fi: free WiFi,TOOLS,4.2,134203,4.1M,10000000,Free,0,Everyone,Tools
+WiFi Overview 360,TOOLS,4.1,15693,18M,1000000,Free,0,Everyone,Tools
+Speedcheck,TOOLS,4.6,48979,14M,1000000,Free,0,Everyone,Tools
+Internet Speed Meter Lite,TOOLS,4.5,410303,Varies with device,10000000,Free,0,Everyone,Tools
+Wifi Inspector,TOOLS,4.3,63712,Varies with device,5000000,Free,0,Everyone,Tools
+WiFi Automatic,TOOLS,4.1,10595,Varies with device,1000000,Free,0,Everyone,Tools
+NETGEAR WiFi Analytics,TOOLS,4.1,9496,696k,1000000,Free,0,Everyone,Tools
+Keypad Lock Screen,TOOLS,4.2,428581,4.7M,10000000,Free,0,Everyone,Tools
+photo keypad lockscreen,TOOLS,4.1,225544,8.1M,10000000,Free,0,Everyone,Tools
+CM Locker - Security Lockscreen,TOOLS,4.6,3090727,Varies with device,100000000,Free,0,Everyone,Tools
+Solo Locker (DIY Locker),TOOLS,4.5,474439,7.9M,10000000,Free,0,Everyone,Tools
+Lock Screen,TOOLS,4.0,41137,4.6M,1000000,Free,0,Everyone,Tools
+ZERO Lock Screen,TOOLS,3.5,75336,544k,1000000,Free,0,Everyone,Tools
+AppLock - Fingerprint,TOOLS,4.4,745245,3.5M,10000000,Free,0,Everyone,Tools
+Applock,TOOLS,4.4,4934130,Varies with device,100000000,Free,0,Everyone,Tools
+Smart AppLock (App Protect),TOOLS,4.4,137562,Varies with device,10000000,Free,0,Everyone,Tools
+Screen Off and Lock,TOOLS,4.1,172990,525k,10000000,Free,0,Everyone,Tools
+Screen Lock,TOOLS,4.2,68309,2.1M,1000000,Free,0,Everyone,Tools
+Nova Launcher,PERSONALIZATION,4.6,1121805,Varies with device,50000000,Free,0,Everyone,Personalization
+Funny Ringtones,PERSONALIZATION,4.4,7146,14M,1000000,Free,0,Everyone 10+,Personalization
+ZEDGE™ Ringtones & Wallpapers,PERSONALIZATION,4.6,6466641,Varies with device,100000000,Free,0,Teen,Personalization
+"XOS - Launcher,Theme,Wallpaper",PERSONALIZATION,4.6,49657,8.7M,5000000,Free,0,Everyone,Personalization
+3D Live Neon Weed Launcher,PERSONALIZATION,4.5,1724,21M,100000,Free,0,Mature 17+,Personalization
+Evie Launcher,PERSONALIZATION,4.7,139258,Varies with device,5000000,Free,0,Everyone,Personalization
+Golden Launcher,PERSONALIZATION,4.4,32794,12M,5000000,Free,0,Everyone,Personalization
+Launcher,PERSONALIZATION,4.5,102923,18M,1000000,Free,0,Everyone,Personalization
+"CM Launcher 3D - Theme, Wallpapers, Efficient",PERSONALIZATION,4.6,6702776,17M,100000000,Free,0,Teen,Personalization
+4K Wallpapers and Ultra HD Backgrounds,PERSONALIZATION,4.6,7583,3.8M,500000,Free,0,Everyone 10+,Personalization
+OnePlus Launcher,PERSONALIZATION,4.0,24215,Varies with device,1000000,Free,0,Everyone,Personalization
+Birds Sounds Ringtones & Wallpapers,PERSONALIZATION,4.6,5073,23M,1000000,Free,0,Everyone 10+,Personalization
+Funny Alarm Clock Ringtones,PERSONALIZATION,4.5,15633,14M,1000000,Free,0,Everyone,Personalization
+ZenUI Launcher,PERSONALIZATION,4.7,1141545,15M,50000000,Free,0,Everyone,Personalization
+"Color Call - Caller Screen, LED Flash",PERSONALIZATION,4.7,29485,9.9M,1000000,Free,0,Everyone,Personalization
+New Launcher 2018,PERSONALIZATION,4.4,142393,12M,10000000,Free,0,Everyone,Personalization
+Diamond Zipper Lock Screen,PERSONALIZATION,4.3,71688,12M,10000000,Free,0,Everyone,Personalization
+"Emoji Keyboard - Cute Emoji,GIF, Sticker, Emoticon",PERSONALIZATION,4.7,114851,20M,10000000,Free,0,Everyone,Personalization
+3D Blue Glass Water Keyboard Theme,PERSONALIZATION,4.1,62209,7.4M,10000000,Free,0,Everyone,Personalization
+Backgrounds (HD Wallpapers),PERSONALIZATION,4.7,202474,3.0M,10000000,Free,0,Teen,Personalization
+Smart Launcher 5,PERSONALIZATION,4.4,512102,Varies with device,10000000,Free,0,Everyone,Personalization
+New 2018 Keyboard,PERSONALIZATION,4.6,298321,14M,10000000,Free,0,Everyone,Personalization
+"APUS Launcher - Theme, Wallpaper, Hide Apps",PERSONALIZATION,4.5,5783441,14M,100000000,Free,0,Everyone,Personalization
+ZenUI Themes – Stylish Themes,PERSONALIZATION,4.4,47393,7.2M,10000000,Free,0,Everyone,Personalization
+"Keyboard - wallpapers , photos",PERSONALIZATION,4.4,55525,22M,10000000,Free,0,Everyone,Personalization
+Lovely Cute Pink Kitty Cat Keyboard Theme,PERSONALIZATION,4.3,2267,7.2M,500000,Free,0,Everyone,Personalization
+Apex Launcher,PERSONALIZATION,4.3,266401,Varies with device,10000000,Free,0,Everyone,Personalization
+Microsoft Launcher,PERSONALIZATION,4.6,649568,26M,10000000,Free,0,Everyone,Personalization
+Goku Wallpaper Art,PERSONALIZATION,4.7,6342,38M,1000000,Free,0,Everyone,Personalization
+Door Lock Screen,PERSONALIZATION,4.3,5413,3.9M,1000000,Free,0,Everyone,Personalization
+Yandex Browser with Protect,PERSONALIZATION,4.5,1237135,Varies with device,50000000,Free,0,Everyone,Personalization
+Cute wallpapers & kawaii backgrounds images,PERSONALIZATION,4.6,4724,5.4M,1000000,Free,0,Everyone,Personalization
+ASUS Cover for ZenFone 2,PERSONALIZATION,4.4,43960,9.8M,10000000,Free,0,Everyone,Personalization
+"Hola Launcher- Theme,Wallpaper",PERSONALIZATION,4.5,3277209,7.6M,100000000,Free,0,Everyone,Personalization
+OnePlus Icon Pack - Square,PERSONALIZATION,4.7,229,1.1M,500000,Free,0,Everyone,Personalization
+Live 3D Neon Blue Love Heart Keyboard Theme,PERSONALIZATION,4.3,6626,9.1M,1000000,Free,0,Everyone,Personalization
+Pink Diamond Princess Keyboard Theme,PERSONALIZATION,3.7,10796,6.8M,1000000,Free,0,Everyone,Personalization
+"Wallpapers HD, 4K Backgrounds",PERSONALIZATION,4.7,273994,12M,10000000,Free,0,Everyone,Personalization
+Photo Lock App - Hide Pictures & Videos,PERSONALIZATION,4.5,29203,3.3M,5000000,Free,0,Everyone,Personalization
+Romantic Love Photo Frames,PERSONALIZATION,4.4,18918,12M,5000000,Free,0,Everyone,Personalization
+Colorful Glitter Neon Butterfly Keyboard Theme,PERSONALIZATION,4.3,2056,9.8M,500000,Free,0,Everyone,Personalization
+OnePlus Icon Pack,PERSONALIZATION,4.8,440,920k,500000,Free,0,Everyone,Personalization
+Water Garden Live Wallpaper,PERSONALIZATION,4.6,66453,14M,5000000,Free,0,Everyone,Personalization
+Water Droplets Keyboard Theme,PERSONALIZATION,4.1,398,6.8M,100000,Free,0,Everyone,Personalization
+"FUN Keyboard – Emoji Keyboard, Sticker,Theme & GIF",PERSONALIZATION,4.7,12089,27M,500000,Free,0,Everyone,Personalization
+Freeme Launcher—Stylish Theme,PERSONALIZATION,4.1,2828,7.4M,100000,Free,0,Everyone,Personalization
+ZEDGE™ Ringtones & Wallpapers,PERSONALIZATION,4.6,6466641,Varies with device,100000000,Free,0,Teen,Personalization
+Ringtones & Wallpapers for Me,PERSONALIZATION,4.2,89342,29M,10000000,Free,0,Everyone,Personalization
+Ringtone Maker,PERSONALIZATION,4.3,495905,Varies with device,50000000,Free,0,Everyone,Personalization
+Retro Clock Widget,PERSONALIZATION,4.2,86743,Varies with device,5000000,Free,0,Everyone,Personalization
+Zooper Widget,PERSONALIZATION,4.0,30498,5.9M,1000000,Free,0,Everyone,Personalization
+Beautiful Widgets Pro,PERSONALIZATION,4.2,97890,14M,1000000,Paid,$2.49,Everyone,Personalization
+Beautiful Widgets Free,PERSONALIZATION,3.9,25037,14M,1000000,Free,0,Everyone,Personalization
+HD Widgets,PERSONALIZATION,4.3,58617,26M,1000000,Paid,$0.99,Everyone,Personalization
+DashClock Widget,PERSONALIZATION,4.1,62301,1.9M,1000000,Free,0,Everyone,Personalization
+Fancy Widgets,PERSONALIZATION,4.2,37237,3.9M,5000000,Free,0,Everyone,Personalization
+Kairo XP (for HD Widgets),PERSONALIZATION,4.4,1591,779k,10000,Paid,$0.99,Everyone,Personalization
+icon wallpaper dressup💞CocoPPa,PERSONALIZATION,4.3,595120,Varies with device,10000000,Free,0,Everyone,Personalization
+The real aquarium - HD,PERSONALIZATION,4.3,100130,Varies with device,5000000,Free,0,Everyone,Personalization
+Best Wallpapers QHD,PERSONALIZATION,4.4,294701,5.1M,10000000,Free,0,Teen,Personalization
+Dog Licks Screen Wallpaper,PERSONALIZATION,4.3,63624,10M,5000000,Free,0,Everyone,Personalization
+Waterfall Live Wallpaper,PERSONALIZATION,4.1,112977,13M,10000000,Free,0,Everyone,Personalization
+Galaxy Live Wallpaper,PERSONALIZATION,4.2,58052,4.0M,5000000,Free,0,Teen,Personalization
+Northern Lights FREE (Aurora),PERSONALIZATION,4.1,12180,5.4M,1000000,Free,0,Everyone,Personalization
+Flowers Live Wallpaper,PERSONALIZATION,4.1,118459,3.3M,10000000,Free,0,Everyone,Personalization
+Petals 3D live wallpaper,PERSONALIZATION,4.2,112479,4.3M,10000000,Free,0,Everyone,Personalization
+Galactic Core Free Wallpaper,PERSONALIZATION,4.1,69417,853k,10000000,Free,0,Everyone,Personalization
+LINE Launcher,PERSONALIZATION,4.4,733838,21M,10000000,Free,0,Everyone,Personalization
+Asteroids 3D live wallpaper,PERSONALIZATION,4.1,157495,6.4M,10000000,Free,0,Everyone,Personalization
+Sun Rise Free Live Wallpaper,PERSONALIZATION,4.3,86481,8.6M,10000000,Free,0,Everyone,Personalization
+Wallpapers HD,PERSONALIZATION,4.6,484981,2.1M,10000000,Free,0,Everyone,Personalization
+Tiger Live Wallpaper,PERSONALIZATION,4.1,77724,7.1M,5000000,Free,0,Teen,Personalization
+ZEDGE™ Ringtones & Wallpapers,PERSONALIZATION,4.6,6466641,Varies with device,100000000,Free,0,Teen,Personalization
+Backgrounds HD (Wallpapers),PERSONALIZATION,4.6,2390185,Varies with device,100000000,Free,0,Teen,Personalization
+Pink Roses Live Wallpaper,PERSONALIZATION,4.2,33074,3.3M,1000000,Free,0,Everyone,Personalization
+Butterfly Live Wallpaper,PERSONALIZATION,4.1,35771,3.5M,5000000,Free,0,Everyone,Personalization
+Koi Free Live Wallpaper,PERSONALIZATION,4.2,290241,4.1M,50000000,Free,0,Everyone,Personalization
+Wallpaper,PERSONALIZATION,4.5,69488,9.7M,1000000,Free,0,Everyone,Personalization
+Wolves Live Wallpaper,PERSONALIZATION,4.3,10401,3.3M,1000000,Free,0,Everyone,Personalization
+Horses Live Wallpaper,PERSONALIZATION,4.2,28806,7.1M,1000000,Free,0,Everyone,Personalization
+Tropical Beach Live Wallpaper,PERSONALIZATION,4.0,11343,8.4M,1000000,Free,0,Everyone,Personalization
+Glowing Flowers Live Wallpaper,PERSONALIZATION,4.2,66730,7.0M,5000000,Free,0,Everyone,Personalization
+Dolphins Live Wallpaper,PERSONALIZATION,4.2,25807,5.5M,1000000,Free,0,Everyone,Personalization
+Nova Launcher,PERSONALIZATION,4.6,1121805,Varies with device,50000000,Free,0,Everyone,Personalization
+Apex Launcher,PERSONALIZATION,4.3,266402,Varies with device,10000000,Free,0,Everyone,Personalization
+Smart Launcher 5,PERSONALIZATION,4.4,512106,Varies with device,10000000,Free,0,Everyone,Personalization
+Buzz Launcher-Smart&Free Theme,PERSONALIZATION,4.4,251616,13M,10000000,Free,0,Everyone,Personalization
+Yandex.Shell (Launcher+Dialer),PERSONALIZATION,4.4,87300,Varies with device,1000000,Free,0,Everyone,Personalization
+ADW Launcher 2,PERSONALIZATION,4.3,181399,Varies with device,10000000,Free,0,Everyone,Personalization
+BIG Launcher,PERSONALIZATION,4.3,881,5.9M,10000,Paid,$9.99,Everyone,Personalization
+Smart Launcher Pro 3,PERSONALIZATION,4.6,40704,Varies with device,100000,Paid,$4.49,Everyone,Personalization
+"iKeyboard - emoji, emoticons",PERSONALIZATION,4.5,624924,24M,10000000,Free,0,Everyone,Personalization
+Simple Neon Blue Future Tech Keyboard Theme,PERSONALIZATION,4.1,51145,6.2M,10000000,Free,0,Everyone,Personalization
+ai.type Free Emoji Keyboard,PERSONALIZATION,4.3,647844,Varies with device,10000000,Free,0,Everyone,Personalization
+"GO Keyboard - Emoticon keyboard, Free Theme, GIF",PERSONALIZATION,4.4,2591941,Varies with device,100000000,Free,0,Everyone,Personalization
+TouchPal Purple Butterfly Theme,PERSONALIZATION,4.2,7435,6.9M,1000000,Free,0,Everyone,Personalization
+2018Emoji Keyboard 😂 Emoticons Lite -sticker&gif,PERSONALIZATION,4.2,115773,Varies with device,10000000,Free,0,Everyone,Personalization
+Lavender Emoji Keyboard Theme,PERSONALIZATION,4.1,12008,6.1M,1000000,Free,0,Everyone,Personalization
+Microsoft Word,PRODUCTIVITY,4.5,2084126,Varies with device,500000000,Free,0,Everyone,Productivity
+"All-In-One Toolbox: Cleaner, Booster, App Manager",PRODUCTIVITY,4.7,536926,Varies with device,10000000,Free,0,Everyone,Productivity
+Adobe Acrobat Reader,PRODUCTIVITY,4.3,3016297,Varies with device,100000000,Free,0,Everyone,Productivity
+"AVG Cleaner – Speed, Battery & Memory Booster",PRODUCTIVITY,4.4,1188154,24M,10000000,Free,0,Everyone,Productivity
+Google Drive,PRODUCTIVITY,4.4,2731171,Varies with device,1000000000,Free,0,Everyone,Productivity
+QR Scanner & Barcode Scanner 2018,PRODUCTIVITY,3.8,8226,4.1M,10000000,Free,0,Everyone,Productivity
+Chrome Beta,PRODUCTIVITY,4.4,228794,Varies with device,10000000,Free,0,Everyone,Productivity
+Microsoft Outlook,PRODUCTIVITY,4.3,3252896,50M,100000000,Free,0,Everyone,Productivity
+Google PDF Viewer,PRODUCTIVITY,4.2,226456,Varies with device,10000000,Free,0,Everyone,Productivity
+Microsoft Excel,PRODUCTIVITY,4.5,1079491,Varies with device,100000000,Free,0,Everyone,Productivity
+My Claro Peru,PRODUCTIVITY,3.2,11200,11M,5000000,Free,0,Everyone,Productivity
+Power Booster - Junk Cleaner & CPU Cooler & Boost,PRODUCTIVITY,4.5,9653,5.1M,1000000,Free,0,Everyone,Productivity
+Google Assistant,PRODUCTIVITY,4.2,58675,1.3M,10000000,Free,0,Everyone,Productivity
+Microsoft OneDrive,PRODUCTIVITY,4.4,1038306,Varies with device,100000000,Free,0,Everyone,Productivity
+Calculator - unit converter,PRODUCTIVITY,4.7,287250,Varies with device,50000000,Free,0,Everyone,Productivity
+Microsoft OneNote,PRODUCTIVITY,4.4,480643,Varies with device,100000000,Free,0,Everyone,Productivity
+Metro name iD,PRODUCTIVITY,4.0,27800,Varies with device,10000000,Free,0,Everyone,Productivity
+Google Keep,PRODUCTIVITY,4.4,691474,Varies with device,100000000,Free,0,Everyone,Productivity
+Archos File Manager,PRODUCTIVITY,4.0,2131,2.3M,5000000,Free,0,Everyone,Productivity
+ES File Explorer File Manager,PRODUCTIVITY,4.6,5383985,16M,100000000,Free,0,Everyone,Productivity
+ASUS SuperNote,PRODUCTIVITY,4.5,26559,Varies with device,10000000,Free,0,Everyone,Productivity
+HTC File Manager,PRODUCTIVITY,4.2,13500,Varies with device,10000000,Free,0,Everyone,Productivity
+MyMTN,PRODUCTIVITY,4.0,8550,15M,1000000,Free,0,Everyone,Productivity
+Dropbox,PRODUCTIVITY,4.4,1861310,61M,500000000,Free,0,Everyone,Productivity
+ASUS Quick Memo,PRODUCTIVITY,4.5,23089,1.6M,10000000,Free,0,Everyone,Productivity
+HTC Calendar,PRODUCTIVITY,3.9,6949,Varies with device,10000000,Free,0,Everyone,Productivity
+Google Calendar,PRODUCTIVITY,4.2,858208,Varies with device,500000000,Free,0,Everyone,Productivity
+Google Docs,PRODUCTIVITY,4.3,815981,Varies with device,100000000,Free,0,Everyone,Productivity
+ASUS Calling Screen,PRODUCTIVITY,4.2,102451,Varies with device,10000000,Free,0,Everyone,Productivity
+lifebox,PRODUCTIVITY,4.2,56403,49M,5000000,Free,0,Everyone,Productivity
+Yandex.Disk,PRODUCTIVITY,4.4,115072,Varies with device,5000000,Free,0,Everyone,Productivity
+Content Transfer,PRODUCTIVITY,4.7,19302,7.2M,5000000,Free,0,Everyone,Productivity
+"Evernote – Organizer, Planner for Notes & Memos",PRODUCTIVITY,4.6,1488396,Varies with device,100000000,Free,0,Everyone,Productivity
+HTC Mail,PRODUCTIVITY,3.1,6572,Varies with device,10000000,Free,0,Everyone,Productivity
+Advanced Task Killer,PRODUCTIVITY,4.4,577059,1.5M,50000000,Free,0,Everyone,Productivity
+MyVodafone (India) - Online Recharge & Pay Bills,PRODUCTIVITY,4.1,1092367,Varies with device,10000000,Free,0,Everyone,Productivity
+Microsoft PowerPoint,PRODUCTIVITY,4.5,618798,Varies with device,100000000,Free,0,Everyone,Productivity
+Microsoft Translator,PRODUCTIVITY,4.6,209696,49M,5000000,Free,0,Everyone,Productivity
+"My Airtel-Online Recharge, Pay Bill, Wallet, UPI",PRODUCTIVITY,4.3,1498393,14M,50000000,Free,0,Everyone,Productivity
+Samsung Notes,PRODUCTIVITY,3.9,15368,Varies with device,100000000,Free,0,Everyone,Productivity
+Do It Later: Tasks & To-Dos,PRODUCTIVITY,4.5,123412,Varies with device,50000000,Free,0,Everyone,Productivity
+Verizon Cloud,PRODUCTIVITY,4.3,185632,Varies with device,50000000,Free,0,Everyone,Productivity
+myAT&T,PRODUCTIVITY,3.7,80847,Varies with device,50000000,Free,0,Everyone,Productivity
+SwiftKey Keyboard,PRODUCTIVITY,4.5,2764964,Varies with device,100000000,Free,0,Everyone,Productivity
+Hacker's Keyboard,PRODUCTIVITY,4.4,41418,1.2M,1000000,Free,0,Everyone,Productivity
+MEGA,PRODUCTIVITY,4.0,549973,Varies with device,50000000,Free,0,Everyone,Productivity
+Security & Privacy,PRODUCTIVITY,4.0,212,10.0M,1000000,Free,0,Everyone,Productivity
+7 Weeks - Habit & Goal Tracker,PRODUCTIVITY,4.4,6011,4.3M,500000,Free,0,Everyone,Productivity
+Loop - Habit Tracker,PRODUCTIVITY,4.7,17955,3.8M,1000000,Free,0,Everyone,Productivity
+"TickTick: To Do List with Reminder, Day Planner",PRODUCTIVITY,4.6,25370,Varies with device,1000000,Free,0,Everyone,Productivity
+Keeper: Free Password Manager & Secure Vault,PRODUCTIVITY,4.2,74146,32M,10000000,Free,0,Everyone,Productivity
+Pushbullet - SMS on PC,PRODUCTIVITY,4.5,176873,4.5M,1000000,Free,0,Everyone,Productivity
+Wunderlist: To-Do List & Tasks,PRODUCTIVITY,4.6,404617,Varies with device,10000000,Free,0,Everyone,Productivity
+Planner Pro-Personal Organizer,PRODUCTIVITY,4.0,10270,8.4M,1000000,Free,0,Everyone,Productivity
+Todoist: To-do lists for task management & errands,PRODUCTIVITY,4.5,155999,12M,10000000,Free,0,Everyone,Productivity
+Cozi Family Organizer,PRODUCTIVITY,4.4,56713,25M,1000000,Free,0,Everyone,Productivity
+IFTTT,PRODUCTIVITY,4.3,117255,Varies with device,1000000,Free,0,Everyone,Productivity
+Google Keep,PRODUCTIVITY,4.4,691474,Varies with device,100000000,Free,0,Everyone,Productivity
+"Any.do: To-do list, Calendar, Reminders & Planner",PRODUCTIVITY,4.5,298843,Varies with device,10000000,Free,0,Everyone,Productivity
+Trello,PRODUCTIVITY,4.5,72513,12M,5000000,Free,0,Everyone,Productivity
+"Evernote – Organizer, Planner for Notes & Memos",PRODUCTIVITY,4.6,1488396,Varies with device,100000000,Free,0,Everyone,Productivity
+Easy Voice Recorder,PRODUCTIVITY,4.4,205191,7.1M,10000000,Free,0,Everyone,Productivity
+Dashlane Free Password Manager,PRODUCTIVITY,4.6,73695,Varies with device,1000000,Free,0,Everyone,Productivity
+CM FILE MANAGER HD,PRODUCTIVITY,4.3,144879,Varies with device,10000000,Free,0,Everyone,Productivity
+ES File Explorer File Manager,PRODUCTIVITY,4.6,5383971,16M,100000000,Free,0,Everyone,Productivity
+Solid Explorer Classic,PRODUCTIVITY,4.5,49794,6.5M,1000000,Free,0,Everyone,Productivity
+File Browser by Astro (File Manager),PRODUCTIVITY,4.3,609182,9.2M,50000000,Free,0,Everyone,Productivity
+File Explorer,PRODUCTIVITY,4.1,979,720k,100000,Free,0,Everyone,Productivity
+The Maner,PRODUCTIVITY,4.2,53015,2.2M,5000000,Free,0,Everyone,Productivity
+AndroZip™ FREE File Manager,PRODUCTIVITY,4.2,277794,Varies with device,10000000,Free,0,Everyone,Productivity
+Solid Explorer File Manager,PRODUCTIVITY,4.6,67523,Varies with device,1000000,Free,0,Everyone,Productivity
+Smart File Manager,PRODUCTIVITY,4.2,17415,4.1M,1000000,Free,0,Everyone,Productivity
+Microsoft Word,PRODUCTIVITY,4.5,2084125,Varies with device,500000000,Free,0,Everyone,Productivity
+Google Drive,PRODUCTIVITY,4.4,2731211,Varies with device,1000000000,Free,0,Everyone,Productivity
+Adobe Acrobat Reader,PRODUCTIVITY,4.3,3016305,Varies with device,100000000,Free,0,Everyone,Productivity
+Google PDF Viewer,PRODUCTIVITY,4.2,226456,Varies with device,10000000,Free,0,Everyone,Productivity
+Google Sheets,PRODUCTIVITY,4.3,496399,Varies with device,100000000,Free,0,Everyone,Productivity
+Microsoft Excel,PRODUCTIVITY,4.5,1079616,Varies with device,100000000,Free,0,Everyone,Productivity
+Google Docs,PRODUCTIVITY,4.3,815974,Varies with device,100000000,Free,0,Everyone,Productivity
+"Polaris Office - Word, Docs, Sheets, Slide, PDF",PRODUCTIVITY,4.3,549900,60M,10000000,Free,0,Everyone,Productivity
+Microsoft PowerPoint,PRODUCTIVITY,4.5,618796,Varies with device,100000000,Free,0,Everyone,Productivity
+"WPS Office - Word, Docs, PDF, Note, Slide & Sheet",PRODUCTIVITY,4.5,1508137,37M,100000000,Free,0,Everyone,Productivity
+Microsoft OneNote,PRODUCTIVITY,4.4,480640,Varies with device,100000000,Free,0,Everyone,Productivity
+Google Calendar,PRODUCTIVITY,4.2,858227,Varies with device,500000000,Free,0,Everyone,Productivity
+Google Slides,PRODUCTIVITY,4.2,244567,Varies with device,100000000,Free,0,Everyone,Productivity
+ColorNote Notepad Notes,PRODUCTIVITY,4.6,2401017,Varies with device,100000000,Free,0,Everyone,Productivity
+Note Everything,PRODUCTIVITY,4.4,57033,Varies with device,5000000,Free,0,Everyone,Productivity
+Simple Notepad,PRODUCTIVITY,4.3,12321,713k,1000000,Free,0,Everyone,Productivity
+Keep My Notes - Notepad & Memo,PRODUCTIVITY,4.6,122424,4.7M,5000000,Free,0,Everyone,Productivity
+Sticky Note + : Sync Notes,PRODUCTIVITY,4.2,21507,6.6M,1000000,Free,0,Everyone,Productivity
+Notepad,PRODUCTIVITY,4.2,80581,2.5M,10000000,Free,0,Everyone,Productivity
+Squid - Take Notes & Markup PDFs,PRODUCTIVITY,4.2,37204,19M,1000000,Free,0,Everyone,Productivity
+Ultimate Notepad,PRODUCTIVITY,4.0,10643,Varies with device,5000000,Free,0,Everyone,Productivity
+Notepad & To do list,PRODUCTIVITY,4.3,226295,4.2M,10000000,Free,0,Everyone,Productivity
+"JotterPad - Writer, Screenplay, Novel",PRODUCTIVITY,4.6,57904,11M,1000000,Free,0,Everyone,Productivity
+Google Keep,PRODUCTIVITY,4.4,691474,Varies with device,100000000,Free,0,Everyone,Productivity
+Wunderlist: To-Do List & Tasks,PRODUCTIVITY,4.6,404610,Varies with device,10000000,Free,0,Everyone,Productivity
+"Evernote – Organizer, Planner for Notes & Memos",PRODUCTIVITY,4.6,1488397,Varies with device,100000000,Free,0,Everyone,Productivity
+"Any.do: To-do list, Calendar, Reminders & Planner",PRODUCTIVITY,4.5,298854,Varies with device,10000000,Free,0,Everyone,Productivity
+Todoist: To-do lists for task management & errands,PRODUCTIVITY,4.5,155999,12M,10000000,Free,0,Everyone,Productivity
+Microsoft OneNote,PRODUCTIVITY,4.4,480638,Varies with device,100000000,Free,0,Everyone,Productivity
+Planning Center Services,PRODUCTIVITY,4.3,5157,Varies with device,500000,Free,0,Everyone,Productivity
+Calendar+ Schedule Planner App,PRODUCTIVITY,4.0,8985,5.7M,1000000,Free,0,Everyone,Productivity
+Today Calendar 2017,PRODUCTIVITY,4.2,16349,9.0M,1000000,Free,0,Everyone,Productivity
+To-Do Calendar Planner,PRODUCTIVITY,4.2,30291,Varies with device,1000000,Free,0,Everyone,Productivity
+New Calendar,PRODUCTIVITY,4.5,25985,6.9M,1000000,Free,0,Everyone,Productivity
+Planner Pro-Personal Organizer,PRODUCTIVITY,4.0,10270,8.4M,1000000,Free,0,Everyone,Productivity
+Calendar Widget Month + Agenda,PRODUCTIVITY,4.2,60840,1.9M,5000000,Free,0,Everyone,Productivity
+DigiCal Calendar Agenda,PRODUCTIVITY,4.4,133573,Varies with device,5000000,Free,0,Everyone,Productivity
+Time Recording - Timesheet App,PRODUCTIVITY,4.6,23393,Varies with device,1000000,Free,0,Everyone,Productivity
+Jorte Calendar & Organizer,PRODUCTIVITY,4.3,198051,Varies with device,10000000,Free,0,Everyone,Productivity
+Business Calendar 2,PRODUCTIVITY,4.6,102594,15M,5000000,Free,0,Everyone,Productivity
+Google Calendar,PRODUCTIVITY,4.2,858230,Varies with device,500000000,Free,0,Everyone,Productivity
+aCalendar - Android Phone,PRODUCTIVITY,4.4,80119,Varies with device,10000000,Free,0,Everyone,Productivity
+aCalendar+ Calendar & Tasks,PRODUCTIVITY,4.6,26919,Varies with device,100000,Paid,$5.99,Everyone,Productivity
+Google Drive,PRODUCTIVITY,4.4,2731211,Varies with device,1000000000,Free,0,Everyone,Productivity
+G Cloud Backup,PRODUCTIVITY,4.6,267189,Varies with device,5000000,Free,0,Everyone,Productivity
+Microsoft OneDrive,PRODUCTIVITY,4.4,1038303,Varies with device,100000000,Free,0,Everyone,Productivity
+Unclouded - Cloud Manager,PRODUCTIVITY,4.1,6850,11M,100000,Free,0,Everyone,Productivity
+Dropbox,PRODUCTIVITY,4.4,1861309,61M,500000000,Free,0,Everyone,Productivity
+Amazon Drive,PRODUCTIVITY,4.4,18669,4.1M,1000000,Free,0,Everyone,Productivity
+SugarSync,PRODUCTIVITY,4.1,16420,3.8M,1000000,Free,0,Everyone,Productivity
+pCloud: Free Cloud Storage,PRODUCTIVITY,4.3,16149,Varies with device,1000000,Free,0,Everyone,Productivity
+MediaFire,PRODUCTIVITY,4.1,71432,3.8M,5000000,Free,0,Everyone,Productivity
+Cloud Print,PRODUCTIVITY,4.1,282460,Varies with device,500000000,Free,0,Everyone,Productivity
+Baby Names,PARENTING,4.5,86,2.8M,10000,Free,0,Everyone,Parenting
+My baby Piano,PARENTING,3.9,17941,Varies with device,5000000,Free,0,Everyone,Parenting;Music & Video
+Zoo For Preschool Kids 3-9 Years,PARENTING,4.3,76,8.2M,10000,Free,0,Everyone,Parenting;Education
+My baby Game (Balloon POP!),PARENTING,3.8,3614,3.3M,1000000,Free,0,Everyone,Parenting;Brain Games
+Arabic Alphabets,PARENTING,4.3,34,6.2M,10000,Free,0,Everyone,Parenting
+Learn the letters and words,PARENTING,4.3,31,85M,10000,Free,0,Everyone,Parenting;Education
+Development of the child up to a year,PARENTING,4.6,1413,14M,100000,Free,0,Mature 17+,Parenting
+Favorite children's songs,PARENTING,4.7,39,95M,10000,Free,0,Everyone,Parenting
+Ali Baba's Farm Tutorial Kids Games,PARENTING,4.3,36,5.5M,5000,Free,0,Everyone,Parenting
+Baby Panda Learns Shapes,PARENTING,4.0,3789,42M,1000000,Free,0,Everyone,Parenting;Education
+Learning English for children,PARENTING,4.3,67,15M,50000,Free,0,Everyone,Parenting;Education
+Mozart Baby Sleep,PARENTING,4.7,107,98M,50000,Free,0,Teen,Parenting
+Kids Videos,PARENTING,4.1,559,6.4M,100000,Free,0,Everyone,Parenting
+My baby firework,PARENTING,3.7,4976,2.8M,1000000,Free,0,Everyone,Parenting;Education
+We learn children's verses in kindergarten,PARENTING,4.3,3248,6.5M,100000,Free,0,Everyone,Parenting;Education
+Baby Food - Homemade Recipes,PARENTING,4.1,44,3.6M,10000,Free,0,Everyone,Parenting
+My baby Phone,PARENTING,3.7,9293,2.4M,1000000,Free,0,Everyone,Parenting
+Baby Sleep: White noise lullabies for newborns,PARENTING,4.6,62386,3.4M,1000000,Free,0,Everyone,Parenting
+Arabic Chat - Chat,PARENTING,4.4,162,1.5M,10000,Free,0,Everyone,Parenting
+BookBaby - Baby Development,PARENTING,4.6,1002,5.0M,50000,Free,0,Everyone,Parenting
+Kids Craft Ideas,PARENTING,4.1,99,6.6M,10000,Free,0,Everyone,Parenting
+Child Growth Tracking,PARENTING,4.4,498,Varies with device,50000,Free,0,Everyone,Parenting
+Family Album Mitene: Private Photo & Video Sharing,PARENTING,4.7,34336,Varies with device,1000000,Free,0,Everyone,Parenting
+Family GPS Tracker and Chat + Baby Monitor Online,PARENTING,4.4,9073,Varies with device,500000,Free,0,Everyone,Parenting
+Educational Children's Songs,PARENTING,4.3,163,59M,100000,Free,0,Everyone,Parenting
+How do I take care of my child?,PARENTING,4.8,190,6.8M,100000,Free,0,Everyone,Parenting
+Baby Name Together,PARENTING,4.0,464,24M,100000,Free,0,Everyone,Parenting
+White Noise for Baby,PARENTING,4.9,717,6.6M,100000,Free,0,Everyone,Parenting
+Favorite Soviet cartoons,PARENTING,4.3,63,4.9M,10000,Free,0,Everyone,Parenting
+The first year of a baby's life,PARENTING,4.8,7505,9.1M,100000,Free,0,Everyone,Parenting
+Safe365 – Cell Phone GPS Locator For Your Family,PARENTING,4.4,11501,11M,1000000,Free,0,Everyone,Parenting
+Listen to the story~The Story of the Fairy Tales,PARENTING,4.7,69,5.8M,5000,Free,0,Everyone,Parenting
+"Amazon FreeTime – Kids’ Videos, Books, & TV shows",PARENTING,4.2,2715,24M,500000,Free,0,Everyone,Parenting;Music & Video
+"Kids Fang - Infant Videos, Children's Songs, Fairy Tales, Lullaby Collections",PARENTING,4.6,349,4.4M,100000,Free,0,Everyone,Parenting
+PPS Online,PARENTING,4.6,37,16M,10000,Free,0,Everyone,Parenting
+Johny Johny Yes Papa Nursery Rhyme - offline Video,PARENTING,4.5,806,11M,500000,Free,0,Everyone,Parenting
+Latest Emmanuella Comedy Video,PARENTING,4.6,60,4.9M,10000,Free,0,Everyone,Parenting
+Baby Care & Tracker,PARENTING,4.1,319,11M,100000,Free,0,Everyone,Parenting
+Urban Limo Taxi Simulator,PARENTING,3.8,824,53M,1000000,Free,0,Everyone,Parenting
+Rainbow - Journal & Activities,PARENTING,4.8,6668,20M,100000,Free,0,Everyone,Parenting
+Classical music for baby,PARENTING,4.8,1940,38M,100000,Free,0,Everyone,Parenting;Music & Video
+How do I care about my child?,PARENTING,4.3,34,4.9M,10000,Free,0,Everyone,Parenting
+My Child from eDziecko.pl,PARENTING,4.5,1025,17M,100000,Free,0,Everyone,Parenting
+Baby Panda Musical Genius,PARENTING,4.0,3346,37M,1000000,Free,0,Everyone,Parenting;Music & Video
+Baby Monitor,PARENTING,4.4,5343,5.2M,1000000,Free,0,Everyone,Parenting
+Daniel Tiger for Parents,PARENTING,4.7,247,28M,100000,Free,0,Everyone,Parenting;Music & Video
+Voice Tables - no internet,PARENTING,4.3,970,71M,100000,Free,0,Everyone,Parenting
+Vegetable Fun,PARENTING,3.9,3182,46M,1000000,Free,0,Everyone,Parenting;Education
+It's open.,PARENTING,4.4,1528,16M,100000,Free,0,Everyone,Parenting
+Children's Stories 2018 - The Lion Come Lion,PARENTING,4.4,39,18M,10000,Free,0,Everyone,Parenting;Music & Video
+Feed Baby - Baby Tracker,PARENTING,4.5,76795,18M,1000000,Free,0,Everyone,Parenting
+The Weather Channel: Rain Forecast & Storm Alerts,WEATHER,4.4,1558437,Varies with device,50000000,Free,0,Everyone,Weather
+Weather forecast,WEATHER,4.8,159455,10M,1000000,Free,0,Everyone,Weather
+AccuWeather: Daily Forecast & Live Weather Reports,WEATHER,4.4,2053404,Varies with device,50000000,Free,0,Everyone,Weather
+Live Weather Pro,WEATHER,4.8,892,17M,10000,Free,0,Everyone,Weather
+"Weather by WeatherBug: Forecast, Radar & Alerts",WEATHER,4.5,981995,Varies with device,10000000,Free,0,Everyone,Weather
+weather - weather forecast,WEATHER,4.7,11118,9.7M,1000000,Free,0,Everyone,Weather
+MyRadar NOAA Weather Radar,WEATHER,4.5,178934,Varies with device,10000000,Free,0,Everyone,Weather
+SMHI Weather,WEATHER,3.5,11297,Varies with device,1000000,Free,0,Everyone,Weather
+Free live weather on screen,WEATHER,4.4,15370,21M,1000000,Free,0,Everyone,Weather
+Weather Radar Widget,WEATHER,4.3,18194,3.2M,1000000,Free,0,Everyone,Weather
+Weather –Simple weather forecast,WEATHER,4.4,40606,15M,10000000,Free,0,Everyone,Weather
+Weather Crave,WEATHER,4.2,133338,44M,5000000,Free,0,Everyone,Weather
+Klara weather,WEATHER,4.6,36900,4.8M,500000,Free,0,Everyone,Weather
+Yahoo Weather,WEATHER,4.4,1312037,Varies with device,10000000,Free,0,Everyone,Weather
+Real time Weather Forecast,WEATHER,4.4,4184,10M,1000000,Free,0,Everyone,Weather
+METEO FRANCE,WEATHER,3.9,100994,54M,5000000,Free,0,Everyone,Weather
+APE Weather ( Live Forecast),WEATHER,4.3,20008,9.1M,5000000,Free,0,Everyone,Weather
+Live Weather & Daily Local Weather Forecast,WEATHER,4.5,13426,19M,1000000,Free,0,Everyone,Weather
+Weather,WEATHER,4.2,18773,12M,10000000,Free,0,Everyone,Weather
+Rainfall radar - weather,WEATHER,3.7,26941,Varies with device,5000000,Free,0,Everyone,Weather
+Yahoo! Weather for SH Forecast for understanding the approach of rain clouds Free,WEATHER,4.2,7457,Varies with device,1000000,Free,0,Everyone,Weather
+The Weather Network,WEATHER,3.9,135337,Varies with device,5000000,Free,0,Everyone,Weather
+Klart.se - Sweden's best weather,WEATHER,3.6,7623,19M,1000000,Free,0,Everyone,Weather
+"GO Weather - Widget, Theme, Wallpaper, Efficient",WEATHER,4.5,1422858,Varies with device,50000000,Free,0,Everyone,Weather
+Info BMKG,WEATHER,4.3,21404,7.6M,1000000,Free,0,Everyone,Weather
+Weather From DMI/YR,WEATHER,4.3,2143,Varies with device,100000,Free,0,Everyone,Weather
+wetter.com - Weather and Radar,WEATHER,4.2,189313,38M,10000000,Free,0,Everyone,Weather
+Storm Radar: Tornado Tracker & Hurricane Alerts,WEATHER,4.6,89868,Varies with device,1000000,Free,0,Everyone,Weather
+Yandex.Weather,WEATHER,4.5,309617,Varies with device,10000000,Free,0,Everyone,Weather
+Local Weather Forecast & Visual Widget,WEATHER,4.5,3478,6.1M,500000,Free,0,Everyone,Weather
+Wetter by t-online.de,WEATHER,4.2,24349,9.2M,1000000,Free,0,Everyone,Weather
+HTC Weather,WEATHER,3.9,22154,Varies with device,10000000,Free,0,Everyone,Weather
+Weather Live Pro,WEATHER,4.8,17493,11M,100000,Paid,$4.49,Everyone,Weather
+AEMET's time,WEATHER,3.8,15966,9.2M,1000000,Free,0,Everyone,Weather
+New 2018 Weather App & Widget,WEATHER,4.5,2332,20M,500000,Free,0,Teen,Weather
+Météociel,WEATHER,4.5,29344,22M,500000,Free,0,Everyone,Weather
+Weather by eltiempo.es,WEATHER,4.2,67772,Varies with device,5000000,Free,0,Everyone,Weather
+Climatempo Lite - 15 day weather forecast,WEATHER,4.0,634,Varies with device,100000,Free,0,Everyone,Weather
+ForecaWeather,WEATHER,4.2,18425,5.3M,1000000,Free,0,Everyone,Weather
+YouTube,VIDEO_PLAYERS,4.3,25655305,Varies with device,1000000000,Free,0,Teen,Video Players & Editors
+All Video Downloader 2018,VIDEO_PLAYERS,4.3,7557,5.6M,1000000,Free,0,Everyone,Video Players & Editors
+Video Downloader,VIDEO_PLAYERS,4.2,59089,5.4M,10000000,Free,0,Everyone,Video Players & Editors
+HD Video Player,VIDEO_PLAYERS,4.3,1551,2.9M,1000000,Free,0,Everyone,Video Players & Editors
+Iqiyi (for tablet),VIDEO_PLAYERS,3.6,12764,25M,1000000,Free,0,Teen,Video Players & Editors
+Motorola FM Radio,VIDEO_PLAYERS,3.9,54807,Varies with device,100000000,Free,0,Everyone,Video Players & Editors
+Video Player All Format,VIDEO_PLAYERS,4.8,259003,Varies with device,10000000,Free,0,Everyone,Video Players & Editors
+Motorola Gallery,VIDEO_PLAYERS,3.9,121916,23M,100000000,Free,0,Everyone,Video Players & Editors
+Free TV series,VIDEO_PLAYERS,3.7,400,7.2M,100000,Free,0,Teen,Video Players & Editors
+Video Player All Format for Android,VIDEO_PLAYERS,4.6,3930,3.3M,500000,Free,0,Everyone,Video Players & Editors
+VLC for Android,VIDEO_PLAYERS,4.4,1032076,Varies with device,100000000,Free,0,Everyone,Video Players & Editors
+Code,VIDEO_PLAYERS,4.4,239242,Varies with device,10000000,Free,0,Everyone,Video Players & Editors
+Vote for,VIDEO_PLAYERS,4.2,193381,17M,50000000,Free,0,Teen,Video Players & Editors
+XX HD Video downloader-Free Video Downloader,VIDEO_PLAYERS,4.1,7624,6.0M,1000000,Free,0,Everyone,Video Players & Editors
+OBJECTIVE,VIDEO_PLAYERS,3.8,19738,33M,1000000,Free,0,Teen,Video Players & Editors
+Music - Mp3 Player,VIDEO_PLAYERS,4.4,259605,3.1M,10000000,Free,0,Everyone,Video Players & Editors
+HD Movie Video Player,VIDEO_PLAYERS,4.5,18699,4.1M,1000000,Free,0,Everyone,Video Players & Editors
+"YouCut - Video Editor & Video Maker, No Watermark",VIDEO_PLAYERS,4.6,98819,27M,5000000,Free,0,Everyone,Video Players & Editors
+"Video Editor,Crop Video,Movie Video,Music,Effects",VIDEO_PLAYERS,4.7,53006,44M,1000000,Free,0,Everyone,Video Players & Editors
+YouTube Studio,VIDEO_PLAYERS,4.3,436921,Varies with device,10000000,Free,0,Teen,Video Players & Editors
+video player for android,VIDEO_PLAYERS,4.5,351168,13M,10000000,Free,0,Everyone,Video Players & Editors
+Vigo Video,VIDEO_PLAYERS,4.3,1615596,Varies with device,50000000,Free,0,Teen,Video Players & Editors
+Google Play Movies & TV,VIDEO_PLAYERS,3.7,906384,Varies with device,1000000000,Free,0,Teen,Video Players & Editors
+HTC Service － DLNA,VIDEO_PLAYERS,3.9,3484,3.0M,10000000,Free,0,Everyone,Video Players & Editors
+VPlayer,VIDEO_PLAYERS,3.6,5639,Varies with device,1000000,Free,0,Everyone,Video Players & Editors
+MiniMovie - Free Video and Slideshow Editor,VIDEO_PLAYERS,4.5,504823,Varies with device,50000000,Free,0,Everyone,Video Players & Editors
+Samsung Video Library,VIDEO_PLAYERS,4.4,25922,6.1M,50000000,Free,0,Everyone,Video Players & Editors
+OnePlus Gallery,VIDEO_PLAYERS,3.8,5555,64M,1000000,Free,0,Everyone,Video Players & Editors
+LIKE – Magic Video Maker & Community,VIDEO_PLAYERS,4.6,921868,47M,50000000,Free,0,Teen,Video Players & Editors
+HTC Service—Video Player,VIDEO_PLAYERS,4.2,6449,Varies with device,5000000,Free,0,Everyone,Video Players & Editors
+Play Tube,VIDEO_PLAYERS,4.3,15874,5.4M,1000000,Free,0,Everyone,Video Players & Editors
+Droid Zap by Motorola,VIDEO_PLAYERS,3.8,2093,Varies with device,5000000,Free,0,Everyone,Video Players & Editors
+video player,VIDEO_PLAYERS,4.4,26421,Varies with device,1000000,Free,0,Everyone,Video Players & Editors
+G Guide Program Guide (SOFTBANK EMOBILE WILLCOM version),VIDEO_PLAYERS,3.1,2689,Varies with device,1000000,Free,0,Everyone,Video Players & Editors
+Video.Guru - Video Maker,VIDEO_PLAYERS,4.6,36969,27M,1000000,Free,0,Everyone,Video Players & Editors
+HTC Gallery,VIDEO_PLAYERS,4.1,45744,Varies with device,10000000,Free,0,Everyone,Video Players & Editors
+"PowerDirector Video Editor App: 4K, Slow Mo & More",VIDEO_PLAYERS,4.5,714665,50M,10000000,Free,0,Everyone,Video Players & Editors
+Cartoon Network App,VIDEO_PLAYERS,4.0,119202,Varies with device,10000000,Free,0,Everyone 10+,Video Players & Editors;Music & Video
+MX Player,VIDEO_PLAYERS,4.5,6474426,Varies with device,500000000,Free,0,Everyone,Video Players & Editors
+Video Status,VIDEO_PLAYERS,4.3,6685,4.0M,1000000,Free,0,Everyone,Video Players & Editors
+Video Wallpaper Show,VIDEO_PLAYERS,4.1,0,13M,500,Free,0,Everyone,Video Players & Editors
+SVT Play,VIDEO_PLAYERS,3.7,11549,Varies with device,1000000,Free,0,Teen,Video Players & Editors
+BluTV,VIDEO_PLAYERS,3.9,28835,Varies with device,1000000,Free,0,Teen,Video Players & Editors
+Tencent Video - Supporting the whole network,VIDEO_PLAYERS,3.5,13205,44M,1000000,Free,0,Teen,Video Players & Editors
+Casper Ssinema,VIDEO_PLAYERS,3.3,1261,2.5M,10000,Free,0,Everyone,Video Players & Editors
+amazer - Global Kpop Video Community,VIDEO_PLAYERS,4.3,1215,23M,100000,Free,0,Everyone 10+,Video Players & Editors
+MX Player,VIDEO_PLAYERS,4.5,6474672,Varies with device,500000000,Free,0,Everyone,Video Players & Editors
+Video Editor,VIDEO_PLAYERS,4.1,159622,23M,5000000,Free,0,Everyone,Video Players & Editors;Creativity
+"Omlet Arcade - Stream, Meet, Play",VIDEO_PLAYERS,4.4,169965,14M,10000000,Free,0,Teen,Video Players & Editors
+VUE: video editor & camcorder,VIDEO_PLAYERS,4.4,38630,89M,1000000,Free,0,Everyone,Video Players & Editors
+"Fox News – Breaking News, Live Video & News Alerts",NEWS_AND_MAGAZINES,4.5,249919,Varies with device,10000000,Free,0,Everyone 10+,News & Magazines
+"NEW - Read Newspaper, News 24h",NEWS_AND_MAGAZINES,4.4,158196,Varies with device,10000000,Free,0,Everyone,News & Magazines
+BaBe + - Indonesian News,NEWS_AND_MAGAZINES,4.3,42624,16M,1000000,Free,0,Everyone 10+,News & Magazines
+daily News,NEWS_AND_MAGAZINES,4.5,26411,26M,1000000,Free,0,Everyone,News & Magazines
+BBC News,NEWS_AND_MAGAZINES,4.3,296781,Varies with device,10000000,Free,0,Everyone 10+,News & Magazines
+"Free TV Shows App:News, TV Series, Episode, Movies",NEWS_AND_MAGAZINES,4.6,29706,11M,1000000,Free,0,Teen,News & Magazines
+News24,NEWS_AND_MAGAZINES,4.1,30693,Varies with device,1000000,Free,0,Everyone 10+,News & Magazines
+"Le Monde, the continuous news",NEWS_AND_MAGAZINES,4.2,83558,Varies with device,5000000,Free,0,Everyone,News & Magazines
+Wireless news,NEWS_AND_MAGAZINES,3.5,6066,56M,1000000,Free,0,Everyone,News & Magazines
+CNN Breaking US & World News,NEWS_AND_MAGAZINES,4.0,293080,25M,10000000,Free,0,Everyone 10+,News & Magazines
+Gnoche entertainment news · sports news is also free,NEWS_AND_MAGAZINES,3.8,54256,Varies with device,5000000,Free,0,Everyone,News & Magazines
+BaBe - Read News,NEWS_AND_MAGAZINES,4.3,355921,17M,10000000,Free,0,Teen,News & Magazines
+Nigeria News NAIJ.com,NEWS_AND_MAGAZINES,4.3,37882,9.1M,1000000,Free,0,Teen,News & Magazines
+detikcom - Latest & Most Complete News,NEWS_AND_MAGAZINES,4.1,190888,11M,10000000,Free,0,Teen,News & Magazines
+"Dailyhunt (Newshunt) - Latest News, Viral Videos",NEWS_AND_MAGAZINES,4.3,948198,Varies with device,50000000,Free,0,Teen,News & Magazines
+BaBe Lite - Read Quota Saving News,NEWS_AND_MAGAZINES,4.5,9548,15M,1000000,Free,0,Everyone,News & Magazines
+ARY NEWS URDU,NEWS_AND_MAGAZINES,4.4,1071,9.7M,500000,Free,0,Everyone,News & Magazines
+Bengali Newspaper - The first L.,NEWS_AND_MAGAZINES,4.0,11908,5.5M,1000000,Free,0,Everyone,News & Magazines
+"Read- Latest News, Information, Gossip and Politics",NEWS_AND_MAGAZINES,4.1,185058,6.7M,10000000,Free,0,Teen,News & Magazines
+"Reddit: Social News, Trending Memes & Funny Videos",NEWS_AND_MAGAZINES,4.6,697212,Varies with device,10000000,Free,0,Mature 17+,News & Magazines
+BBC Persian | BBC Farsi News,NEWS_AND_MAGAZINES,4.3,978,2.9M,100000,Free,0,Everyone,News & Magazines
+Google News,NEWS_AND_MAGAZINES,3.9,877635,13M,1000000000,Free,0,Teen,News & Magazines
+Opera News - Trending news and videos,NEWS_AND_MAGAZINES,4.5,51684,8.5M,10000000,Free,0,Teen,News & Magazines
+"Topbuzz: Breaking News, Videos & Funny GIFs",NEWS_AND_MAGAZINES,4.7,175110,25M,10000000,Free,0,Mature 17+,News & Magazines
+Twitter,NEWS_AND_MAGAZINES,4.3,11667403,Varies with device,500000000,Free,0,Mature 17+,News & Magazines
+"Pulse Nabd - World News, Urgent",NEWS_AND_MAGAZINES,4.5,357944,12M,10000000,Free,0,Everyone,News & Magazines
+Asahi Shimbun Digital,NEWS_AND_MAGAZINES,3.1,735,6.3M,500000,Free,0,Everyone,News & Magazines
+"Breaking News, Local news, Attacks and Alerts Free",NEWS_AND_MAGAZINES,4.7,2543,6.3M,500000,Free,0,Everyone,News & Magazines
+WE,NEWS_AND_MAGAZINES,3.8,18818,Varies with device,1000000,Free,0,Everyone 10+,News & Magazines
+Sky News,NEWS_AND_MAGAZINES,4.0,30287,19M,1000000,Free,0,Everyone 10+,News & Magazines
+Microsoft News,NEWS_AND_MAGAZINES,4.2,31504,31M,1000000,Free,0,Everyone 10+,News & Magazines
+"Onet - news, weather, sport",NEWS_AND_MAGAZINES,4.0,13950,Varies with device,1000000,Free,0,Mature 17+,News & Magazines
+"Vietnam Today - Read online newspapers, the hottest news 24h",NEWS_AND_MAGAZINES,4.2,21147,9.0M,5000000,Free,0,Teen,News & Magazines
+Apple Daily Apple News,NEWS_AND_MAGAZINES,3.4,41490,25M,5000000,Free,0,Teen,News & Magazines
+"The Report, Fox, Breitbart - Conservative News",NEWS_AND_MAGAZINES,4.6,2090,4.6M,50000,Free,0,Everyone,News & Magazines
+РИА Новости,NEWS_AND_MAGAZINES,4.5,44274,8.0M,1000000,Free,0,Everyone,News & Magazines
+Tencent News,NEWS_AND_MAGAZINES,4.0,7006,23M,1000000,Free,0,Everyone,News & Magazines
+ARY NEWS,NEWS_AND_MAGAZINES,4.4,2959,9.8M,1000000,Free,0,Everyone,News & Magazines
+Kurio - Read the Latest News,NEWS_AND_MAGAZINES,4.2,40167,8.7M,1000000,Free,0,Everyone,News & Magazines
+Daily Mail Online,NEWS_AND_MAGAZINES,4.1,56807,Varies with device,5000000,Free,0,Everyone 10+,News & Magazines
+Flipboard: News For Our Time,NEWS_AND_MAGAZINES,4.4,1284017,Varies with device,500000000,Free,0,Everyone 10+,News & Magazines
+Loop - Caribbean Local News,NEWS_AND_MAGAZINES,4.0,4332,12M,1000000,Free,0,Everyone,News & Magazines
+"AD - News, Sports, Region & Entertainment",NEWS_AND_MAGAZINES,3.7,10382,Varies with device,1000000,Free,0,Everyone,News & Magazines
+Podcast Addict,NEWS_AND_MAGAZINES,4.6,413999,10M,5000000,Free,0,Teen,News & Magazines
+Podcast Republic - Podcast Player & Radio Player,NEWS_AND_MAGAZINES,4.5,66978,Varies with device,1000000,Free,0,Teen,News & Magazines
+Podcast App: Free & Offline Podcasts by Player FM,NEWS_AND_MAGAZINES,4.6,66384,19M,1000000,Free,0,Teen,News & Magazines
+Spreaker Podcast Radio,NEWS_AND_MAGAZINES,4.5,17703,6.6M,500000,Free,0,Teen,News & Magazines
+BeyondPod Podcast Manager,NEWS_AND_MAGAZINES,3.9,32121,Varies with device,1000000,Free,0,Everyone,News & Magazines
+Dezeen Magazine RSS Reader,NEWS_AND_MAGAZINES,4.3,350,14M,10000,Free,0,Everyone,News & Magazines
+"issuu - Read Magazines, Catalogs, Newspapers.",NEWS_AND_MAGAZINES,4.4,74425,8.6M,1000000,Free,0,Everyone,News & Magazines
+Google News,NEWS_AND_MAGAZINES,3.9,877635,13M,1000000000,Free,0,Teen,News & Magazines
+"BuzzFeed: News, Tasty, Quizzes",NEWS_AND_MAGAZINES,4.3,131028,13M,5000000,Free,0,Teen,News & Magazines
+Flipboard: News For Our Time,NEWS_AND_MAGAZINES,4.4,1284017,Varies with device,500000000,Free,0,Everyone 10+,News & Magazines
+Fast News,NEWS_AND_MAGAZINES,4.4,84957,Varies with device,1000000,Free,0,Everyone 10+,News & Magazines
+LA Times: Your California News,NEWS_AND_MAGAZINES,3.6,3311,10M,100000,Free,0,Everyone,News & Magazines
+The Washington Post Classic,NEWS_AND_MAGAZINES,4.5,23158,Varies with device,1000000,Free,0,Everyone 10+,News & Magazines
+Chicago Tribune,NEWS_AND_MAGAZINES,3.6,1380,Varies with device,100000,Free,0,Everyone,News & Magazines
+USA TODAY,NEWS_AND_MAGAZINES,4.1,49259,Varies with device,5000000,Free,0,Everyone 10+,News & Magazines
+World Newspapers,NEWS_AND_MAGAZINES,4.4,185884,7.5M,1000000,Free,0,Mature 17+,News & Magazines
+The Wall Street Journal: Business & Market News,NEWS_AND_MAGAZINES,4.1,40975,36M,1000000,Free,0,Everyone 10+,News & Magazines
+Financial Times,NEWS_AND_MAGAZINES,4.2,27104,8.2M,1000000,Free,0,Everyone 10+,News & Magazines
+The Guardian,NEWS_AND_MAGAZINES,4.7,247992,22M,5000000,Free,0,Teen,News & Magazines
+NYTimes - Latest News,NEWS_AND_MAGAZINES,3.9,63647,23M,10000000,Free,0,Everyone 10+,News & Magazines
+Digg,NEWS_AND_MAGAZINES,3.9,6105,Varies with device,100000,Free,0,Teen,News & Magazines
+News360: Personalized News,NEWS_AND_MAGAZINES,4.4,30722,Varies with device,1000000,Free,0,Teen,News & Magazines
+BBC News,NEWS_AND_MAGAZINES,4.3,296781,Varies with device,10000000,Free,0,Everyone 10+,News & Magazines
+RT News (Russia Today),NEWS_AND_MAGAZINES,4.6,56524,14M,1000000,Free,0,Teen,News & Magazines
+NPR News,NEWS_AND_MAGAZINES,4.0,24790,Varies with device,1000000,Free,0,Everyone,News & Magazines
+Reuters News,NEWS_AND_MAGAZINES,4.3,13169,25M,1000000,Free,0,Everyone 10+,News & Magazines
+Bloomberg: Market & Financial News,NEWS_AND_MAGAZINES,4.2,61692,27M,10000000,Free,0,Everyone,News & Magazines
+"Fox News – Breaking News, Live Video & News Alerts",NEWS_AND_MAGAZINES,4.5,249919,Varies with device,10000000,Free,0,Everyone 10+,News & Magazines
+Haystack TV: Local & World News - Free,NEWS_AND_MAGAZINES,4.3,3684,Varies with device,100000,Free,0,Everyone 10+,News & Magazines
+ABC News - US & World News,NEWS_AND_MAGAZINES,4.0,18976,35M,1000000,Free,0,Everyone 10+,News & Magazines
+NBC News,NEWS_AND_MAGAZINES,4.1,63020,Varies with device,5000000,Free,0,Everyone 10+,News & Magazines
+Sync for reddit,NEWS_AND_MAGAZINES,4.6,62740,8.6M,500000,Free,0,Mature 17+,News & Magazines
+USA TODAY,NEWS_AND_MAGAZINES,4.1,49259,Varies with device,5000000,Free,0,Everyone 10+,News & Magazines
+AP Mobile - Breaking News,NEWS_AND_MAGAZINES,4.5,76677,4.6M,1000000,Free,0,Everyone 10+,News & Magazines
+CNN Breaking US & World News,NEWS_AND_MAGAZINES,4.0,293080,25M,10000000,Free,0,Everyone 10+,News & Magazines
+HuffPost - News,NEWS_AND_MAGAZINES,4.2,78154,12M,1000000,Free,0,Everyone 10+,News & Magazines
+News Republic,NEWS_AND_MAGAZINES,4.3,479594,18M,10000000,Free,0,Teen,News & Magazines
+Newsroom: News Worth Sharing,NEWS_AND_MAGAZINES,4.2,201737,Varies with device,10000000,Free,0,Everyone 10+,News & Magazines
+Twitter,NEWS_AND_MAGAZINES,4.3,11667403,Varies with device,500000000,Free,0,Mature 17+,News & Magazines
+SmartNews: Breaking News Headlines,NEWS_AND_MAGAZINES,4.2,233305,3.1M,10000000,Free,0,Everyone,News & Magazines
+Updates for Samsung - Android Update Versions,NEWS_AND_MAGAZINES,4.0,80368,Varies with device,10000000,Free,0,Everyone,News & Magazines
+AC - Tips & News for Android™,NEWS_AND_MAGAZINES,4.2,23292,14M,1000000,Free,0,Everyone 10+,News & Magazines
+BBC News,NEWS_AND_MAGAZINES,4.3,296781,Varies with device,10000000,Free,0,Everyone 10+,News & Magazines
+NPR News,NEWS_AND_MAGAZINES,4.0,24790,Varies with device,1000000,Free,0,Everyone,News & Magazines
+"Fox News – Breaking News, Live Video & News Alerts",NEWS_AND_MAGAZINES,4.5,249919,Varies with device,10000000,Free,0,Everyone 10+,News & Magazines
+CBS News,NEWS_AND_MAGAZINES,4.3,23641,23M,1000000,Free,0,Everyone 10+,News & Magazines
+Haystack TV: Local & World News - Free,NEWS_AND_MAGAZINES,4.3,3684,Varies with device,100000,Free,0,Everyone 10+,News & Magazines
+NPR One,NEWS_AND_MAGAZINES,3.9,13217,8.8M,1000000,Free,0,Teen,News & Magazines
+ABC News - US & World News,NEWS_AND_MAGAZINES,4.0,18976,35M,1000000,Free,0,Everyone 10+,News & Magazines
+USA TODAY,NEWS_AND_MAGAZINES,4.1,49259,Varies with device,5000000,Free,0,Everyone 10+,News & Magazines
+NBC News,NEWS_AND_MAGAZINES,4.1,63020,Varies with device,5000000,Free,0,Everyone 10+,News & Magazines
+The Wall Street Journal: Business & Market News,NEWS_AND_MAGAZINES,4.1,40975,36M,1000000,Free,0,Everyone 10+,News & Magazines
+JailBase - Arrests + Mugshots,NEWS_AND_MAGAZINES,4.0,17240,Varies with device,1000000,Free,0,Everyone 10+,News & Magazines
+CNN Breaking US & World News,NEWS_AND_MAGAZINES,4.0,293080,25M,10000000,Free,0,Everyone 10+,News & Magazines
+Pocket,NEWS_AND_MAGAZINES,4.5,256680,12M,10000000,Free,0,Everyone,News & Magazines
+"AOL - News, Mail & Video",NEWS_AND_MAGAZINES,4.1,62465,Varies with device,5000000,Free,0,Everyone 10+,News & Magazines
+NYTimes - Latest News,NEWS_AND_MAGAZINES,3.9,63647,23M,10000000,Free,0,Everyone 10+,News & Magazines
+Newsroom: News Worth Sharing,NEWS_AND_MAGAZINES,4.2,201737,Varies with device,10000000,Free,0,Everyone 10+,News & Magazines
+Google News,NEWS_AND_MAGAZINES,3.9,877643,13M,1000000000,Free,0,Teen,News & Magazines
+BaconReader for Reddit,NEWS_AND_MAGAZINES,4.5,103074,Varies with device,1000000,Free,0,Mature 17+,News & Magazines
+"BuzzFeed: News, Tasty, Quizzes",NEWS_AND_MAGAZINES,4.3,131028,13M,5000000,Free,0,Teen,News & Magazines
+Flipboard: News For Our Time,NEWS_AND_MAGAZINES,4.4,1284018,Varies with device,500000000,Free,0,Everyone 10+,News & Magazines
+"Waze - GPS, Maps, Traffic Alerts & Live Navigation",MAPS_AND_NAVIGATION,4.6,7232629,Varies with device,100000000,Free,0,Everyone,Maps & Navigation
+"T map (te map, T map, navigation)",MAPS_AND_NAVIGATION,4.2,15681,Varies with device,5000000,Free,0,Everyone,Maps & Navigation
+"MapQuest: Directions, Maps, GPS & Navigation",MAPS_AND_NAVIGATION,4.1,53481,Varies with device,10000000,Free,0,Everyone,Maps & Navigation
+"Yahoo! transit guide free timetable, operation information, transfer search",MAPS_AND_NAVIGATION,4.4,104800,22M,10000000,Free,0,Everyone,Maps & Navigation
+乗換NAVITIME　Timetable & Route Search in Japan Tokyo,MAPS_AND_NAVIGATION,4.4,50459,Varies with device,5000000,Free,0,Everyone,Maps & Navigation
+Transit: Real-Time Transit App,MAPS_AND_NAVIGATION,4.2,43269,Varies with device,5000000,Free,0,Everyone,Maps & Navigation
+Mapy.cz - Cycling & Hiking offline maps,MAPS_AND_NAVIGATION,4.5,56443,43M,1000000,Free,0,Everyone,Maps & Navigation
+Uber,MAPS_AND_NAVIGATION,4.2,4928420,Varies with device,100000000,Free,0,Everyone,Maps & Navigation
+GPS Navigation & Offline Maps Sygic,MAPS_AND_NAVIGATION,4.4,1421884,33M,50000000,Free,0,Everyone,Maps & Navigation
+Map and Router Badge,MAPS_AND_NAVIGATION,4.4,3652,32M,500000,Free,0,Everyone,Maps & Navigation
+Yandex.Transport,MAPS_AND_NAVIGATION,4.0,126282,Varies with device,10000000,Free,0,Everyone,Maps & Navigation
+Air Traffic,MAPS_AND_NAVIGATION,4.3,14110,6.8M,1000000,Free,0,Everyone,Maps & Navigation
+Speed Cameras Radar,MAPS_AND_NAVIGATION,4.4,18710,4.0M,1000000,Free,0,Everyone,Maps & Navigation
+Atlan3D Navigation: Korea navigator,MAPS_AND_NAVIGATION,4.2,22063,Varies with device,1000000,Free,0,Everyone,Maps & Navigation
+Compass,MAPS_AND_NAVIGATION,4.3,286454,3.7M,10000000,Free,0,Everyone,Maps & Navigation
+"Mappy - Plan, route comparison, GPS",MAPS_AND_NAVIGATION,4.1,15922,Varies with device,1000000,Free,0,Everyone,Maps & Navigation
+Gps Route Finder,MAPS_AND_NAVIGATION,4.4,652,3.4M,100000,Free,0,Everyone,Maps & Navigation
+"My Location: GPS Maps, Share & Save Places",MAPS_AND_NAVIGATION,4.3,29768,Varies with device,5000000,Free,0,Everyone,Maps & Navigation
+"Yanosik: ""antyradar"", traffic jams, navigation, camera",MAPS_AND_NAVIGATION,4.4,102248,Varies with device,5000000,Free,0,Everyone,Maps & Navigation
+NAVITIME - Map & Transfer Navi,MAPS_AND_NAVIGATION,4.2,41225,Varies with device,5000000,Free,0,Everyone,Maps & Navigation
+Sygic Car Navigation,MAPS_AND_NAVIGATION,4.7,162049,48M,5000000,Free,0,Everyone,Maps & Navigation
+Czech Public Transport IDOS,MAPS_AND_NAVIGATION,4.3,26014,7.7M,1000000,Free,0,Everyone,Maps & Navigation
+Karta GPS - Offline Navigation,MAPS_AND_NAVIGATION,4.5,53562,60M,1000000,Free,0,Everyone,Maps & Navigation
+Circle ratio,MAPS_AND_NAVIGATION,3.7,10562,60M,1000000,Free,0,Everyone,Maps & Navigation
+Soviet Military Maps Free,MAPS_AND_NAVIGATION,4.3,21589,5.6M,1000000,Free,0,Everyone,Maps & Navigation
+"Truck Car Navi by Navitime Large size car, traffic jam, traffic closure, live camera, typhoon / precipitation map",MAPS_AND_NAVIGATION,4.2,3682,Varies with device,100000,Free,0,Everyone,Maps & Navigation
+Sentin Information Map,MAPS_AND_NAVIGATION,4.1,2909,5.2M,100000,Free,0,Everyone,Maps & Navigation
+Snapp,MAPS_AND_NAVIGATION,4.5,37937,25M,1000000,Free,0,Everyone,Maps & Navigation
+GPS Speedometer and Odometer,MAPS_AND_NAVIGATION,4.8,15865,3.3M,1000000,Free,0,Everyone,Maps & Navigation
+GPS Traffic Speedcam Route Planner by ViaMichelin,MAPS_AND_NAVIGATION,4.3,63920,29M,5000000,Free,0,Everyone,Maps & Navigation
+Trucker Path – Truck Stops & Weigh Stations,MAPS_AND_NAVIGATION,4.7,38375,49M,1000000,Free,0,Everyone,Maps & Navigation
+Map Coordinates,MAPS_AND_NAVIGATION,4.3,16657,3.6M,1000000,Free,0,Everyone,Maps & Navigation
+Grab Driver,MAPS_AND_NAVIGATION,4.2,301413,48M,5000000,Free,0,Everyone,Maps & Navigation
+SBB Mobile,MAPS_AND_NAVIGATION,3.7,20605,Varies with device,1000000,Free,0,Everyone,Maps & Navigation
+"GPS Speedometer, Distance Meter",MAPS_AND_NAVIGATION,4.6,16094,5.4M,1000000,Free,0,Everyone,Maps & Navigation
+Blitzer.de,MAPS_AND_NAVIGATION,4.5,65590,18M,5000000,Free,0,Everyone,Maps & Navigation
+GPS Speedometer - Trip Meter - Altimeter,MAPS_AND_NAVIGATION,4.3,32225,3.2M,1000000,Free,0,Everyone,Maps & Navigation
+Radarbot Free: Speed Camera Detector & Speedometer,MAPS_AND_NAVIGATION,4.5,44348,11M,5000000,Free,0,Everyone,Maps & Navigation
+FindShip,MAPS_AND_NAVIGATION,4.2,23279,8.5M,1000000,Free,0,Everyone,Maps & Navigation
+ÖBB Scotty,MAPS_AND_NAVIGATION,4.2,12572,24M,1000000,Free,0,Everyone,Maps & Navigation
+Subway Terminator: Smarter Subway,MAPS_AND_NAVIGATION,4.3,70556,26M,10000000,Free,0,Everyone,Maps & Navigation
+Alopec - Online Shipping System,MAPS_AND_NAVIGATION,4.3,1240,14M,100000,Free,0,Everyone,Maps & Navigation
+Yandex.Trains,MAPS_AND_NAVIGATION,4.4,56471,Varies with device,5000000,Free,0,Everyone,Maps & Navigation
+NAVITIME Bus Transit JAPAN,MAPS_AND_NAVIGATION,3.7,6939,Varies with device,1000000,Free,0,Everyone,Maps & Navigation
+hum app,MAPS_AND_NAVIGATION,4.4,10218,78M,1000000,Free,0,Everyone,Maps & Navigation
+Moovit: Bus Time & Train Time Live Info,MAPS_AND_NAVIGATION,4.4,617477,Varies with device,10000000,Free,0,Everyone,Maps & Navigation
+"Dynavix - Navigation, Maps, Traffic data & Cameras",MAPS_AND_NAVIGATION,4.2,1688,Varies with device,50000,Free,0,Everyone,Maps & Navigation
+National Rail Enquiries,MAPS_AND_NAVIGATION,3.5,18857,7.0M,1000000,Free,0,Everyone,Maps & Navigation
+ixigo Cabs-Compare & Book Taxi,MAPS_AND_NAVIGATION,4.2,11838,9.2M,1000000,Free,0,Everyone,Maps & Navigation
+Maps & GPS Navigation — OsmAnd,MAPS_AND_NAVIGATION,4.2,60838,Varies with device,5000000,Free,0,Everyone,Maps & Navigation
+Snapchat,SOCIAL,4.0,17000166,Varies with device,500000000,Free,0,Teen,Social
+Flashlight,TOOLS,4.5,162335,4.9M,10000000,Free,0,Everyone,Tools
+aa,FAMILY,4.2,886418,6.5M,50000000,Free,0,Everyone,Strategy
+A Call From Santa Claus!,FAMILY,3.9,3720,11M,1000000,Free,0,Everyone,Entertainment
+Rope Hero Return of a Legend,GAME,4.3,9951,96M,1000000,Free,0,Mature 17+,Arcade
+A Word A Day,FAMILY,3.7,2398,2.9M,500000,Free,0,Everyone,Education
+Draw a Stickman: EPIC 2 Free,GAME,4.3,213340,24M,10000000,Free,0,Everyone,Adventure
+Akinator,FAMILY,4.3,1805398,55M,50000000,Free,0,Teen,Entertainment
+Dog Sim Online: Raise a Family,FAMILY,4.6,94989,74M,5000000,Free,0,Teen,Simulation
+Pou,FAMILY,4.3,10483141,24M,500000000,Free,0,Everyone,Casual
+Agar.io,GAME,4.2,3815614,32M,100000000,Free,0,Everyone,Action
+Color by Number - Draw Sandbox Pixel Art,FAMILY,4.6,10247,15M,1000000,Free,0,Everyone,Entertainment
+A+ Mobile,FINANCE,3.9,730,6.3M,10000,Free,0,Everyone,Finance
+Angry Birds Classic,GAME,4.4,5565856,97M,100000000,Free,0,Everyone,Arcade
+Build a Bridge!,FAMILY,4.6,263454,74M,10000000,Free,0,Everyone,Puzzle
+UNO ™ & Friends,GAME,4.1,1728557,Varies with device,50000000,Free,0,Everyone,Card
+Find a Way: Addictive Puzzle,FAMILY,4.8,39480,14M,500000,Free,0,Everyone,Puzzle
+CompTIA A+ Pocket Prep,FAMILY,4.3,1311,14M,10000,Free,0,Everyone,Education
+My Talking Tom,FAMILY,4.5,14885236,Varies with device,500000000,Free,0,Everyone,Casual
+Netflix,FAMILY,4.4,5453997,Varies with device,100000000,Free,0,Teen,Entertainment
+Comptia A+ 220-901 & 220-902,FAMILY,4.4,174,5.7M,10000,Free,0,Everyone,Education
+Create A Superhero HD,FAMILY,3.3,8642,19M,500000,Free,0,Teen,Casual
+Azar,COMMUNICATION,4.2,1092337,Varies with device,50000000,Free,0,Mature 17+,Communication
+4 in a Row,GAME,3.8,4257,Varies with device,500000,Free,0,Everyone,Board
+Bubble Shooter,GAME,4.5,43576,50M,5000000,Free,0,Everyone,Arcade
+Adobe Acrobat Reader,PRODUCTIVITY,4.3,3014548,Varies with device,100000000,Free,0,Everyone,Productivity
+Subway Surfers,GAME,4.5,27711703,76M,1000000000,Free,0,Everyone 10+,Arcade
+Super Mario Run,GAME,3.7,1221896,70M,100000000,Free,0,Everyone,Action
+STARDOM: THE A-LIST,GAME,4.5,152658,29M,1000000,Free,0,Teen,Adventure
+LokLok: Draw on a Lock Screen,COMMUNICATION,4.1,14766,16M,500000,Free,0,Teen,Communication
+The Tribez: Build a Village,FAMILY,4.4,1852384,Varies with device,10000000,Free,0,Everyone,Simulation
+Photo Warp,FAMILY,3.7,353342,13M,50000000,Free,0,Everyone,Entertainment
+LEGO® Juniors Create & Cruise,FAMILY,4.1,672089,73M,50000000,Free,0,Everyone,Educational;Action & Adventure
+CompTIA Exam Training,FAMILY,4.8,3053,17M,50000,Free,0,Everyone,Education
+WhatsApp Messenger,COMMUNICATION,4.4,69109672,Varies with device,1000000000,Free,0,Everyone,Communication
+Magisto Video Editor & Maker,VIDEO_PLAYERS,4.3,960726,Varies with device,10000000,Free,0,Everyone,Video Players & Editors
+Glow Hockey,GAME,4.1,1703479,Varies with device,100000000,Free,0,Everyone,Arcade
+Google Translate,TOOLS,4.4,5741684,Varies with device,500000000,Free,0,Everyone,Tools
+Pokémon GO,GAME,4.1,10421284,85M,100000000,Free,0,Everyone,Adventure
+Instagram,SOCIAL,4.5,66509917,Varies with device,1000000000,Free,0,Teen,Social
+My Talking Angela,FAMILY,4.5,9876369,99M,100000000,Free,0,Everyone,Casual
+YouTube Kids,FAMILY,4.5,469851,Varies with device,50000000,Free,0,Everyone,Entertainment;Music & Video
+Asphalt 8: Airborne,GAME,4.5,8389714,92M,100000000,Free,0,Teen,Racing
+PAC-MAN,GAME,4.2,685450,37M,100000000,Free,0,Everyone,Arcade
+Basketball Stars,SPORTS,4.4,867920,45M,10000000,Free,0,Everyone,Sports
+Colorfy: Coloring Book for Adults - Free,FAMILY,4.5,787107,Varies with device,10000000,Free,0,Everyone,Entertainment
+Lep's World 2 🍀🍀,GAME,4.3,798522,57M,100000000,Free,0,Everyone 10+,Arcade
+Wolfify - Be a Werewolf,FAMILY,3.8,6760,26M,500000,Free,0,Everyone,Entertainment
+Law of Creation: A Playable Manga,GAME,4.5,13118,47M,500000,Free,0,Teen,Adventure
+Real City Car Driver,GAME,3.7,413609,22M,10000000,Free,0,Mature 17+,Racing
+Toca Kitchen 2,FAMILY,4.5,1013465,56M,50000000,Free,0,Everyone,Educational;Pretend Play
+Rolling Sky,GAME,4.5,1117212,50M,50000000,Free,0,Everyone,Board
+Amazon Shopping,SHOPPING,4.3,908525,42M,100000000,Free,0,Teen,Shopping
+Gymnastics Superstar - Spin your way to gold!,FAMILY,4.6,305765,34M,10000000,Free,0,Everyone,Role Playing
+Fake Call - Fake Caller ID,PRODUCTIVITY,4.3,154668,Varies with device,10000000,Free,0,Everyone,Productivity
+SuperCity: Build a Story,FAMILY,4.4,98324,70M,1000000,Free,0,Everyone,Simulation
+Chick-fil-A,FOOD_AND_DRINK,4.3,27931,17M,5000000,Free,0,Everyone,Food & Drink
+4 in a row,GAME,4.3,47698,4.1M,5000000,Free,0,Everyone,Board
+YouTube,VIDEO_PLAYERS,4.3,25623548,Varies with device,1000000000,Free,0,Teen,Video Players & Editors
+Four In A Line Free,GAME,4.3,133195,11M,5000000,Free,0,Everyone,Board
+Flow Free,FAMILY,4.3,1295293,11M,100000000,Free,0,Everyone,Puzzle
+Like A Boss,FAMILY,4.4,17069,94M,500000,Free,0,Everyone 10+,Role Playing
+AutoCAD - DWG Viewer & Editor,PRODUCTIVITY,4.2,145088,24M,10000000,Free,0,Everyone,Productivity
+Hungry Hearts Diner: A Tale of Star-Crossed Souls,FAMILY,4.9,46253,56M,500000,Free,0,Everyone 10+,Simulation
+Microsoft Word,PRODUCTIVITY,4.5,2078744,Varies with device,500000000,Free,0,Everyone,Productivity
+Dragon Sim Online: Be A Dragon,FAMILY,4.6,111741,66M,5000000,Free,0,Teen,Simulation
+Alto's Adventure,GAME,4.6,515240,63M,10000000,Free,0,Everyone,Action
+Fortune City - A Finance App,FINANCE,4.6,49275,91M,500000,Free,0,Everyone,Finance
+Draw A Stickman,GAME,3.4,29265,17M,1000000,Free,0,Everyone,Adventure
+Be A Legend: Soccer,SPORTS,3.8,85763,21M,1000000,Free,0,Everyone,Sports
+Zombie Tsunami,GAME,4.4,4918776,Varies with device,100000000,Free,0,Everyone 10+,Arcade
+Bible,BOOKS_AND_REFERENCE,4.7,2440695,Varies with device,100000000,Free,0,Teen,Books & Reference
+Cat Sim Online: Play with Cats,FAMILY,4.6,137198,81M,5000000,Free,0,Everyone 10+,Simulation
+Facebook,SOCIAL,4.1,78128208,Varies with device,1000000000,Free,0,Teen,Social
+Four In A Line,GAME,3.8,22191,3.0M,1000000,Free,0,Everyone,Board
+Tik Tok - including musical.ly,SOCIAL,4.4,5637451,59M,100000000,Free,0,Teen,Social
+B612 - Beauty & Filter Camera,PHOTOGRAPHY,4.4,5276983,Varies with device,100000000,Free,0,Everyone,Photography
+Disney Magic Timer by Oral-B,FAMILY,3.9,31061,83M,1000000,Free,0,Everyone,Health & Fitness;Action & Adventure
+B-Messenger Video Chat,SOCIAL,4.1,12495,19M,1000000,Free,0,Mature 17+,Social
+Bestie - Camera360 Selfie,PHOTOGRAPHY,4.5,512996,23M,10000000,Free,0,Everyone,Photography
+B,FINANCE,3.7,800,32M,50000,Free,0,Everyone,Finance
+BIGO LIVE - Live Stream,SOCIAL,4.4,2349421,39M,100000000,Free,0,Teen,Social
+Block Craft 3D: Building Simulator Games For Free,FAMILY,4.5,944661,57M,50000000,Free,0,Everyone,Simulation
+8 Ball Pool,SPORTS,4.5,14184910,52M,100000000,Free,0,Everyone,Sports
+B-BLE(BLE4.0 Scan),TOOLS,3.8,159,7.5M,10000,Free,0,Everyone,Tools
+Cardi B Piano Game,GAME,3.1,50,7.4M,10000,Free,0,Everyone,Music
+VPN Free - Betternet Hotspot VPN & Private Browser,TOOLS,4.5,799206,8.9M,10000000,Free,0,Everyone,Tools
+ADS-B Driver,TOOLS,5.0,2,6.3M,100,Paid,$1.99,Everyone,Tools
+MORTAL KOMBAT X,GAME,4.4,3039889,18M,10000000,Free,0,Mature 17+,Action
+B-17 Flying Fortress WWII LWP,PERSONALIZATION,4.3,7,14M,100,Paid,$1.49,Everyone,Personalization
+► MultiCraft ― Free Miner! 👍,GAME,4.3,1305050,Varies with device,50000000,Free,0,Everyone 10+,Adventure
+B.GOOD,FOOD_AND_DRINK,2.9,155,20M,10000,Free,0,Everyone,Food & Drink
+B-Dubs®,LIFESTYLE,3.1,3042,Varies with device,500000,Free,0,Everyone,Lifestyle
+Oral-B App,HEALTH_AND_FITNESS,3.3,14210,96M,1000000,Free,0,Everyone,Health & Fitness
+Smart Launcher theme b. gold,PERSONALIZATION,4.1,291,35M,5000,Paid,$1.99,Everyone,Personalization
+EMT Tutor NREMT-B Study Guide,MEDICAL,4.6,625,8.4M,10000,Paid,$3.99,Everyone,Medical
+Next Launcher 3D Theme Hit-B,PERSONALIZATION,4.4,83,8.6M,1000,Paid,$1.70,Everyone,Personalization
+Pixel Gun 3D: Survival shooter & Battle Royale,GAME,4.5,4487182,55M,50000000,Free,0,Teen,Action
+B-52 Spirits of Glory Deluxe,GAME,4.3,12,29M,100,Paid,$0.99,Everyone,Arcade
+Servers Ultimate Pack B,TOOLS,4.3,668,13M,50000,Free,0,Everyone,Tools
+EMT-B Pocket Prep,MEDICAL,4.5,2948,16M,50000,Free,0,Everyone,Medical
+UC Browser - Fast Download Private & Secure,COMMUNICATION,4.5,17712922,40M,500000000,Free,0,Teen,Communication
+Air Transat CinePlus B,TRAVEL_AND_LOCAL,2.2,83,6.7M,50000,Free,0,Everyone,Travel & Local
+Hungry Shark Evolution,GAME,4.5,6071542,100M,100000000,Free,0,Teen,Arcade
+Perfect Piano,GAME,4.2,828489,Varies with device,50000000,Free,0,Everyone,Music
+Hay Day,FAMILY,4.5,10053186,94M,100000000,Free,0,Everyone,Casual
+Diary with lock,LIFESTYLE,4.6,815280,4.4M,10000000,Free,0,Everyone,Lifestyle
+B-Grade Renegade,GAME,3.9,24,64M,1000,Paid,$1.99,Teen,Action
+CARDI B WALLPAPERS,PERSONALIZATION,4.1,8,4.5M,1000,Free,0,Everyone,Personalization
+Plan B,MAPS_AND_NAVIGATION,3.3,19,6.0M,5000,Free,0,Everyone,Maps & Navigation
+Block! Hexa Puzzle™,FAMILY,4.5,472247,Varies with device,50000000,Free,0,Everyone,Puzzle
+B Tiff Viewer,PHOTOGRAPHY,4.1,283,7.4M,100000,Free,0,Everyone,Photography
+Cardi B Wallpaper,ART_AND_DESIGN,4.8,253,3.7M,50000,Free,0,Everyone,Art & Design
+A & B Taxi,MAPS_AND_NAVIGATION,4.1,41,25M,1000,Free,0,Everyone,Maps & Navigation
+Cardi B HD Wallpapers Lock Screen,PERSONALIZATION,4.5,2,10M,500,Free,0,Mature 17+,Personalization
+CURSUM B,GAME,4.3,30,26M,500,Paid,$0.99,Everyone,Racing
+Clash of Clans,FAMILY,4.6,44881447,98M,100000000,Free,0,Everyone 10+,Strategy
+Clash Royale,FAMILY,4.6,23125280,97M,100000000,Free,0,Everyone 10+,Strategy
+C Programming,FAMILY,4.3,22248,1.8M,1000000,Free,0,Everyone,Education
+CppDroid - C/C++ IDE,FAMILY,4.1,29978,Varies with device,1000000,Free,0,Everyone,Education
+Learn C [NEW],FAMILY,4.5,349,11M,50000,Free,0,Everyone,Education
+Mobile C [ C/C++ Compiler ],FAMILY,4.3,4624,78M,100000,Free,0,Everyone,Education
+Critical Ops,GAME,4.4,1397944,50M,10000000,Free,0,Teen,Action
+C4droid - C/C++ compiler & IDE,FAMILY,4.7,2890,Varies with device,50000,Paid,$2.99,Everyone,Education
+Candy Crush Saga,FAMILY,4.4,22419455,74M,500000000,Free,0,Everyone,Casual
+CL Mobile - Classifieds for Craigslist,SHOPPING,4.4,27275,8.3M,1000000,Free,0,Teen,Shopping
+Google Chrome: Fast & Secure,COMMUNICATION,4.3,9642112,Varies with device,1000000000,Free,0,Everyone,Communication
+C Locker Pro,PERSONALIZATION,4.2,1531,7.7M,10000,Paid,$2.99,Everyone,Personalization
+C Programs and Reference,BOOKS_AND_REFERENCE,4.2,873,2.5M,50000,Free,0,Everyone,Books & Reference
+Learn C++,FAMILY,4.6,73404,5.3M,1000000,Free,0,Everyone,Education
+"C Launcher: Themes, Wallpapers, DIY, Smart, Clean",PERSONALIZATION,4.5,901110,Varies with device,10000000,Free,0,Everyone 10+,Personalization
+C Programming Zone,FAMILY,4.6,1218,4.0M,50000,Free,0,Everyone,Education
+C Offline Tutorial,BOOKS_AND_REFERENCE,4.7,88,4.2M,1000,Free,0,Everyone,Books & Reference
+Neon Glow C - Icon Pack,PERSONALIZATION,4.8,557,74M,10000,Paid,$0.99,Everyone,Personalization
+All C Programs,FAMILY,4.7,2387,6.9M,100000,Free,0,Everyone,Education
+Clean Master- Space Cleaner & Antivirus,TOOLS,4.7,42916526,Varies with device,500000000,Free,0,Everyone,Tools
+C by GE,LIFESTYLE,1.7,686,6.6M,10000,Free,0,Everyone,Lifestyle
+CPlus for Craigslist - Officially Licensed,LIFESTYLE,4.5,8096,16M,1000000,Free,0,Mature 17+,Lifestyle
+Alt-C,PRODUCTIVITY,4.0,499,4.7M,10000,Free,0,Everyone,Productivity
+C-SPAN Radio,FAMILY,3.6,608,5.4M,100000,Free,0,Everyone,Entertainment
+Bridge-C - Get More Storage,TOOLS,2.0,24,35M,1000,Free,0,Everyone,Tools
+Community by C Space,LIFESTYLE,4.7,707,26M,5000,Free,0,Everyone,Lifestyle
+My C Spire,PRODUCTIVITY,4.1,376,32M,50000,Free,0,Everyone,Productivity
+learn c in hindi,FAMILY,4.3,109,2.7M,5000,Free,0,Everyone,Education
+Learn C Programming (Examples) (OFFLINE),FAMILY,4.3,43,3.7M,10000,Free,0,Everyone,Education
+"C Programming - Learn Code, Theory & Discuss",FAMILY,4.5,2751,7.0M,100000,Free,0,Everyone,Education
+Expert C Programming - Learn C Coding Easily,FAMILY,4.4,77,6.9M,5000,Free,0,Everyone,Education
+Hill Climb Racing,GAME,4.4,8921451,63M,100000000,Free,0,Everyone,Racing
+codeEazy - C/C++/JAVA,FAMILY,4.6,130,2.2M,10000,Free,0,Everyone,Education
+Batmobile™ R/C Controller,FAMILY,3.7,452,30M,100000,Free,0,Everyone,Entertainment
+C Pattern Programs Free,FAMILY,4.5,4115,5.8M,100000,Free,0,Everyone,Education
+C Programs Handbook,BOOKS_AND_REFERENCE,4.0,459,3.1M,50000,Free,0,Everyone,Books & Reference
+C Functions,FAMILY,4.8,55,1.5M,1000,Free,0,Everyone,Education
+Learn C# - .Net - C Sharp Programming Tutorial App,FAMILY,4.0,1320,8.6M,100000,Free,0,Everyone,Education
+Learn Basic C - For Beginners,FAMILY,4.7,27,772k,5000,Free,0,Everyone,Education
+C Prowess,FAMILY,4.8,306,3.3M,5000,Free,0,Everyone,Education
+101 C Programming Problems,FAMILY,4.6,498,5.0M,50000,Free,0,Everyone,Education
+Let us C - Example Programs,FAMILY,4.3,36,1.1M,5000,Free,0,Everyone,Education
+C Examples,FAMILY,4.2,1002,4.4M,10000,Free,0,Everyone,Education
+C BOOK-C PROGRAMS,FAMILY,4.8,138,2.1M,10000,Free,0,Everyone,Education
+100+ C Programs,FAMILY,4.2,20,1.6M,5000,Free,0,Everyone,Education
+ZEDGE™ Ringtones & Wallpapers,PERSONALIZATION,4.6,6459626,Varies with device,100000000,Free,0,Teen,Personalization
+Dubsmash,VIDEO_PLAYERS,4.2,1971777,29M,100000000,Free,0,Teen,Video Players & Editors
+Discord - Chat for Gamers,COMMUNICATION,4.5,305347,39M,10000000,Free,0,Teen,Communication
+Hitman Sniper,GAME,4.6,408292,29M,10000000,Paid,$0.99,Mature 17+,Action
+FRONTLINE COMMANDO: D-DAY,GAME,4.5,1736105,14M,10000000,Free,0,Mature 17+,Action
+Minion Rush: Despicable Me Official Game,FAMILY,4.5,10214862,Varies with device,100000000,Free,0,Everyone 10+,Casual;Action & Adventure
+Fruit Ninja®,GAME,4.3,5091448,41M,100000000,Free,0,Everyone,Arcade
+"DU Recorder – Screen Recorder, Video Editor, Live",VIDEO_PLAYERS,4.8,2588730,9.7M,50000000,Free,0,Everyone,Video Players & Editors
+Google Duo - High Quality Video Calls,COMMUNICATION,4.6,2083237,Varies with device,500000000,Free,0,Everyone,Communication
+Crossy Road,GAME,4.5,4229977,60M,100000000,Free,0,Everyone,Action
+Temple Run 2,GAME,4.3,8116142,62M,500000000,Free,0,Everyone,Action
+Beach Buggy Blitz,GAME,4.2,640974,47M,50000000,Free,0,Everyone,Racing
+Vector,GAME,4.4,3058687,89M,100000000,Free,0,Everyone 10+,Arcade
+Dr. Driving,GAME,4.5,4972230,9.9M,100000000,Free,0,Everyone,Racing
+D Day World War II Commando Survival Shooting,GAME,4.2,951,64M,100000,Free,0,Teen,Action
+Geometry Dash Meltdown,GAME,4.6,1591129,48M,50000000,Free,0,Everyone,Arcade
+Koi Live Wallpaper,PERSONALIZATION,4.6,14026,12M,100000,Paid,$0.99,Everyone,Personalization
+Dropbox,PRODUCTIVITY,4.4,1860844,61M,500000000,Free,0,Everyone,Productivity
+KineMaster – Pro Video Editor,VIDEO_PLAYERS,4.5,1013867,32M,50000000,Free,0,Everyone,Video Players & Editors
+Block City Wars + skins export,FAMILY,4.5,762706,28M,10000000,Free,0,Teen,Simulation
+Sniper 3D Gun Shooter: Free Shooting Games - FPS,GAME,4.6,7657490,Varies with device,100000000,Free,0,Mature 17+,Action
+Bike Race Free - Top Motorcycle Racing Games,GAME,4.5,2586261,Varies with device,100000000,Free,0,Everyone,Racing
+Dance School Stories - Dance Dreams Come True,FAMILY,4.4,91171,36M,1000000,Free,0,Everyone,Role Playing
+3D Bowling,SPORTS,4.1,1076243,13M,100000000,Free,0,Everyone,Sports
+Plants vs. Zombies FREE,FAMILY,4.4,4064868,69M,100000000,Free,0,Everyone 10+,Strategy
+Dream League Soccer 2018,SPORTS,4.6,9873470,74M,100000000,Free,0,Everyone,Sports
+Mind Games Pro,FAMILY,4.6,15301,18M,100000,Paid,$2.99,Everyone,Puzzle;Brain Games
+Z Ringtones PREMIUM 2018,PERSONALIZATION,4.5,10158,3.6M,500000,Free,0,Everyone,Personalization
+Smash Hit,GAME,4.5,4147718,79M,100000000,Free,0,Everyone,Arcade
+Bad Piggies,FAMILY,4.3,1168959,66M,50000000,Free,0,Everyone,Puzzle
+Temple Run,GAME,4.3,4000433,42M,100000000,Free,0,Everyone,Arcade
+Broken Screen Prank,FAMILY,3.3,23682,9.8M,1000000,Free,0,Teen,Casual
+Screen Lock - with Fingerprint Simulator,TOOLS,3.7,338449,2.8M,10000000,Free,0,Everyone,Tools
+Tuner - gStrings Free,TOOLS,4.5,214265,Varies with device,10000000,Free,0,Everyone,Tools
+Car Parking Game 3D - Real City Driving Challenge,FAMILY,4.4,187892,40M,5000000,Free,0,Everyone,Simulation
+E!,FAMILY,3.1,740,20M,100000,Free,0,Teen,Entertainment
+E! News,NEWS_AND_MAGAZINES,4.0,15443,25M,1000000,Free,0,Teen,News & Magazines
+eBay: Buy & Sell this Summer - Discover Deals Now!,SHOPPING,4.4,2788460,Varies with device,100000000,Free,0,Teen,Shopping
+ESPN,SPORTS,4.2,521081,Varies with device,10000000,Free,0,Everyone 10+,Sports
+Chuck E.'s Skate Universe,FAMILY,3.9,94910,44M,10000000,Free,0,Everyone,Action;Action & Adventure
+Eventbrite - Discover popular events & nearby fun,FAMILY,4.4,63773,8.8M,5000000,Free,0,Everyone,Entertainment
+ES File Explorer File Manager,PRODUCTIVITY,4.6,5378795,16M,100000000,Free,0,Everyone,Productivity
+Eternium,FAMILY,4.8,1506783,89M,10000000,Free,0,Teen,Role Playing
+Firefox Browser fast & private,COMMUNICATION,4.4,3075096,Varies with device,100000000,Free,0,Everyone,Communication
+E*TRADE Mobile,FINANCE,3.9,10657,58M,1000000,Free,0,Everyone,Finance
+WWE,FAMILY,4.5,736824,20M,10000000,Free,0,Teen,Entertainment
+E-cigarette for free,FAMILY,3.6,1354,4.8M,500000,Free,0,Mature 17+,Entertainment
+Moto LED for Moto X & E [Root],LIFESTYLE,3.4,4082,318k,500000,Free,0,Everyone,Lifestyle
+Mobile Security & Antivirus,PRODUCTIVITY,4.7,564759,Varies with device,10000000,Free,0,Everyone,Productivity
+Lookout Security & Antivirus,TOOLS,4.4,951413,13M,100000000,Free,0,Everyone,Tools
+World History Quick e-Book,FAMILY,4.4,1657,4.9M,100000,Free,0,Everyone,Education;Education
+Greeting Cards & Wishes,SOCIAL,4.5,17350,12M,500000,Free,0,Everyone,Social
+Amazon Kindle,BOOKS_AND_REFERENCE,4.2,814151,Varies with device,100000000,Free,0,Teen,Books & Reference
+"Evernote – Organizer, Planner for Notes & Memos",PRODUCTIVITY,4.6,1488289,Varies with device,100000000,Free,0,Everyone,Productivity
+Maps & GPS Navigation OsmAnd+,TRAVEL_AND_LOCAL,4.3,15209,Varies with device,100000,Paid,$8.99,Everyone,Travel & Local
+Microsoft Edge,COMMUNICATION,4.3,27156,66M,5000000,Free,0,Everyone,Communication
+Microsoft Outlook,PRODUCTIVITY,4.3,3249518,50M,100000000,Free,0,Everyone,Productivity
+Pinterest,SOCIAL,4.6,4300936,Varies with device,100000000,Free,0,Teen,Social
+ClassDojo,FAMILY,4.4,148536,59M,10000000,Free,0,Everyone,Education;Education
+The Coupons App,SHOPPING,4.5,181983,Varies with device,10000000,Free,0,Everyone,Shopping
+theScore esports,SPORTS,4.5,16257,14M,500000,Free,0,Everyone 10+,Sports
+EX File Explorer File Manager,PRODUCTIVITY,4.0,4660,5.9M,1000000,Free,0,Everyone,Productivity
+Aab e Hayat Full Novel,BOOKS_AND_REFERENCE,4.3,1476,41M,100000,Free,0,Everyone,Books & Reference
+EBookDroid - PDF & DJVU Reader,PRODUCTIVITY,4.5,75951,Varies with device,5000000,Free,0,Everyone,Productivity
+Ebook Reader,BOOKS_AND_REFERENCE,4.1,85842,37M,5000000,Free,0,Everyone,Books & Reference
+Gmail,COMMUNICATION,4.3,4604324,Varies with device,1000000000,Free,0,Everyone,Communication
+E-NUM,FINANCE,4.0,10374,Varies with device,500000,Free,0,Everyone,Finance
+Maps - Navigate & Explore,TRAVEL_AND_LOCAL,4.3,9231613,Varies with device,1000000000,Free,0,Everyone,Travel & Local
+"AliExpress - Smarter Shopping, Better Living",SHOPPING,4.6,5911055,Varies with device,100000000,Free,0,Teen,Shopping
+Aldiko Book Reader,BOOKS_AND_REFERENCE,4.2,210534,22M,10000000,Free,0,Everyone,Books & Reference
+Flipkart Online Shopping App,SHOPPING,4.4,6003590,Varies with device,100000000,Free,0,Teen,Shopping
+Wish - Shopping Made Fun,SHOPPING,4.5,6200739,15M,100000000,Free,0,Everyone,Shopping
+Synd e-Passbook,FINANCE,4.3,9400,6.1M,1000000,Free,0,Everyone,Finance
+Messenger – Text and Video Chat for Free,COMMUNICATION,4.0,56642847,Varies with device,1000000000,Free,0,Everyone,Communication
+Facebook Lite,SOCIAL,4.3,8595964,Varies with device,500000000,Free,0,Teen,Social
+Messenger Lite: Free Calls & Messages,COMMUNICATION,4.4,1429038,Varies with device,100000000,Free,0,Everyone,Communication
+Video Downloader for Facebook,TOOLS,4.6,894435,3.1M,50000000,Free,0,Teen,Tools
+F-Stop Gallery Pro,PHOTOGRAPHY,4.4,1302,58k,10000,Paid,$4.99,Everyone,Photography
+Offroad Pickup Truck F,FAMILY,4.3,4551,79M,500000,Free,0,Everyone,Simulation
+F-Stop Gallery,PHOTOGRAPHY,4.2,12726,15M,1000000,Free,0,Everyone,Photography
+Talking Tom Cat 2,FAMILY,4.3,3213548,55M,100000000,Free,0,Everyone 10+,Entertainment
+FlashLight F.Light,TOOLS,4.3,3943,11M,100000,Free,0,Everyone,Tools
+F-Secure SENSE,TOOLS,4.6,57,13M,5000,Free,0,Everyone,Tools
+Super Car F. Mod for MCPE,GAME,3.6,214,4.9M,50000,Free,0,Everyone,Adventure
+Twitter,NEWS_AND_MAGAZINES,4.3,11657972,Varies with device,500000000,Free,0,Mature 17+,News & Magazines
+F-Secure KEY Password manager,TOOLS,4.2,2588,7.6M,100000,Free,0,Everyone,Tools
+Inputting Plus: Ctrl + Z/F/C/V,PRODUCTIVITY,4.2,1117,3.0M,50000,Free,0,Everyone,Productivity
+CTRL-F - Search the real world,PRODUCTIVITY,4.4,607,37M,50000,Free,0,Everyone,Productivity
+F-Secure SAFE,TOOLS,4.3,9433,9.3M,500000,Free,0,Everyone,Tools
+MHD F-Series,AUTO_AND_VEHICLES,4.9,73,23M,1000,Free,0,Everyone,Auto & Vehicles
+F-Secure AV Test,TOOLS,4.5,1250,241k,50000,Free,0,Everyone,Tools
+LINE: Free Calls & Messages,COMMUNICATION,4.2,10790092,Varies with device,500000000,Free,0,Everyone,Communication
+imo beta free calls and text,COMMUNICATION,4.3,659395,11M,100000000,Free,0,Everyone,Communication
+F-Secure Mobile Security,TOOLS,4.2,13096,9.2M,500000,Free,0,Everyone,Tools
+f'east,LIFESTYLE,3.8,38,4.8M,5000,Free,0,Everyone,Lifestyle
+Dumb Ways to Die 2: The Games,FAMILY,4.2,1671658,Varies with device,50000000,Free,0,Teen,Casual
+Speech Therapy: F,FAMILY,1.0,1,16M,10,Paid,$2.99,Everyone,Education
+HumorCast - Authentic Weather,WEATHER,4.4,6495,40M,100000,Free,0,Teen,Weather
+F & M Mobile Banking,FINANCE,4.0,43,13M,5000,Free,0,Everyone,Finance
+F,TOOLS,4.0,6,4.9M,500,Free,0,Everyone,Tools
+RPG End of Aspiration F,FAMILY,4.4,20368,31M,500000,Free,0,Teen,Role Playing
+F-Sim Space Shuttle,FAMILY,4.4,5427,Varies with device,100000,Paid,$4.99,Everyone,Simulation
+Weather Live,WEATHER,4.5,76593,Varies with device,500000,Paid,$5.99,Everyone,Weather
+Norwegian For Kids & Babies F,FAMILY,4.2,0,14M,5,Paid,$39.99,Everyone,Education
+R+F PULSE,BUSINESS,3.4,58,3.0M,10000,Free,0,Everyone,Business
+F-Secure Freedome for Business,BUSINESS,3.8,183,9.9M,50000,Free,0,Everyone,Business
+F-1 watchface by Delta,PERSONALIZATION,4.3,0,Varies with device,10,Paid,$2.49,Everyone,Personalization
+"f.lux (preview, root-only)",HEALTH_AND_FITNESS,3.7,5559,3.7M,500000,Free,0,Everyone,Health & Fitness
+F Length Sim (no Ads),PHOTOGRAPHY,4.2,0,1.7M,10,Paid,$2.00,Everyone,Photography
+Arto: f.infrared photo,PHOTOGRAPHY,4.1,41,11M,500,Paid,$1.49,Everyone,Photography
+Geometry Dash World,GAME,4.6,759838,63M,10000000,Free,0,Everyone,Arcade
+Convert degree Celsius to Fahrenheit or °F to °C,TOOLS,4.4,51,2.1M,5000,Free,0,Everyone,Tools
+F-Gas Solutions,BUSINESS,4.2,127,1.4M,10000,Free,0,Everyone,Business
+Google+,SOCIAL,4.2,4828372,Varies with device,1000000000,Free,0,Teen,Social
+PUBG MOBILE,GAME,4.4,3697174,36M,50000000,Free,0,Teen,Action
+Gangstar Vegas - mafia game,GAME,4.5,4830407,32M,50000000,Free,0,Mature 17+,Action
+Gboard - the Google Keyboard,TOOLS,4.2,1855262,Varies with device,500000000,Free,0,Everyone,Tools
+Granny,GAME,4.5,1128805,59M,50000000,Free,0,Teen,Arcade
+Offroad Car G,FAMILY,4.3,64884,37M,5000000,Free,0,Everyone,Simulation
+Google,TOOLS,4.4,8021623,Varies with device,1000000000,Free,0,Everyone,Tools
+Google Now Launcher,TOOLS,4.2,857215,7.9M,100000000,Free,0,Everyone,Tools
+Rolling G Sky,GAME,3.6,2065,25M,100000,Free,0,Everyone,Adventure
+Hangouts,COMMUNICATION,4.0,3419464,Varies with device,1000000000,Free,0,Everyone,Communication
+G-Switch 2,GAME,4.4,12683,19M,1000000,Free,0,Everyone,Action
+G-Switch 3,GAME,4.6,3656,39M,100000,Free,0,Everyone,Action
+G Cloud Apps Backup Key * root,TOOLS,4.5,1034,196k,5000,Paid,$4.99,Everyone,Tools
+Share G - Images Sharing - Wallpapers App,SOCIAL,4.4,120,2.3M,10000,Free,0,Teen,Social
+Next Launcher 3D Theme Hit-G,PERSONALIZATION,4.2,59,8.1M,1000,Paid,$1.70,Everyone,Personalization
+Wrestling Revolution 3D,SPORTS,4.3,989344,51M,50000000,Free,0,Teen,Sports
+G Cloud Backup,PRODUCTIVITY,4.6,267042,Varies with device,5000000,Free,0,Everyone,Productivity
+G-Playlists,TOOLS,1.8,53,3.4M,1000,Paid,$1.49,Everyone,Tools
+G-Switch,GAME,3.8,4116,8.8M,100000,Free,0,Everyone,Action
+Offroad G-Class 2018,FAMILY,4.4,7715,28M,500000,Free,0,Everyone,Simulation
+G-SHOCK+,LIFESTYLE,3.0,4710,Varies with device,100000,Free,0,Everyone,Lifestyle
+Ramfer - CNC Lathe G-code Tool,PRODUCTIVITY,3.4,5,11M,100,Paid,$2.99,Everyone,Productivity
+G-Force Driving Assistant,SPORTS,4.6,10,6.1M,100,Paid,$3.88,Everyone,Sports
+My G:,MAPS_AND_NAVIGATION,3.7,96,14M,10000,Free,0,Everyone,Maps & Navigation
+G-SHOCK Connected,LIFESTYLE,3.0,543,94M,50000,Free,0,Everyone,Lifestyle
+Go,PERSONALIZATION,4.6,89,11M,5000,Paid,$0.99,Everyone,Personalization
+Google Drive,PRODUCTIVITY,4.4,2728941,Varies with device,1000000000,Free,0,Everyone,Productivity
+G-Homa,LIFESTYLE,3.1,777,14M,50000,Free,0,Everyone,Lifestyle
+G-NetTrack Pro,TOOLS,4.3,255,1.6M,5000,Paid,$14.99,Everyone,Tools
+"G Theme 2 for LG V30, LG G6",PERSONALIZATION,4.3,25,15M,500,Paid,$1.49,Everyone,Personalization
+Speedometer with G-FORCE meter,TOOLS,3.8,415,2.7M,50000,Free,0,Everyone,Tools
+A41 WatchFace for Android Wear Smart Watch,LIFESTYLE,4.5,231,5.7M,5000,Paid,$0.99,Everyone,Lifestyle
+Radial-G : Infinity,GAME,3.6,517,47M,50000,Free,0,Everyone,Arcade
+G-NetReport Pro,TOOLS,4.0,0,1.6M,10,Paid,$25.99,Everyone,Tools
+Dialer theme G Black Gold,PERSONALIZATION,4.2,33,857k,500,Paid,$1.49,Everyone,Personalization
+G-REMOTE,HOUSE_AND_HOME,4.5,30,25M,1000,Free,0,Everyone,House & Home
+Car G-Force Meter,TOOLS,4.2,184,1.3M,10000,Free,0,Everyone,Tools
+G-NetWiFi Pro,TOOLS,3.3,6,1.5M,100,Paid,$5.99,Everyone,Tools
+Helix Jump,GAME,4.2,1485806,33M,100000000,Free,0,Everyone,Action
+HSPA+ Tweaker (3G booster),TOOLS,4.3,99290,3.9M,5000000,Free,0,Everyone,Tools
+Offroad Car H,FAMILY,4.2,1960,87M,100000,Free,0,Everyone,Simulation
+H&M,LIFESTYLE,3.7,41917,14M,10000000,Free,0,Everyone,Lifestyle
+Guns - Shot Sounds,FAMILY,3.8,29544,10M,10000000,Free,0,Everyone,Entertainment
+HPlus,HEALTH_AND_FITNESS,2.9,1786,5.9M,100000,Free,0,Everyone,Health & Fitness
+Geometry Dash Lite,GAME,4.5,6181640,58M,100000000,Free,0,Everyone,Arcade
+DNS Changer - BEST (Gprs/Edge/3G/H/H+/4G),TOOLS,4.3,123,1.9M,5000,Free,0,Everyone,Tools
+H*nest Meditation,LIFESTYLE,4.9,145,48M,5000,Paid,$1.99,Mature 17+,Lifestyle
+Car Driving Simulator Drift,GAME,4.4,19816,57M,1000000,Free,0,Everyone,Racing
+Deaf - Hearing chat device H,COMMUNICATION,4.4,9,51k,500,Paid,$3.99,Everyone,Communication
+صور حرف H,ART_AND_DESIGN,4.4,13,4.5M,1000,Free,0,Everyone,Art & Design
+H Band 2.0,HEALTH_AND_FITNESS,2.9,4031,8.9M,500000,Free,0,Everyone,Health & Fitness
+H!LooK - Dating,DATING,4.2,46,26M,10000,Free,0,Mature 17+,Dating
+H-Connect,HEALTH_AND_FITNESS,4.0,50,15M,5000,Free,0,Everyone,Health & Fitness
+most expensive app (H),FAMILY,4.3,6,1.5M,100,Paid,$399.99,Everyone,Entertainment
+AntennaPict β,COMMUNICATION,4.3,15439,2.2M,1000000,Free,0,Everyone,Communication
+Elkhart County 4-H Fair,FAMILY,3.9,38,42M,5000,Free,0,Everyone,Entertainment
+H TV,FAMILY,4.3,103064,5.6M,5000000,Free,0,Everyone,Entertainment
+H letter images,SOCIAL,4.3,17,8.5M,1000,Free,0,Teen,Social
+H Band,HEALTH_AND_FITNESS,4.0,214,8.9M,10000,Free,0,Everyone,Health & Fitness
+The World Ends With You,GAME,4.6,4108,13M,10000,Paid,$17.99,Everyone 10+,Arcade
+MJX H,FAMILY,3.7,126,13M,10000,Free,0,Everyone,Entertainment
+tinyCam Monitor FREE,HOUSE_AND_HOME,4.0,65914,Varies with device,10000000,Free,0,Everyone,House & Home
+H-Kakashi - theme Xperia™,PERSONALIZATION,4.6,621,5.4M,50000,Free,0,Everyone,Personalization
+RC City Police Heavy Traffic Racer,GAME,4.4,3250,27M,1000000,Free,0,Everyone,Racing
+"Alphabet ""H"" Passcode Lock Screen",PERSONALIZATION,4.5,2,3.0M,100,Free,0,Everyone,Personalization
+Ohio State Fair 4-H,FAMILY,3.0,4,19M,1000,Free,0,Everyone,Entertainment
+Larry H Miller Automotive,PRODUCTIVITY,3.1,67,8.3M,10000,Free,0,Everyone,Productivity
+Talking Ben the Dog,FAMILY,4.3,1633565,57M,100000000,Free,0,Everyone,Entertainment
+Add-On: Alcatel (h),PRODUCTIVITY,4.5,107,1.2M,50000,Free,0,Everyone,Productivity
+My Android Device S/W & H/W,FAMILY,4.5,681,2.8M,50000,Free,0,Everyone,Education
+ADMIRALTY H-Note,BUSINESS,4.5,176,19M,10000,Free,0,Everyone,Business
+Force LTE Only,TOOLS,4.1,10426,7.2M,1000000,Free,0,Everyone,Tools
+Ulysse Speedometer Pro,AUTO_AND_VEHICLES,4.6,4140,Varies with device,50000,Paid,$1.99,Everyone,Auto & Vehicles
+Talking Ginger,FAMILY,4.2,1752017,52M,100000000,Free,0,Everyone,Entertainment
+D+H Reaction Wall,GAME,4.3,0,Varies with device,1,Paid,$0.99,Everyone,Arcade
+Motorbike Driving Simulator 3D,GAME,3.9,178723,65M,10000000,Free,0,Everyone,Racing
+Helix,GAME,3.9,2454,37M,500000,Free,0,Everyone,Arcade
+Mobile Number Tracker,TOOLS,3.9,19758,2.9M,5000000,Free,0,Everyone,Tools
+imo free video calls and chat,COMMUNICATION,4.3,4785892,11M,500000000,Free,0,Everyone,Communication
+I am Nose Doctor -Save my Nose,FAMILY,4.2,3133,34M,500000,Free,0,Everyone,Casual
+free video calls and chat,COMMUNICATION,4.2,594720,Varies with device,50000000,Free,0,Everyone,Communication
+What was I in my Past Life,FAMILY,3.7,7453,6.5M,1000000,Free,0,Everyone,Entertainment
+How Old am I?,FAMILY,2.8,4635,3.9M,1000000,Free,0,Everyone,Entertainment
+slither.io,GAME,4.4,5231553,Varies with device,100000000,Free,0,Everyone,Action
+I Screen Dialer,TOOLS,4.1,8137,3.9M,1000000,Free,0,Everyone,Tools
+Where's My Water? Free,FAMILY,4.4,1372013,57M,100000000,Free,0,Everyone,Puzzle;Brain Games
+How Do I Look,PHOTOGRAPHY,2.7,3032,2.8M,500000,Free,0,Everyone,Photography
+Solitaire!,GAME,4.7,403911,23M,10000000,Free,0,Everyone,Card
+POF Free Dating App,SOCIAL,4.2,1175188,Varies with device,50000000,Free,0,Mature 17+,Social
+iGun Pro -The Original Gun App,GAME,4.2,249308,55M,10000000,Free,0,Everyone,Arcade
+Skype - free IM & video calls,COMMUNICATION,4.1,10484169,Varies with device,1000000000,Free,0,Everyone,Communication
+Sonic Dash,GAME,4.5,3777822,75M,100000000,Free,0,Everyone,Arcade
+I'm Ping Pong King :),SPORTS,4.4,29864,40M,1000000,Free,0,Everyone,Sports
+LINE I Love Coffee,FAMILY,4.0,250257,50M,5000000,Free,0,Everyone,Simulation
+Text Free: WiFi Calling App,SOCIAL,4.2,83474,Varies with device,5000000,Free,0,Everyone,Social
+"Talkatone: Free Texts, Calls & Phone Number",COMMUNICATION,4.1,132015,25M,10000000,Free,0,Everyone,Communication
+Instachat 😜,SOCIAL,4.0,80987,25M,5000000,Free,0,Teen,Social
+Textgram - write on photos,ART_AND_DESIGN,4.4,295237,Varies with device,10000000,Free,0,Everyone,Art & Design
+"Fame Boom for Real Followers, Likes",SOCIAL,4.7,896118,6.6M,5000000,Free,0,Everyone,Social
+NinJump,GAME,4.3,421000,36M,10000000,Free,0,Everyone,Arcade
+Zombie Catchers,GAME,4.7,989158,75M,10000000,Free,0,Everyone,Action
+FollowMeter for Instagram,SOCIAL,4.4,90082,8.8M,1000000,Free,0,Everyone,Social
+I LOVE PASTA,FAMILY,4.0,83875,43M,1000000,Free,0,Everyone,Simulation
+Talking Tom Cat,FAMILY,4.3,1838090,Varies with device,100000000,Free,0,Everyone 10+,Casual
+Fidget Spinner,GAME,4.2,307398,9.9M,10000000,Free,0,Everyone,Arcade
+Jetpack Joyride,GAME,4.4,4637439,96M,100000000,Free,0,Everyone 10+,Arcade
+J Touch,TOOLS,4.6,2176,953k,100000,Free,0,Everyone,Tools
+J-Novel Club,FAMILY,3.3,162,9.0M,10000,Free,0,Teen,Entertainment
+Anger of stick 5 : zombie,GAME,4.5,547644,23M,50000000,Free,0,Teen,Action
+J - Style Pro,HEALTH_AND_FITNESS,2.3,74,2.6M,10000,Free,0,Everyone,Health & Fitness
+Cook Baked Lasagna,FAMILY,4.2,56259,23M,10000000,Free,0,Everyone,Casual
+Tom's Love Letters,FAMILY,4.1,705805,35M,50000000,Free,0,Everyone,Entertainment
+The J-Notes: Jazz News,SPORTS,4.2,7,7.2M,1000,Free,0,Everyone 10+,Sports
+Cut the Rope FULL FREE,FAMILY,4.4,2122705,49M,100000000,Free,0,Everyone,Puzzle
+Mali J,SOCIAL,3.2,185,4.7M,10000,Free,0,Teen,Social
+J-UFO,FAMILY,3.5,339,Varies with device,100000,Free,0,Everyone,Entertainment
+Cut the Rope GOLD,FAMILY,4.6,61264,43M,1000000,Paid,$0.99,Everyone,Puzzle
+Turbo FAST,FAMILY,4.3,1329008,97M,50000000,Free,0,Everyone,Racing;Action & Adventure
+"The Voice, sing and connect",FAMILY,4.1,405824,Varies with device,10000000,Free,0,Everyone,Entertainment
+J. Cole Rapper Wallpaper HD,PERSONALIZATION,4.1,8,3.1M,1000,Free,0,Everyone,Personalization
+Keyboard for Sony Xperia J,PERSONALIZATION,4.1,797,6.7M,50000,Free,0,Everyone,Personalization
+J Alvarej Moji,COMMUNICATION,4.2,2,13M,10,Paid,$1.99,Everyone,Communication
+Harris J Lyrics,FAMILY,4.7,36,7.1M,1000,Free,0,Everyone,Entertainment
+Smart TV Remote,TOOLS,3.5,81747,9.1M,10000000,Free,0,Everyone,Tools
+J.ME Fly,FAMILY,3.9,28,98M,1000,Free,0,Everyone,Entertainment
+J Balvin Piano Tiles,GAME,4.3,6,30M,500,Free,0,Everyone,Music
+Guess the song of J Balvin,GAME,4.3,28,8.9M,1000,Free,0,Everyone,Trivia
+J-Stars Victory VS Guide,GAME,4.1,609,13M,10000,Free,0,Everyone,Action
+2048 BTS J Hope KPop Puzzle Game,FAMILY,4.7,17,2.4M,1000,Free,0,Everyone,Puzzle
+J. Polep Plus Mobile,PRODUCTIVITY,4.2,0,44M,100,Free,0,Everyone,Productivity
+J. Cole Albums (2007-2017),FAMILY,4.6,7,7.3M,1000,Free,0,Mature 17+,Entertainment
+J Dark Ice Substratum Theme,PERSONALIZATION,4.5,164,33M,10000,Free,0,Everyone,Personalization
+BTS J-Hope Wallpaper KPOP Fans HD,PERSONALIZATION,4.7,98,3.4M,10000,Free,0,Everyone,Personalization
+BTS j-hope LINE Launcher theme,PERSONALIZATION,4.9,934,3.8M,10000,Free,0,Everyone,Personalization
+BTS J-Hope Wallpaper HD for KPOP Fans,PERSONALIZATION,4.3,4,3.6M,500,Free,0,Everyone,Personalization
+Kik,COMMUNICATION,4.3,2451136,Varies with device,100000000,Free,0,Teen,Communication
+K Health,HEALTH_AND_FITNESS,4.1,290,40M,50000,Free,0,Teen,Health & Fitness
+CIRCLE K,SHOPPING,4.4,9140,14M,500000,Free,0,Everyone,Shopping
+K-@ Mail Pro - Email App,COMMUNICATION,4.2,1603,Varies with device,10000,Paid,$4.99,Everyone,Communication
+K-@ Mail - Email App,COMMUNICATION,4.1,1760,Varies with device,100000,Free,0,Everyone,Communication
+Keepsafe Photo Vault: Hide Private Photos & Videos,PHOTOGRAPHY,4.6,1656808,Varies with device,50000000,Free,0,Everyone,Photography
+KIM KARDASHIAN: HOLLYWOOD,GAME,4.3,1017408,34M,10000000,Free,0,Teen,Adventure
+Sight Words Pre-K to Grade-3,FAMILY,4.4,1185,40M,100000,Free,0,Everyone,Educational;Education
+K PLUS,FINANCE,4.4,124324,Varies with device,10000000,Free,0,Everyone,Finance
+[Substratum] K-Manager for K-Klock,PERSONALIZATION,4.5,14,11M,1000,Free,0,Everyone,Personalization
+KDRAMA Amino for K-Drama Fans,SOCIAL,4.6,4046,63M,100000,Free,0,Teen,Social
+K keyboard - Myanmar,TOOLS,4.8,1955,14M,100000,Free,0,Everyone,Tools
+Zapzapmath: K-6 Math Games,FAMILY,4.3,1065,61M,100000,Free,0,Everyone,Educational;Education
+KPOP Amino for K-Pop Entertainment,SOCIAL,4.8,19047,63M,100000,Free,0,Teen,Social
+K.MOJI,FAMILY,4.8,16,8.9M,500,Paid,$1.99,Everyone,Entertainment
+K-Chiing VPN (Free),TOOLS,3.7,43,10M,5000,Free,0,Mature 17+,Tools
+Preschool All-In-One,FAMILY,4.1,9019,44M,1000000,Free,0,Everyone,Casual;Education
+OST),FAMILY,3.7,4444,10M,500000,Free,0,Everyone,Entertainment
+Kpop Music Quiz (K-pop Game),FAMILY,4.2,6418,59M,100000,Free,0,Everyone,Casual
+Radio K - KUOM,FAMILY,4.5,39,7.4M,1000,Free,0,Everyone,Entertainment
+Math Games for Pre-K - Grade 4,FAMILY,4.6,28,23M,1000,Paid,$1.99,Everyone,Education;Education
+"PowerDirector Video Editor App: 4K, Slow Mo & More",VIDEO_PLAYERS,4.5,712737,50M,10000000,Free,0,Everyone,Video Players & Editors
+Fuzzy Numbers: Pre-K Number Foundation,FAMILY,4.7,21,44M,1000,Paid,$5.99,Everyone,Education;Education
+KakaoTalk: Free Calls & Text,COMMUNICATION,4.3,2546549,Varies with device,100000000,Free,0,Everyone,Communication
+Speech Therapy: K,FAMILY,4.2,2,15M,1000,Free,0,Everyone,Education
+K-Otic Universe,FAMILY,4.9,55,40M,1000,Free,0,Everyone,Puzzle
+Magic Tiles - TWICE Edition (K-Pop),GAME,4.4,2351,62M,100000,Free,0,Everyone,Music
+CASE K-12 Math English Science,FAMILY,4.6,60,2.1M,10000,Free,0,Everyone,Education
+Mermaid Princess Pre K Games,FAMILY,4.2,19,31M,5000,Free,0,Everyone,Educational;Education
+K-App Mitarbeiter Galeria Kaufhof,PRODUCTIVITY,4.2,0,19M,100,Free,0,Everyone,Productivity
+"Niche: College, K-12, and Neighborhood Search",LIFESTYLE,4.0,42,26M,5000,Free,0,Everyone,Lifestyle
+"K-Spapp, the K-Space app",FAMILY,4.8,39,3.6M,1000,Free,0,Everyone,Education
+"Math Quiz Free: Grades K,1,2,3",FAMILY,4.3,159,13M,10000,Free,0,Everyone,Education;Education
+K-9 Material (unofficial),COMMUNICATION,4.4,64,4.5M,5000,Free,0,Teen,Communication
+Discovery K!ds Play! Español,FAMILY,4.2,11263,35M,1000000,Free,0,Everyone,Entertainment;Music & Video
+Magic Tiles - Blackpink Edition (K-Pop),GAME,4.6,4304,71M,100000,Free,0,Everyone,Music
+Wallpapers Bus Scania Irizar K,PERSONALIZATION,4.3,35,15M,10000,Free,0,Teen,Personalization
+Anna.K Tarot,FAMILY,4.8,17,23M,100,Paid,$3.99,Mature 17+,Entertainment
+K-pop Music,FAMILY,4.0,369,3.5M,10000,Free,0,Everyone,Entertainment
+Daily K-Talk,FAMILY,4.3,264,60M,10000,Free,0,Everyone,Education
+Korean Dungeon: K-Word 1000,GAME,4.7,703,40M,10000,Free,0,Everyone 10+,Word
+"LiveMe - Video chat, new friends, and make money",SOCIAL,4.5,456866,Varies with device,10000000,Free,0,Teen,Social
+Talking Tom Gold Run,GAME,4.6,2694969,78M,100000000,Free,0,Everyone,Action
+"letgo: Buy & Sell Used Stuff, Cars & Real Estate",SHOPPING,4.5,972256,20M,50000000,Free,0,Teen,Shopping
+Lep's World 🍀,GAME,4.3,696019,Varies with device,50000000,Free,0,Everyone 10+,Arcade
+"L.POINT - 엘포인트 [ 포인트, 멤버십, 적립, 사용, 모바일 카드, 쿠폰, 롯데]",LIFESTYLE,4.0,45224,49M,5000000,Free,0,Everyone,Lifestyle
+Love Balls,FAMILY,4.2,357049,40M,50000000,Free,0,Everyone,Puzzle
+SpongeBob Diner Dash,FAMILY,4.0,576210,48M,50000000,Free,0,Everyone,Casual
+Last Day on Earth: Survival,GAME,4.5,2308916,87M,10000000,Free,0,Teen,Action
+"Messenger L SMS, MMS",PERSONALIZATION,4.0,6263,20M,500000,Free,0,Everyone,Personalization
+Tom Loves Angela,FAMILY,4.1,1111915,50M,100000000,Free,0,Everyone,Entertainment
+EXO-L,FAMILY,4.6,67410,865k,1000000,Free,0,Everyone,Entertainment
+Lie Detector,FAMILY,3.1,306,2.9M,50000,Free,0,Everyone,Simulation
+EXO-L Amino for EXO Fans,SOCIAL,4.9,5677,67M,50000,Free,0,Teen,Social
+Calculator L,PRODUCTIVITY,4.5,2965,2.4M,100000,Free,0,Everyone,Productivity
+My Teacher - Classroom Play,FAMILY,4.0,155276,61M,10000000,Free,0,Everyone,Role Playing;Pretend Play
+Emoji Android L Keyboard,PRODUCTIVITY,4.0,11535,6.8M,1000000,Free,0,Everyone,Productivity
+Lollipop Keyboard L Pro,PERSONALIZATION,3.6,5525,2.6M,500000,Free,0,Everyone,Personalization
+French to English Speaking - Apprendre l' Anglais,FAMILY,4.5,4251,13M,1000000,Free,0,Everyone,Education
+Ant Smasher by Best Cool & Fun Games,GAME,4.2,1185148,29M,100000000,Free,0,Everyone,Arcade
+Cheating Tom 3 - Genius School,GAME,4.3,90415,84M,10000000,Free,0,Everyone,Arcade
+Clock L,PERSONALIZATION,3.9,2852,5.4M,100000,Free,0,Everyone,Personalization
+Dialer theme Droid L,PERSONALIZATION,4.3,1734,2.8M,100000,Free,0,Mature 17+,Personalization
+SPEED L,SHOPPING,4.3,85,2.9M,50000,Free,0,Everyone,Shopping
+Lie Detector Test Prank,FAMILY,4.4,222308,6.9M,10000000,Free,0,Everyone,Entertainment
+Xbox,FAMILY,4.3,556659,46M,10000000,Free,0,Everyone,Entertainment
+Je Parle ANGLAIS - Apprendre l’anglais Audio cours,FAMILY,4.4,499,27M,100000,Free,0,Everyone,Education
+"Mobizen Screen Recorder - Record, Capture, Edit",PRODUCTIVITY,4.3,1827212,Varies with device,50000000,Free,0,Everyone,Productivity
+Minecraft,FAMILY,4.5,2375336,Varies with device,10000000,Paid,$6.99,Everyone 10+,Arcade;Action & Adventure
+Mobizen Screen Recorder for SAMSUNG,VIDEO_PLAYERS,4.4,953894,37M,10000000,Free,0,Everyone,Video Players & Editors
+MapleStory M,FAMILY,3.5,31538,82M,1000000,Free,0,Everyone 10+,Role Playing
+M-Files,BUSINESS,4.4,236,44M,10000,Free,0,Everyone,Business
+M Launcher -Marshmallow 6.0,PERSONALIZATION,4.4,37234,7.3M,1000000,Free,0,Everyone,Personalization
+"Mobizen Screen Recorder for LG - Record, Capture",VIDEO_PLAYERS,4.5,58820,37M,1000000,Free,0,Everyone,Video Players & Editors
+MakeupPlus - Your Own Virtual Makeup Artist,PHOTOGRAPHY,4.4,758780,53M,50000000,Free,0,Everyone,Photography
+M3-X5-X6-M-İ3-İ8 RACİNG 2018,GAME,4.4,596,44M,100000,Free,0,Everyone,Arcade
+MEGA,PRODUCTIVITY,4.0,549214,Varies with device,50000000,Free,0,Everyone,Productivity
+360-M Flight,TOOLS,3.9,84,24M,10000,Free,0,Everyone,Tools
+M-acceleration 3D Car Racing,GAME,3.9,1202,34M,100000,Free,0,Everyone,Racing
+m>notes notepad,PRODUCTIVITY,4.3,184,Varies with device,1000,Paid,$2.99,Everyone,Productivity
+M+,NEWS_AND_MAGAZINES,4.9,198,9.1M,10000,Free,0,Everyone,News & Magazines
+Super Hero M Craft Run,GAME,3.7,303,38M,100000,Free,0,Everyone,Arcade
+M-Sight Pro,VIDEO_PLAYERS,3.3,30,15M,5000,Free,0,Everyone,Video Players & Editors
+💎 I'm rich,LIFESTYLE,3.8,718,26M,10000,Paid,$399.99,Everyone,Lifestyle
+Don't Hug Me I'm So Scared,GAME,3.5,901,63M,50000,Free,0,Everyone,Adventure
+GTS-M,TOOLS,4.2,38,251k,5000,Free,0,Everyone,Tools
+MX Player,VIDEO_PLAYERS,4.5,6469179,Varies with device,500000000,Free,0,Everyone,Video Players & Editors
+M star Dialer,COMMUNICATION,3.5,400,4.2M,100000,Free,0,Everyone,Communication
+I'm Rich - Trump Edition,LIFESTYLE,3.6,275,7.3M,10000,Paid,$400.00,Everyone,Lifestyle
+I’m Expecting - Pregnancy App,HEALTH_AND_FITNESS,4.6,71266,49M,1000000,Free,0,Everyone,Health & Fitness
+Free WiFi Connect,COMMUNICATION,3.9,167229,9.7M,10000000,Free,0,Everyone,Communication
+M Notifier for M Launcher,TOOLS,4.2,2803,1.4M,100000,Free,0,Everyone,Tools
+M Theme - Dark Green Icon Pack,PERSONALIZATION,4.2,202,4.9M,10000,Free,0,Everyone,Personalization
+m-Faisaa,FINANCE,4.0,142,6.2M,10000,Free,0,Everyone,Finance
+m:go BiH,COMMUNICATION,3.2,559,6.0M,10000,Free,0,Everyone,Communication
+Diabetes:M,MEDICAL,4.6,15537,Varies with device,100000,Free,0,Everyone,Medical
+Libre Scan (Diabetes:M addon),MEDICAL,2.4,102,1.2M,10000,Free,0,Everyone,Medical
+m.ride - your motorcycle app,AUTO_AND_VEHICLES,4.5,189,16M,10000,Free,0,Everyone,Auto & Vehicles
+Rope'n'Fly 4,GAME,4.1,234606,59M,10000000,Free,0,Everyone,Action
+N Launcher: Nougat Theme,PERSONALIZATION,4.2,128,7.7M,10000,Free,0,Everyone,Personalization
+Dino in City-Dinosaur N Police,FAMILY,3.7,10035,30M,1000000,Free,0,Teen,Simulation
+N Launcher Pro - Nougat 7.0,PERSONALIZATION,4.3,2538,6.4M,100000,Paid,$2.99,Everyone,Personalization
+Cops N Robbers - FPS Mini Game,GAME,4.2,156862,64M,5000000,Free,0,Everyone 10+,Action
+Cops N Robbers 2,GAME,4.1,63680,46M,1000000,Free,0,Everyone 10+,Adventure
+Hands 'n Guns Simulator,FAMILY,3.9,19727,76M,1000000,Free,0,Teen,Simulation
+Hide N Seek : Mini Game,GAME,3.8,4719,54M,500000,Free,0,Everyone,Action
+N Launcher - Nougat 7.0,PERSONALIZATION,4.4,32597,8.4M,1000000,Free,0,Everyone,Personalization
+Cook'n Recipe App,LIFESTYLE,3.4,552,22M,10000,Free,0,Everyone,Lifestyle
+Rope'n'Fly 3 - Dusk Till Dawn,GAME,4.0,166033,23M,10000000,Free,0,Everyone 10+,Arcade
+Tap N Pay,PRODUCTIVITY,4.4,253,8.2M,10000,Free,0,Everyone,Productivity
+N-Com Wizard,COMMUNICATION,3.3,960,3.8M,50000,Free,0,Everyone,Communication
+Drag'n'Boom,GAME,4.8,133180,54M,1000000,Free,0,Everyone 10+,Arcade
+Traps n' Gemstones,GAME,4.5,413,9.1M,1000,Paid,$4.99,Everyone,Adventure
+Shop 'n Save,SHOPPING,3.4,620,40M,100000,Free,0,Everyone,Shopping
+Dual N-Back - Brain game,FAMILY,4.3,817,28M,100000,Free,0,Everyone,Educational
+N Files - File Manager & Explorer,PRODUCTIVITY,4.3,369,11M,10000,Free,0,Everyone,Productivity
+Guns'n'Glory Zombies Premium,FAMILY,4.1,313,34M,5000,Paid,$2.99,Everyone 10+,Strategy
+Cops N Robbers,GAME,4.0,37789,58M,1000000,Free,0,Teen,Adventure
+Guns'n'Glory Premium,FAMILY,4.4,3570,21M,100000,Paid,$2.99,Everyone 10+,Strategy
+Madagascar Surf n' Slides Free,FAMILY,3.8,48929,45M,5000000,Free,0,Everyone,Educational;Education
+Guns'n'Glory,FAMILY,4.4,89947,22M,5000000,Free,0,Everyone 10+,Strategy
+Ghosts'n Goblins MOBILE,GAME,3.8,466,28M,10000,Paid,$0.99,Everyone,Arcade
+Mopar Drag N Brag,GAME,4.2,30630,17M,1000000,Free,0,Everyone,Racing
+Read Unlimitedly! Kids'n Books,FAMILY,3.8,7462,31M,1000000,Free,0,Everyone,Education;Music & Video
+Dark Infusion Substratum Theme for Android N & O,PERSONALIZATION,4.8,133,59M,1000,Paid,$2.49,Everyone,Personalization
+Fantastic Chefs: Match 'n Cook,FAMILY,4.7,8600,91M,500000,Free,0,Everyone,Puzzle
+Guns'n'Glory Heroes Premium,FAMILY,4.3,923,Varies with device,10000,Paid,$2.99,Everyone,Strategy
+Eat'n Park,LIFESTYLE,3.5,292,20M,50000,Free,0,Everyone,Lifestyle
+Draw N Guess Multiplayer,GAME,3.9,29505,69M,1000000,Free,0,Everyone,Word
+Car Parking Crane N Drifting,FAMILY,4.2,106,71M,50000,Free,0,Everyone,Simulation
+Lock 'n' Roll Pro - Ad Free,GAME,4.6,169,13M,1000,Paid,$0.99,Everyone,Card
+Rock N' Cash Casino Slots -Free Vegas Slot Games,GAME,4.7,6187,33M,100000,Free,0,Teen,Casino
+Age of Conquest: N. America,FAMILY,4.5,659,3.3M,10000,Paid,$3.99,Everyone,Strategy
+Sketch 'n' go,VIDEO_PLAYERS,3.8,3965,6.4M,100000,Free,0,Everyone,Video Players & Editors
+Guns'n'Glory WW2 Premium,FAMILY,4.5,4656,20M,100000,Paid,$2.99,Everyone 10+,Strategy
+Rock n Roll Music Quiz Game,GAME,3.7,80,7.6M,10000,Free,0,Everyone,Trivia
+Cook 'n Learn Smart Kitchen,FAMILY,3.5,205,62M,50000,Free,0,Everyone,Educational;Education
+Jump'N'Shoot Attack,GAME,4.1,155,32M,1000,Paid,$2.49,Everyone,Arcade
+Ghouls'n Ghosts MOBILE,GAME,3.9,168,49M,5000,Paid,$1.99,Everyone 10+,Arcade
+N-Back,FAMILY,4.1,413,930k,10000,Free,0,Everyone,Puzzle
+Oddworld: New 'n' Tasty,GAME,4.6,1475,34M,10000,Paid,$4.99,Teen,Action
+Knights N Squires,FAMILY,4.4,148826,49M,1000000,Free,0,Teen,Role Playing
+Opera Mini - fast web browser,COMMUNICATION,4.5,5150801,Varies with device,100000000,Free,0,Everyone,Communication
+Opera Browser: Fast and Secure,COMMUNICATION,4.4,2473795,Varies with device,100000000,Free,0,Everyone,Communication
+Planet O - Icon Pack,PERSONALIZATION,4.6,354,24M,10000,Paid,$0.99,Everyone,Personalization
+The Noise-O-Meter,FAMILY,4.0,1699,72M,100000,Free,0,Everyone,Entertainment;Music & Video
+O Launcher 8.0 for Android™ O Oreo Launcher,TOOLS,4.4,11393,8.7M,1000000,Free,0,Everyone,Tools
+Opera Mini browser beta,COMMUNICATION,4.4,401530,Varies with device,10000000,Free,0,Everyone,Communication
+Stand O’Food® (Full),FAMILY,4.4,925,40M,10000,Paid,$1.99,Everyone,Casual
+WiFi-o-Matic,PRODUCTIVITY,4.0,736,6.8M,50000,Free,0,Everyone,Productivity
+Detect-O-Gromit (D.O.G 2),FAMILY,3.8,45,47M,10000,Paid,$2.49,Everyone,Entertainment
+O Shopping,SHOPPING,3.9,671,3.6M,100000,Free,0,Everyone,Shopping
+Obbligo o Verità? PRO,GAME,4.3,4,2.9M,100,Paid,$0.99,Teen,Board
+AC Remote for O General - NOW FREE,TOOLS,3.7,274,26M,50000,Free,0,Everyone,Tools
+O'Route Orienteering,SPORTS,4.2,6,1.3M,100,Paid,$3.02,Everyone,Sports
+Drink-O-Tron The Drinking Game,GAME,4.1,140,45M,50000,Free,0,Mature 17+,Card
+Multiling O Keyboard + emoji,PRODUCTIVITY,4.3,30443,540k,1000000,Free,0,Everyone,Productivity
+Google I/O 2018,BOOKS_AND_REFERENCE,4.3,22401,4.6M,500000,Free,0,Everyone,Books & Reference
+Prime Key for Nougat Launcher& O Launcher &KitKat,PERSONALIZATION,4.1,324,313k,5000,Paid,$6.99,Everyone,Personalization
+OO Launcher for Android O 8.0 Oreo™ Launcher,PERSONALIZATION,4.4,14832,8.6M,1000000,Free,0,Everyone,Personalization
+Band O'Clock,LIFESTYLE,3.8,1140,746k,100000,Free,0,Everyone,Lifestyle
+O Launcher,TOOLS,4.3,2059,10M,100000,Free,0,Everyone,Tools
+O-Star,DATING,4.4,59,38M,5000,Free,0,Everyone,Dating
+Verdad o Reto,SOCIAL,3.8,826,5.1M,500000,Free,0,Teen,Social
+Pixlr-o-matic,PHOTOGRAPHY,4.5,180697,6.1M,10000000,Free,0,Everyone,Photography
+O-Level Past Papers & Solution (up to 2017),FAMILY,3.8,589,28M,100000,Free,0,Everyone,Education
+"O Multiple - App Cloner, Duals APP, tarallel",TOOLS,3.9,145,5.2M,50000,Free,0,Everyone,Tools
+The Maze Runner,GAME,4.0,428268,22M,10000000,Free,0,Everyone,Action
+Psiphon Pro - The Internet Freedom VPN,COMMUNICATION,4.3,298041,Varies with device,10000000,Free,0,Everyone,Communication
+PicsArt Photo Studio: Collage Maker & Pic Editor,PHOTOGRAPHY,4.5,7590099,34M,100000000,Free,0,Teen,Photography
+P Icon Pack for Pixel,PERSONALIZATION,4.4,38,51M,1000,Free,0,Everyone,Personalization
+Android P | Xperia™ Theme 4800+ icons,PERSONALIZATION,4.6,29,39M,100,Paid,$1.99,Everyone,Personalization
+Android P Home KLWP,PERSONALIZATION,4.3,0,2.1M,5,Paid,$1.49,Everyone,Personalization
+P-Home for KLWP,PERSONALIZATION,5.0,4,12M,100,Paid,$0.99,Everyone,Personalization
+[substratum] Vacuum: P,PERSONALIZATION,4.4,230,11M,1000,Paid,$1.49,Everyone,Personalization
+"Super P Launcher for Android P 9.0 launcher, theme",TOOLS,4.4,2026,7.5M,100000,Free,0,Everyone,Tools
+pixiv,SOCIAL,4.2,86956,24M,1000000,Free,0,Mature 17+,Social
+[Sub/EMUI] P Pro - EMUI 8.1/8.0/5.X Theme,PERSONALIZATION,4.0,13,19M,100,Paid,$0.99,Everyone,Personalization
+Pacify Exceed (Android P) - Theme for Xperia™,PERSONALIZATION,4.3,5,1.9M,10,Paid,$1.49,Everyone,Personalization
+Theme Android P Design for LG V30,PERSONALIZATION,4.2,35,5.2M,500,Paid,$1.49,Everyone,Personalization
+Pistachio Launcher for Android P 9.0,PERSONALIZATION,4.3,0,2.3M,1,Paid,$1.49,Everyone,Personalization
+Theme Android P for LG G7 & V35,PERSONALIZATION,4.6,5,4.5M,100,Paid,$1.49,Everyone,Personalization
+Volume Slider Like Android P Volume Control,TOOLS,4.1,1129,1.7M,10000,Paid,$0.99,Everyone,Tools
+Pacify (Android P theme) - Theme for Xperia™,PERSONALIZATION,4.3,1,1.8M,10,Paid,$0.99,Everyone,Personalization
+P Launcher for Android™ 9.0,PERSONALIZATION,3.9,35,6.3M,5000,Free,0,Everyone,Personalization
+PixelLab - Text on pictures,PHOTOGRAPHY,4.6,108002,Varies with device,10000000,Free,0,Everyone,Photography
+Popsicle Launcher for Android P 9.0 launcher,PERSONALIZATION,4.3,0,5.5M,0,Paid,$1.49,Everyone,Personalization
+Theme Android P Black design for LG V30,PERSONALIZATION,4.4,8,6.2M,100,Paid,$1.49,Everyone,Personalization
+P Launcher Theme For Android™ 9.0,PERSONALIZATION,3.9,213,28M,10000,Free,0,Everyone,Personalization
+Theme Android P Black for LG G7 & V35,PERSONALIZATION,4.6,5,4.3M,100,Paid,$1.49,Everyone,Personalization
+P Theme for Android™ P 9.0 Style Launcher,PERSONALIZATION,4.5,216,5.7M,50000,Free,0,Everyone,Personalization
+Android P 9.0,PERSONALIZATION,3.0,12,4.9M,500,Free,0,Everyone,Personalization
+Pureness Pacify (Android P) - Theme for Xperia™,PERSONALIZATION,4.3,0,3.6M,1,Paid,$1.49,Everyone,Personalization
+Android P Wallpapers,PERSONALIZATION,3.6,53,2.0M,5000,Free,0,Everyone,Personalization
+P XPERIA Theme™ | Design For SONY 🎨,PERSONALIZATION,4.4,147,16M,10000,Free,0,Everyone,Personalization
+Parallel Space - Multiple accounts & Two face,PERSONALIZATION,4.6,3062845,7.4M,100000000,Free,0,Everyone,Personalization
+Theme for New Android P,PERSONALIZATION,4.3,13,4.3M,1000,Free,0,Everyone,Personalization
+P9 Launcher - Android™ 9.0 P Launcher Style,TOOLS,4.3,1162,7.3M,100000,Free,0,Everyone,Tools
+Android P Style Icon Pack,PERSONALIZATION,5.0,1,60M,100,Paid,$0.99,Everyone,Personalization
+Android P Stock Wallpapers,PERSONALIZATION,4.5,16,3.7M,1000,Free,0,Everyone,Personalization
+G-Pix [Android P] Dark EMUI 8/5 THEME,PERSONALIZATION,4.1,169,24M,10000,Free,0,Everyone,Personalization
+G-Pix [Android P] EMUI 8/5 THEME,PERSONALIZATION,4.1,720,10M,100000,Free,0,Everyone,Personalization
+Android-P Mono Grey EMUI 8/5 Theme,PERSONALIZATION,4.5,61,7.5M,10000,Free,0,Everyone,Personalization
+P XPERIA Theme™ | PURPLE - Design For SONY 🎨,PERSONALIZATION,4.3,3,13M,500,Free,0,Everyone,Personalization
+Materialistic P Wallpapers,PERSONALIZATION,4.8,24,3.6M,1000,Free,0,Everyone,Personalization
+Android P Rotation,TOOLS,4.5,502,2.0M,10000,Free,0,Everyone,Tools
+P XPERIA Theme™ | INDIGO - Design For SONY 🎨,PERSONALIZATION,4.3,12,14M,1000,Free,0,Everyone,Personalization
+Android P Launcher 9.0 launcher,TOOLS,4.0,164,2.3M,10000,Free,0,Everyone,Tools
+Pixel Oreo/P Dark White AMOLED UI - Icon Pack,PERSONALIZATION,4.8,18,16M,5000,Paid,$1.49,Everyone,Personalization
+pretty Easy privacy p≡p,COMMUNICATION,3.7,21,20M,500,Paid,$0.99,Everyone,Communication
+P Icon Pack,FAMILY,4.2,0,21M,10,Paid,$0.99,Everyone,Entertainment
+Pi Dark [substratum],PERSONALIZATION,4.5,189,2.1M,10000,Free,0,Everyone,Personalization
+"Q Alerts: QAnon Drop Notifications, Research +++",NEWS_AND_MAGAZINES,4.7,143,26M,5000,Paid,$0.99,Mature 17+,News & Magazines
+The Q - Live Trivia Game Network,GAME,2.7,1486,14M,100000,Free,0,Everyone,Trivia
+Fossil Q,LIFESTYLE,2.9,6627,18M,500000,Free,0,Everyone,Lifestyle
+Q,FAMILY,4.2,69126,60M,1000000,Free,0,Everyone,Puzzle
+"Official QR Code® Reader ""Q""",PRODUCTIVITY,4.4,3031,Varies with device,500000,Free,0,Everyone,Productivity
+Q Cat Live Wallpaper,PERSONALIZATION,4.2,4383,7.1M,500000,Free,0,Teen,Personalization
+Q MINDshare Mobile,BUSINESS,3.4,24,Varies with device,10000,Free,0,Everyone,Business
+Fossil Q Legacy,LIFESTYLE,2.6,680,60M,50000,Free,0,Everyone,Lifestyle
+Offroad Car Q,FAMILY,4.1,24668,40M,1000000,Free,0,Everyone,Simulation
+Q*bert: Rebooted,GAME,4.3,13788,55M,1000000,Free,0,Everyone,Arcade
+Quora,SOCIAL,4.5,313403,Varies with device,10000000,Free,0,Teen,Social
+Gun Shoot War Q,GAME,4.2,26893,20M,1000000,Free,0,Teen,Arcade
+FaceQ,FAMILY,4.4,591411,19M,10000000,Free,0,Teen,Entertainment
+Q Actions - Digital Assistant,PRODUCTIVITY,4.2,0,Varies with device,500,Free,0,Everyone,Productivity
+Q Link Wireless Zone,PRODUCTIVITY,4.0,2194,17M,500000,Free,0,Everyone,Productivity
+Q Avatar (Avatar Maker),COMICS,4.4,2012,3.6M,100000,Free,0,Everyone,Comics
+Q downloader : download your social media videos,FAMILY,4.1,41,4.5M,1000,Free,0,Everyone,Entertainment
+Q Avatar Pro,FAMILY,4.8,4,3.6M,100,Paid,$1.49,Teen,Entertainment
+Q-See Plus,VIDEO_PLAYERS,2.2,32,33M,5000,Free,0,Everyone,Video Players & Editors
+Q Wunder,FAMILY,3.8,156,43M,10000,Free,0,Everyone,Education;Education
+Q-See QC View,TOOLS,3.1,657,21M,100000,Free,0,Everyone,Tools
+Leica Q,PHOTOGRAPHY,3.1,133,2.3M,10000,Free,0,Everyone,Photography
+Q Remote Control,TOOLS,3.8,4264,14M,500000,Free,0,Everyone,Tools
+Q-Ticketing,MAPS_AND_NAVIGATION,3.8,114,19M,10000,Free,0,Everyone,Maps & Navigation
+DJMAX TECHNIKA Q - Music Game,GAME,4.3,21107,95M,100000,Free,0,Everyone,Music
+myQ,TOOLS,3.6,3642,29M,100000,Free,0,Everyone,Tools
+QR Code Reader,TOOLS,4.0,495971,2.7M,50000000,Free,0,Everyone,Tools
+ICQ — Video Calls & Chat Messenger,COMMUNICATION,4.4,697939,Varies with device,10000000,Free,0,Everyone,Communication
+Q Operator,BUSINESS,4.6,60,Varies with device,1000,Free,0,Everyone,Business
+Q Call,TOOLS,4.0,20,16M,1000,Free,0,Everyone,Tools
+Q-slope,TOOLS,4.5,2,3.9M,50,Paid,$1.76,Everyone,Tools
+Q-Tech Companion App,FOOD_AND_DRINK,1.8,17,3.1M,10000,Free,0,Everyone,Food & Drink
+Q Mobile Banking,FINANCE,4.7,460,12M,10000,Free,0,Everyone,Finance
+Q Quiz SK,FAMILY,3.9,159,39M,5000,Free,0,Everyone,Education
+Big Q Car Service,MAPS_AND_NAVIGATION,4.4,75,26M,5000,Free,0,Everyone,Maps & Navigation
+Q-See QT View,TOOLS,3.6,7357,19M,100000,Free,0,Everyone,Tools
+ROBLOX,FAMILY,4.5,4443407,67M,100000000,Free,0,Everyone 10+,Adventure;Action & Adventure
+"DataCamp - Learn R, Python & SQL",FAMILY,4.4,944,12M,100000,Free,0,Everyone,Education
+R Language Reference Guide,BOOKS_AND_REFERENCE,3.9,54,2.8M,10000,Free,0,Everyone,Books & Reference
+Run R Script - Online Statistical Data Analysis,FAMILY,3.9,8,6.2M,1000,Free,0,Everyone,Education
+R Programming Language,FAMILY,3.8,39,2.9M,1000,Free,0,Everyone,Education
+R Programming,FAMILY,4.2,2,5.9M,1000,Free,0,Everyone,Education
+R. Physics Puzzle Game,FAMILY,4.2,5369,60M,500000,Free,0,Everyone,Puzzle
+R Instructor,FAMILY,4.1,135,4.9M,1000,Paid,$4.84,Everyone,Education
+GT-R R35 Drift Simulator,FAMILY,4.4,1852,62M,100000,Free,0,Everyone,Simulation
+Offroad Pickup Truck R,FAMILY,4.4,6367,96M,1000000,Free,0,Everyone,Simulation
+Learn R Programming Full,BOOKS_AND_REFERENCE,4.3,11,9.2M,5000,Free,0,Everyone,Books & Reference
+R Programming Tutorial,FAMILY,4.2,5,2.8M,1000,Free,0,Everyone,Education
+R Programing Offline Tutorial,BOOKS_AND_REFERENCE,5.0,4,3.9M,1000,Free,0,Everyone,Books & Reference
+Learn R Language Easy Way,FAMILY,4.1,17,2.2M,10000,Free,0,Everyone,Education
+.R,TOOLS,4.5,259,203k,10000,Free,0,Everyone,Tools
+R-TYPE II,GAME,4.3,5682,37M,50000,Paid,$1.99,Everyone,Arcade
+Guide for R Programming,BOOKS_AND_REFERENCE,4.3,0,3.7M,5,Free,0,Everyone,Books & Reference
+R Programming Solution,FAMILY,3.9,169,7.7M,10000,Free,0,Everyone,Education
+Learn R - Programming Concepts,FAMILY,3.5,6,2.9M,1000,Free,0,Everyone,Education
+Learn R Programming,BOOKS_AND_REFERENCE,4.3,0,29M,10,Free,0,Everyone,Books & Reference
+Car Parking Nissan GT-R R35 Simulator,FAMILY,3.2,513,34M,100000,Free,0,Everyone,Simulation
+R Quick Reference Big Data,BOOKS_AND_REFERENCE,4.3,6,3.6M,1000,Free,0,Everyone,Books & Reference
+Learn R Programming Free EBook,FAMILY,4.2,1,5.7M,50,Free,0,Everyone,Education
+RMEduS - 음성인식을 활용한 R 프로그래밍 실습 시스템,FAMILY,4.2,4,64M,1,Free,0,Everyone,Education
+R Programming Language (Paperset 2) MCQ Quiz,FAMILY,4.2,0,3.4M,10,Free,0,Everyone,Education
+R-net for Android,PRODUCTIVITY,3.3,48,58k,5000,Free,0,Everyone,Productivity
+R File Manager,TOOLS,4.8,17,6.7M,50,Free,0,Everyone,Tools
+R-TYPE,GAME,4.5,7687,23M,100000,Paid,$1.99,Everyone,Arcade
+R Studio,SHOPPING,3.7,23,8.9M,5000,Free,0,Everyone,Shopping
+Day R Premium,FAMILY,4.8,51068,57M,100000,Paid,$4.99,Teen,Role Playing
+"Join R, Community Engagement",SOCIAL,4.7,144,12M,1000,Free,0,Teen,Social
+R Bank,FINANCE,4.3,90,13M,5000,Free,0,Everyone,Finance
+Elemental Knights R Platinum,FAMILY,3.8,2925,93M,50000,Paid,$4.77,Teen,Role Playing
+Wonder5 Masters R,FAMILY,4.1,1655,83M,100000,Free,0,Everyone,Role Playing
+Neon-R (Red),PERSONALIZATION,4.7,25,41M,100,Paid,$0.99,Everyone,Personalization
+Mat|r viewer,PRODUCTIVITY,4.2,5,28M,100,Free,0,Everyone,Productivity
+R. Lee Ermey's Official Sound,FAMILY,4.2,1696,2.7M,100000,Free,0,Mature 17+,Entertainment
+Tutorials for R Programming Offline,FAMILY,4.2,2,4.4M,500,Free,0,Everyone,Education
+R Programming Language (Paperset 1) MCQ Quiz,FAMILY,4.2,1,3.4M,10,Free,0,Everyone,Education
+SHAREit - Transfer & Share,TOOLS,4.6,7775146,17M,500000000,Free,0,Everyone,Tools
+S Launcher for Galaxy TouchWiz,PERSONALIZATION,4.2,11244,2.2M,1000000,Free,0,Everyone,Personalization
+"360 Security - Free Antivirus, Booster, Cleaner",TOOLS,4.6,16771865,Varies with device,100000000,Free,0,Everyone,Tools
+S Player - Lightest and Most Powerful Video Player,TOOLS,4.6,14224,7.1M,1000000,Free,0,Everyone,Tools
+Offroad Pickup Truck S,FAMILY,4.2,5178,20M,1000000,Free,0,Everyone,Simulation
+S Launcher Pro for Galaxy,PERSONALIZATION,4.1,47,26k,1000,Paid,$4.99,Everyone,Personalization
+Type S LED,LIFESTYLE,3.5,628,Varies with device,100000,Free,0,Everyone,Lifestyle
+S Note,PRODUCTIVITY,4.1,12435,31M,10000000,Free,0,Everyone,Productivity
+"S Photo Editor - Collage Maker , Photo Collage",PHOTOGRAPHY,4.4,972574,45M,100000000,Free,0,Everyone,Photography
+Stupid Zombies,GAME,4.5,464900,33M,10000000,Free,0,Teen,Arcade
+S’more - Earn Cash Rewards,PRODUCTIVITY,4.1,15097,14M,1000000,Free,0,Everyone,Productivity
+PitchBlack S - Samsung Substratum Theme “For Oreo”,PERSONALIZATION,4.5,90,37M,1000,Paid,$1.99,Everyone,Personalization
+Samsung Smart Switch Mobile,TOOLS,4.3,146913,24M,100000000,Free,0,Everyone,Tools
+"S S9 Launcher - Galaxy S8/S9 Launcher, theme, cool",TOOLS,4.4,22503,6.5M,1000000,Free,0,Everyone,Tools
+Five Nights at Freddy's 2 Demo,FAMILY,4.3,1503544,40M,50000000,Free,0,Teen,Strategy
+Crime Wars S. Andreas,GAME,4.3,5785,93M,500000,Free,0,Teen,Racing
+S Pen Keeper,TOOLS,3.8,560,314k,50000,Free,0,Everyone,Tools
+SH Script Runner,PRODUCTIVITY,3.9,334,3.7M,50000,Free,0,Everyone,Productivity
+City Taxi Driver sim 2016: Cab simulator Game-s,FAMILY,4.1,16111,57M,1000000,Free,0,Everyone,Simulation
+Shopping List S PRO,SHOPPING,4.8,14,2.7M,100,Paid,$2.49,Everyone,Shopping
+Tumblr,SOCIAL,4.4,2953886,Varies with device,100000000,Free,0,Mature 17+,Social
+Tinder,LIFESTYLE,4.0,2789775,68M,100000000,Free,0,Mature 17+,Lifestyle
+"Topbuzz: Breaking News, Videos & Funny GIFs",NEWS_AND_MAGAZINES,4.7,174827,25M,10000000,Free,0,Mature 17+,News & Magazines
+Twitch: Livestream Multiplayer Games & Esports,FAMILY,4.6,2133047,Varies with device,50000000,Free,0,Teen,Entertainment
+T-Mobile,TOOLS,4.3,482630,Varies with device,10000000,Free,0,Everyone,Tools
+Dino T-Rex,GAME,4.0,69115,2.4M,10000000,Free,0,Everyone,Arcade
+Telegram,COMMUNICATION,4.4,3128611,Varies with device,100000000,Free,0,Mature 17+,Communication
+myAT&T,PRODUCTIVITY,3.7,80816,Varies with device,50000000,Free,0,Everyone,Productivity
+AT&T U-verse,FAMILY,3.7,38606,96M,1000000,Free,0,Everyone,Entertainment
+AT&T Messages for Tablet,COMMUNICATION,3.3,3044,Varies with device,1000000,Free,0,Everyone,Communication
+T Uploader,FAMILY,4.1,75,2.2M,10000,Free,0,Everyone,Education
+T-Mobile DIGITS,COMMUNICATION,3.0,1820,33M,100000,Free,0,Everyone,Communication
+AT&T Digital Life,LIFESTYLE,4.1,10067,Varies with device,1000000,Free,0,Everyone,Lifestyle
+DIRECTV Remote App,FAMILY,3.0,480,19M,1000000,Free,0,Everyone,Entertainment
+AT&T Smart Limits℠,LIFESTYLE,3.8,2300,Varies with device,10000000,Free,0,Everyone,Lifestyle
+T-Mobile Tuesdays,LIFESTYLE,4.0,53144,21M,5000000,Free,0,Everyone,Lifestyle
+"Truecaller: Caller ID, SMS spam blocking & Dialer",COMMUNICATION,4.5,7820775,Varies with device,100000000,Free,0,Everyone,Communication
+AT&T Mobile Transfer,PRODUCTIVITY,4.6,22775,26M,10000000,Free,0,Everyone,Productivity
+T-Mobile Content Transfer,PRODUCTIVITY,4.1,370,29M,500000,Free,0,Everyone,Productivity
+T-Mobile Visual Voicemail,TOOLS,3.6,41502,Varies with device,50000000,Free,0,Everyone,Tools
+I Can't Wake Up!,TOOLS,4.7,963,3.7M,10000,Paid,$2.99,Everyone,Tools
+AT&T FamilyMap®,TOOLS,3.5,21592,25M,10000000,Free,0,Everyone,Tools
+T-Mobile® FamilyMode™,PARENTING,3.1,103,28M,10000,Free,0,Everyone,Parenting
+Portable Wi-Fi hotspot,COMMUNICATION,3.9,138129,2.1M,10000000,Free,0,Everyone,Communication
+Showtime Anytime,FAMILY,3.7,18522,Varies with device,1000000,Free,0,Teen,Entertainment
+AT&T Call Protect,COMMUNICATION,4.2,6454,15M,5000000,Free,0,Everyone,Communication
+Don't Starve: Pocket Edition,GAME,4.4,17988,7.9M,100000,Paid,$4.99,Teen,Adventure
+"Please, Don't Touch Anything",FAMILY,4.4,1771,46M,10000,Paid,$4.99,Teen,Puzzle
+AT&T DriveMode,MAPS_AND_NAVIGATION,3.3,8465,8.9M,10000000,Free,0,Everyone,Maps & Navigation
+The T Factor,EVENTS,4.8,48,13M,1000,Free,0,Everyone,Events
+Please Don't Touch Anything 3D,FAMILY,4.2,146,20M,5000,Paid,$5.99,Teen,Puzzle
+Don't Panic with Andrew J.,BOOKS_AND_REFERENCE,4.5,124,Varies with device,5000,Paid,$2.99,Everyone,Books & Reference
+Don't touch my phone,TOOLS,3.8,21943,2.3M,5000000,Free,0,Everyone,Tools
+Don't Starve: Shipwrecked,GAME,4.1,1468,4.9M,10000,Paid,$4.99,Teen,Adventure
+Ludo - Don't get angry,GAME,4.2,131,23M,1000,Paid,$1.61,Everyone,Board
+Jurassic Life: T Rex Simulator,FAMILY,4.2,1088,35M,10000,Paid,$0.99,Everyone 10+,Simulation
+T-Mobile SyncUP DRIVE,AUTO_AND_VEHICLES,4.0,1981,18M,100000,Free,0,Everyone,Auto & Vehicles
+T-shirt design - Snaptee,LIFESTYLE,4.2,29756,45M,1000000,Free,0,Everyone,Lifestyle
+MBTA GPS - Track the T,MAPS_AND_NAVIGATION,3.8,82,5.6M,5000,Free,0,Everyone,Maps & Navigation
+T. Rowe Price Personal® App,FINANCE,4.5,1057,4.5M,50000,Free,0,Everyone,Finance
+Můj T-Mobile Business,PRODUCTIVITY,3.7,10490,5.8M,1000000,Free,0,Everyone,Productivity
+U by BB&T,FINANCE,4.3,16600,24M,1000000,Free,0,Everyone,Finance
+U LIVE – Video Chat & Stream,SOCIAL,4.5,67611,21M,1000000,Free,0,Mature 17+,Social
+"U - Webinars, Meetings & Messenger",COMMUNICATION,4.1,6601,31M,500000,Free,0,Everyone,Communication
+Hollywood U: Rising Stars,FAMILY,4.2,233588,74M,5000000,Free,0,Teen,Simulation
+U-Dictionary: Best English Learning Dictionary,FAMILY,4.5,166886,21M,10000000,Free,0,Everyone 10+,Education
+Ustream,VIDEO_PLAYERS,4.0,93638,7.3M,10000000,Free,0,Mature 17+,Video Players & Editors
+UC Browser Mini -Tiny Fast Private & Secure,COMMUNICATION,4.4,3648765,3.3M,100000000,Free,0,Teen,Communication
+Uber,MAPS_AND_NAVIGATION,4.2,4921866,Varies with device,100000000,Free,0,Everyone,Maps & Navigation
+ENCHANT U,FAMILY,4.3,83977,11M,500000,Free,0,Everyone,Casual
+/u/app,COMMUNICATION,4.7,573,53M,10000,Free,0,Mature 17+,Communication
+Kicker U,LIFESTYLE,4.1,124,37M,5000,Paid,$3.99,Everyone,Lifestyle
+U-Haul,TRAVEL_AND_LOCAL,3.2,852,37M,100000,Free,0,Everyone,Travel & Local
+Vienna U-Bahn,MAPS_AND_NAVIGATION,3.9,139,2.0M,10000,Free,0,Everyone,Maps & Navigation
+Kicker U Lite,LIFESTYLE,4.1,438,26M,50000,Free,0,Everyone,Lifestyle
+U-Scan,TOOLS,3.4,784,42M,50000,Free,0,Everyone,Tools
+Octo U: Your driving companion,TRAVEL_AND_LOCAL,3.0,331,7.8M,50000,Free,0,Everyone,Travel & Local
+I Love U Theme&Emoji Keyboard,PERSONALIZATION,4.6,655,3.5M,100000,Free,0,Everyone,Personalization
+Channel U,FAMILY,4.6,34,14M,1000,Free,0,Everyone,Entertainment
+"Parallel U - App Cloner, Duals APP, tarallel",TOOLS,4.1,3315,5.1M,500000,Free,0,Everyone,Tools
+U Pull It Auto Dismantler,BUSINESS,3.1,71,1.9M,10000,Free,0,Everyone,Business
+Wii U Simulator,FAMILY,3.4,1178,38M,100000,Free,0,Everyone 10+,Simulation
+U Camera : Phone 6s OS 9 style,PHOTOGRAPHY,4.2,2158,3.0M,500000,Free,0,Everyone,Photography
+U get - Wireless Speed Test,TOOLS,4.2,26,2.2M,5000,Free,0,Everyone,Tools
+U Guard,TOOLS,3.0,245,3.5M,10000,Free,0,Everyone,Tools
+DRC Sim - Wii U Gamepad,FAMILY,2.4,210,4.0M,10000,Free,0,Everyone,Casual
+"See U - Random video chat, video chat",SOCIAL,4.1,568,27M,100000,Free,0,Mature 17+,Social
+[verify-U] VideoIdent,COMMUNICATION,2.9,83,13M,10000,Free,0,Everyone,Communication
+What U See,SOCIAL,4.0,712,21M,100000,Free,0,Teen,Social
+U Assist - Screen Mirroring & Sharing App,PRODUCTIVITY,4.0,198,3.5M,50000,Free,0,Everyone,Productivity
+U+Box,PRODUCTIVITY,3.8,24517,22M,10000000,Free,0,Everyone,Productivity
+Wi u Emulator,FAMILY,2.4,468,7.2M,10000,Free,0,Everyone,Entertainment
+Waiting For U Launcher Theme,PERSONALIZATION,4.4,5599,4.8M,500000,Free,0,Everyone,Personalization
+U of I Community Credit Union,FINANCE,3.7,52,13M,5000,Free,0,Everyone,Finance
+U-Report,SOCIAL,4.3,241,7.5M,10000,Free,0,Teen,Social
+"Meet U - Get Friends for Snapchat, Kik & Instagram",SOCIAL,4.6,4435,5.4M,100000,Free,0,Mature 17+,Social
+U-Craft Mobile,FAMILY,4.2,11404,30M,100000,Free,0,Everyone,Strategy
+Alarmy (Sleep If U Can) - Pro,LIFESTYLE,4.8,10249,Varies with device,10000,Paid,$2.49,Everyone,Lifestyle
+U-Disco,FAMILY,3.6,906,196k,100000,Free,0,Everyone,Entertainment
+SAY-U,FAMILY,3.2,1011,Varies with device,100000,Free,0,Teen,Entertainment
+Be U Salons Hair-Beauty Deals In Delhi & Bangalore,LIFESTYLE,4.0,889,16M,100000,Free,0,Everyone,Lifestyle
+U-48 Submarine Commander Free,GAME,3.5,4575,3.8M,500000,Free,0,Everyone,Arcade
+Berlin Subway – BVG U-Bahn & S-Bahn map and routes,MAPS_AND_NAVIGATION,4.4,509,17M,100000,Free,0,Everyone,Maps & Navigation
+Remote For ATT U-verse TV - NOW FREE,TOOLS,2.5,20,26M,5000,Free,0,Everyone,Tools
+Pocket U ASW,FAMILY,3.9,93,28M,10000,Free,0,Everyone,Education
+V LIVE - Star Live App,FAMILY,4.4,397147,Varies with device,10000000,Free,0,Teen,Entertainment
+Identity V,GAME,4.2,109263,38M,1000000,Free,0,Teen,Action
+VMate,VIDEO_PLAYERS,4.2,192677,17M,50000000,Free,0,Teen,Video Players & Editors
+V Made,BOOKS_AND_REFERENCE,4.3,241,20M,100000,Free,0,Everyone,Books & Reference
+Grand Theft Auto V: The Manual,FAMILY,4.1,182103,6.9M,5000000,Free,0,Teen,Entertainment
+Viber Messenger,COMMUNICATION,4.3,11335481,Varies with device,500000000,Free,0,Everyone,Communication
+V for Voodoo,GAME,4.2,16876,59M,1000000,Free,0,Teen,Trivia
+Sin City Crime Simulator V - Gangster,GAME,4.2,2113,67M,100000,Free,0,Everyone 10+,Action
+The Gang Sniper V. Pocket Edition.,GAME,3.9,6121,61M,500000,Free,0,Mature 17+,Action
+Vimeo,FAMILY,3.9,85578,Varies with device,10000000,Free,0,Teen,Entertainment
+VLC for Android,VIDEO_PLAYERS,4.4,1031045,Varies with device,100000000,Free,0,Everyone,Video Players & Editors
+All Video Downloader,VIDEO_PLAYERS,3.8,165723,1.6M,10000000,Free,0,Everyone,Video Players & Editors
+"Vault-Hide SMS,Pics & Videos,App Lock,Cloud backup",BUSINESS,4.5,984451,Varies with device,50000000,Free,0,Everyone,Business
+VidPlay,VIDEO_PLAYERS,4.2,3546,3.7M,1000000,Free,0,Everyone,Video Players & Editors
+HD Video Downloader : 2018 Best video mate,VIDEO_PLAYERS,3.7,430643,4.9M,50000000,Free,0,Everyone,Video Players & Editors
+Vigo Video,VIDEO_PLAYERS,4.3,1615418,Varies with device,50000000,Free,0,Teen,Video Players & Editors
+V-CUBE Seminar Mobile,BUSINESS,4.3,542,30M,100000,Free,0,Everyone,Business
+VivaVideo - Video Editor & Photo Movie,VIDEO_PLAYERS,4.6,9879473,40M,100000000,Free,0,Teen,Video Players & Editors
+Mod GTA V for MCPE,FAMILY,3.3,4288,10M,500000,Free,0,Everyone,Entertainment
+Vi Trainer,HEALTH_AND_FITNESS,3.6,124,100M,5000,Free,0,Everyone,Health & Fitness
+San Andreas: Gang Crime V,GAME,4.1,2399,42M,100000,Free,0,Mature 17+,Action
+The Grand Bike V,FAMILY,3.8,3478,95M,1000000,Free,0,Everyone,Simulation
+V.360° Camera,PHOTOGRAPHY,3.3,582,28M,100000,Free,0,Everyone,Photography
+FINAL FANTASY V,FAMILY,4.5,15924,4.2M,100000,Paid,$7.99,Teen,Role Playing
+BTS V LINE Launcher theme,PERSONALIZATION,4.8,3283,3.6M,100000,Free,0,Everyone,Personalization
+"VideoShow-Video Editor, Video Maker, Beauty Camera",VIDEO_PLAYERS,4.6,4016834,Varies with device,100000000,Free,0,Everyone,Video Players & Editors
+FORD V SERIES CALC - NO LIMIT,AUTO_AND_VEHICLES,4.2,2,17M,50,Paid,$9.99,Everyone,Auto & Vehicles
+VMate Lite - Funny Short Videos Social Network,SOCIAL,4.3,903,4.6M,1000000,Free,0,Teen,Social
+Mirk V Launcher Theme,PERSONALIZATION,4.5,292,7.9M,10000,Free,0,Everyone,Personalization
+Mike V: Skateboard Party PRO,SPORTS,4.2,2506,Varies with device,50000,Paid,$3.99,Everyone,Sports
+The grand theft V Wallpaper,PERSONALIZATION,3.8,87,4.3M,10000,Free,0,Everyone 10+,Personalization
+V Bucks ProTips New,SOCIAL,4.7,594,3.6M,1000,Free,0,Everyone,Social
+Cheats for GTA V,FAMILY,4.2,450,5.9M,100000,Free,0,Everyone,Entertainment
+V for Vampire - Free,FAMILY,4.3,2772,35M,500000,Free,0,Teen,Puzzle
+Get Free V-bucks_fortnite Hints,FAMILY,4.7,1997,1.8M,5000,Free,0,Everyone,Entertainment
+V BTS Wallpaper,PERSONALIZATION,4.7,127,9.5M,5000,Free,0,Everyone,Personalization
+v-view,FAMILY,3.6,309,19M,10000,Free,0,Everyone,Entertainment
+Mental Hospital V,GAME,4.2,2460,25M,50000,Paid,$0.99,Mature 17+,Action
+Grand Stickman Cover V,GAME,4.0,1744,37M,100000,Free,0,Mature 17+,Action
+Cheat Codes for GTA V,FAMILY,4.3,589,3.6M,100000,Free,0,Mature 17+,Entertainment
+DRAGON QUEST V,FAMILY,4.7,1667,17M,10000,Paid,$14.99,Teen,Role Playing
+WeChat,COMMUNICATION,4.2,5387631,Varies with device,100000000,Free,0,Everyone,Communication
+Easy V-Bux free,FAMILY,4.6,856,2.9M,5000,Free,0,Everyone,Entertainment
+BTS V Kim Taehyung Wallpapers Kpop HD New,PERSONALIZATION,4.8,51,3.4M,5000,Free,0,Everyone,Personalization
+Wattpad 📖 Free Books,BOOKS_AND_REFERENCE,4.6,2915189,Varies with device,100000000,Free,0,Teen,Books & Reference
+W Pro - Weather Forecast & Animated Weather Maps,WEATHER,3.8,11,2.9M,500,Paid,$1.99,Everyone,Weather
+"Waze - GPS, Maps, Traffic Alerts & Live Navigation",MAPS_AND_NAVIGATION,4.6,7231017,Varies with device,100000000,Free,0,Everyone,Maps & Navigation
+"Dating App, Flirt & Chat : W-Match",SOCIAL,4.3,175523,Varies with device,10000000,Free,0,Mature 17+,Social
+W - Weather Forecast & Animated Radar Maps,WEATHER,4.2,29,3.5M,5000,Free,0,Everyone,Weather
+"WPS Office - Word, Docs, PDF, Note, Slide & Sheet",PRODUCTIVITY,4.5,1507205,37M,100000000,Free,0,Everyone,Productivity
+W-History Standalone,SOCIAL,3.2,38,1.5M,1000,Paid,$0.99,Everyone,Social
+Words With Friends Classic,GAME,4.3,1704112,Varies with device,50000000,Free,0,Everyone,Word
+Fantasy Squad W,FAMILY,4.3,2142,47M,50000,Free,0,Everyone 10+,Role Playing
+LINE WEBTOON - Free Comics,COMICS,4.5,1013944,Varies with device,10000000,Free,0,Teen,Comics
+Weather & Clock Widget for Android,WEATHER,4.4,2371543,11M,50000000,Free,0,Everyone,Weather
+W Box VMS,VIDEO_PLAYERS,1.9,105,9.1M,10000,Free,0,Everyone,Video Players & Editors
+WhatsApp Business,COMMUNICATION,4.4,137144,32M,10000000,Free,0,Everyone,Communication
+W Box VMS HD,VIDEO_PLAYERS,2.5,24,16M,5000,Free,0,Everyone,Video Players & Editors
+Ace Screen Recorder w facecam,TOOLS,4.2,2447,2.5M,100000,Free,0,Everyone,Tools
+WIFI WPS WPA TESTER,TOOLS,4.3,352097,6.7M,10000000,Free,0,Everyone,Tools
+Flashlight Free w/ compass,TOOLS,4.0,75,1.9M,10000,Free,0,Everyone,Tools
+"App Lock: Locker w/ fingerprint, Parental Control",TOOLS,4.5,37607,Varies with device,1000000,Free,0,Everyone,Tools
+IRS W-9 form,BUSINESS,4.8,492,27M,10000,Free,0,Everyone,Business
+Open in WhatsApp (click to chat),TOOLS,4.2,12121,79k,1000000,Free,0,Everyone,Tools
+B & W Filter for Photo Editor Pro,PERSONALIZATION,4.7,65,7.6M,5000,Free,0,Everyone,Personalization
+WowBox,LIFESTYLE,4.4,101957,8.2M,5000000,Free,0,Everyone,Lifestyle
+Zaatar w Zeit,FOOD_AND_DRINK,4.4,205,33M,50000,Free,0,Everyone,Food & Drink
+WPSApp,TOOLS,4.4,95080,3.1M,10000000,Free,0,Everyone,Tools
+WhatsCall Free Global Phone Call App & Cheap Calls,COMMUNICATION,4.6,1130966,27M,10000000,Free,0,Everyone,Communication
+Dictionary - WordWeb,BOOKS_AND_REFERENCE,4.6,124970,Varies with device,5000000,Free,0,Teen,Books & Reference
+Profile w/o crop for Telegram,PHOTOGRAPHY,4.2,348,1.5M,10000,Free,0,Everyone,Photography
+We Heart It,SOCIAL,4.5,637254,Varies with device,10000000,Free,0,Teen,Social
+weather HD,PERSONALIZATION,4.0,1546,4.5M,10000,Paid,$1.99,Everyone,Personalization
+TripAdvisor Hotels Flights Restaurants Attractions,TRAVEL_AND_LOCAL,4.4,1162331,Varies with device,100000000,Free,0,Everyone,Travel & Local
+Draw Something Classic,GAME,4.2,1092106,43M,50000000,Free,0,Everyone,Word
+X-VPN - Free Unlimited VPN Proxy,TOOLS,4.5,40617,21M,5000000,Free,0,Everyone,Tools
+Telegram X,SOCIAL,4.6,70449,Varies with device,5000000,Free,0,Teen,Social
+Share Music & Transfer Files - Xender,TOOLS,4.4,1279109,Varies with device,100000000,Free,0,Everyone,Tools
+X Launcher: With OS11 Style Theme & Control Center,ART_AND_DESIGN,4.7,5754,4.4M,100000,Free,0,Everyone,Art & Design
+"Phone X Launcher, OS 11 iLauncher & Control Center",TOOLS,4.2,54063,16M,5000000,Free,0,Everyone,Tools
+Lock Screen Phone X Style OS 11,TOOLS,4.4,1166,13M,100000,Free,0,Everyone,Tools
+Nose Doctor X: Booger Mania,FAMILY,3.2,37584,34M,5000000,Free,0,Everyone,Casual;Pretend Play
+Control Center iOS 11 - Phone X Control Panel,TOOLS,4.1,1925,8.3M,100000,Free,0,Everyone,Tools
+X Browser,COMMUNICATION,4.0,142,2.5M,50000,Free,0,Everyone,Communication
+"X Launcher Pro: PhoneX Theme, OS11 Control Center",ART_AND_DESIGN,4.7,801,3.5M,5000,Paid,$1.99,Everyone,Art & Design
+X-plore File Manager,TOOLS,4.6,168487,6.4M,10000000,Free,0,Everyone,Tools
+Flashlight X,TOOLS,4.6,20418,4.3M,1000000,Free,0,Everyone,Tools
+iSwipe Phone X,TOOLS,4.7,58366,6.3M,1000000,Free,0,Everyone,Tools
+X Launcher Pro - IOS Style Theme & Control Center,ART_AND_DESIGN,4.8,1216,8.6M,10000,Paid,$1.99,Everyone,Art & Design
+X Home Bar - Free,TOOLS,4.6,4210,1.9M,100000,Free,0,Everyone,Tools
+[ROOT] X Privacy Installer,TOOLS,4.2,12147,118k,1000000,Free,0,Everyone,Tools
+Extreme X Ray Robot Stunts,GAME,4.3,10806,49M,5000000,Free,0,Everyone,Racing
+Xray Scanner Prank,FAMILY,3.3,355837,3.7M,10000000,Free,0,Everyone,Entertainment
+X Launcher Prime: With OS Style Theme & No Ads,ART_AND_DESIGN,4.7,149,3.5M,1000,Paid,$1.99,Everyone,Art & Design
+The X-Files: Deep State - Hidden Object Adventure,FAMILY,4.5,22018,53M,500000,Free,0,Teen,Casual
+Theme for Iphone X Plus,PERSONALIZATION,4.0,126,8.0M,10000,Free,0,Everyone,Personalization
+Casino X - Free Online Slots,GAME,4.5,30515,Varies with device,1000000,Free,0,Teen,Casino
+X-WOLF,GAME,4.2,4878,27M,100000,Free,0,Everyone 10+,Adventure
+Light X - Icon Pack,PERSONALIZATION,4.6,252,24M,10000,Paid,$0.99,Everyone,Personalization
+X-Plane 10 Flight Simulator,FAMILY,4.2,63197,11M,1000000,Free,0,Everyone,Simulation
+Anime X Wallpaper,PERSONALIZATION,4.7,32613,3.2M,1000000,Free,0,Everyone,Personalization
+NEW Theme for Phone X,PERSONALIZATION,4.7,8642,3.7M,500000,Free,0,Everyone,Personalization
+X-Plane to GPS,TOOLS,4.2,161,1.2M,5000,Paid,$0.99,Everyone,Tools
+Control Center iOS 11 - Phone X notifications,TOOLS,4.3,514,8.4M,50000,Free,0,Everyone,Tools
+iLocker X - iOS11 Lockscreen with HD Wallpapers,PERSONALIZATION,4.3,1714,31M,100000,Free,0,Everyone,Personalization
+iLauncher OS 12 Pro - Phone X,PERSONALIZATION,4.3,3,9.6M,50,Paid,$2.99,Everyone,Personalization
+Hero Fighter X,GAME,4.5,24210,45M,500000,Free,0,Teen,Action
+Slendrina X,GAME,4.4,12736,56M,1000000,Free,0,Teen,Arcade
+X Back - Icon Pack,PERSONALIZATION,4.5,56,26M,10000,Paid,$0.99,Everyone,Personalization
+Guide (for X-MEN),BOOKS_AND_REFERENCE,4.6,586,17M,100000,Free,0,Everyone,Books & Reference
+"Decibel X PRO - Sound Meter dBA, Noise Detector",TOOLS,4.3,60,6.9M,1000,Paid,$3.99,Everyone,Tools
+Flight Simulator X 2016 Free,FAMILY,3.8,44636,Varies with device,1000000,Free,0,Everyone,Simulation
+Robocar X Ray,GAME,4.5,3432,99M,1000000,Free,0,Mature 17+,Action
+Space X: Sky Wars of Air Force,GAME,4.5,10748,47M,1000000,Free,0,Everyone,Arcade
+OS-X EMUI 4/5/8 THEME,PERSONALIZATION,3.9,916,36M,100000,Free,0,Everyone,Personalization
+Flexiroam X,TRAVEL_AND_LOCAL,4.0,875,21M,100000,Free,0,Everyone,Travel & Local
+X-ray scanner simulator,FAMILY,2.7,1616,3.0M,500000,Free,0,Everyone,Casual
+X Construction,FAMILY,4.5,18612,8.5M,100000,Paid,$1.49,Everyone,Puzzle
+X Home Bar - Home Bar Gesture Pro,TOOLS,4.0,88,2.0M,10000,Paid,$1.99,Everyone,Tools
+PLAYBULB X,LIFESTYLE,2.9,2160,15M,100000,Free,0,Everyone,Lifestyle
+X-Wing Squadron Builder,FAMILY,4.6,5898,50M,100000,Free,0,Everyone,Entertainment
+YouTube TV - Watch & Record Live TV,FAMILY,4.4,38517,17M,1000000,Free,0,Teen,Entertainment
+Yandex Browser with Protect,PERSONALIZATION,4.5,1235841,Varies with device,50000000,Free,0,Everyone,Personalization
+JW Caleb y Sofia,FAMILY,4.6,5227,1.9M,500000,Free,0,Everyone,Education
+Boomerang Make and Race,FAMILY,4.4,281448,70M,10000000,Free,0,Everyone,Racing;Action & Adventure
+YouTube Studio,VIDEO_PLAYERS,4.3,436170,Varies with device,10000000,Free,0,Teen,Video Players & Editors
+Talking Tom & Ben News,FAMILY,4.4,1131937,41M,100000000,Free,0,Everyone,Entertainment
+Vegas Crime Simulator,FAMILY,4.2,721646,99M,50000000,Free,0,Teen,Simulation
+PewDiePie's Tuber Simulator,FAMILY,4.8,1499466,96M,10000000,Free,0,Teen,Casual
+Yahoo Mail – Stay Organized,COMMUNICATION,4.3,4188345,16M,100000000,Free,0,Everyone,Communication
+Real Gangster Crime,GAME,4.3,285814,84M,10000000,Free,0,Teen,Action
+Antivirus & Mobile Security,TOOLS,4.6,351267,5.0M,10000000,Free,0,Everyone,Tools
+Flashlight Ultimate,TOOLS,4.6,16936,5.0M,1000000,Free,0,Everyone,Tools
+PBS KIDS Video,FAMILY,4.2,36214,Varies with device,5000000,Free,0,Everyone,Education;Music & Video
+YouTube Gaming,FAMILY,4.2,130549,Varies with device,5000000,Free,0,Teen,Entertainment
+Gangster Town,GAME,4.1,74842,99M,5000000,Free,0,Teen,Action
+Rope Hero 3,GAME,4.4,45871,99M,5000000,Free,0,Teen,Action
+Avast Mobile Security 2018 - Antivirus & App Lock,TOOLS,4.5,5180480,26M,100000000,Free,0,Everyone,Tools
+"GO Keyboard - Emoticon keyboard, Free Theme, GIF",PERSONALIZATION,4.4,2591610,Varies with device,100000000,Free,0,Everyone,Personalization
+NQ Mobile Security & Antivirus,PRODUCTIVITY,4.4,427185,Varies with device,10000000,Free,0,Teen,Productivity
+yHomework - Math Solver,FAMILY,4.2,50771,Varies with device,1000000,Free,0,Everyone,Education
+GO Launcher - 3D parallax Themes & HD Wallpapers,PERSONALIZATION,4.5,7464996,Varies with device,100000000,Free,0,Everyone,Personalization
+Z Origins - (Z The Game),FAMILY,4.6,4421,37M,50000,Paid,$2.99,Teen,Strategy
+ZArchiver,TOOLS,4.5,337242,Varies with device,10000000,Free,0,Everyone,Tools
+"Zapya - File Transfer, Sharing",TOOLS,4.6,387958,9.0M,10000000,Free,0,Teen,Tools
+Experiment Z - Zombie,GAME,4.0,229329,88M,10000000,Free,0,Mature 17+,Action
+War Z 2,FAMILY,4.5,97071,87M,5000000,Free,0,Teen,Strategy
+Last Empire - War Z: Strategy,FAMILY,4.2,853495,78M,50000000,Free,0,Teen,Strategy
+Z Day: Hearts of Heroes,FAMILY,3.9,5894,67M,1000000,Free,0,Everyone 10+,Strategy
+Z Champions,GAME,4.7,96028,59M,1000000,Free,0,Teen,Arcade
+Zello PTT Walkie Talkie,SOCIAL,4.4,695576,Varies with device,50000000,Free,0,Everyone,Social
+CPU-Z,TOOLS,4.5,295430,1.4M,10000000,Free,0,Everyone,Tools
+WithstandZ - Zombie Survival!,GAME,4.3,121612,59M,1000000,Free,0,Teen,Action
+"Z Camera - Photo Editor, Beauty Selfie, Collage",PHOTOGRAPHY,4.4,1075016,47M,100000000,Free,0,Mature 17+,Photography
+Empire Z: Endless War,FAMILY,4.2,367951,76M,5000000,Free,0,Teen,Strategy
+Zombie War Z : Hero Survival Rules,GAME,3.9,1987,62M,100000,Free,0,Mature 17+,Action
+DRAGON BALL Z DOKKAN BATTLE,GAME,4.1,650114,80M,10000000,Free,0,Teen,Action
+Moto Z Market,TOOLS,2.2,605,3.8M,1000000,Free,0,Everyone,Tools
+Cube Z (Pixel Zombies),GAME,4.2,41444,56M,1000000,Free,0,Teen,Action
+Z War-Zombie Modern Combat,FAMILY,4.2,62301,72M,5000000,Free,0,Teen,Strategy
+Z App,LIFESTYLE,2.8,405,25M,50000,Free,0,Everyone,Lifestyle
+GALAK-Z: Variant Mobile,GAME,3.9,145,79M,10000,Free,0,Everyone,Action
+Z City,FAMILY,4.3,3976,98M,100000,Free,0,Teen,Strategy
+Space Z 🌏 🚀Icon Pack Theme,PERSONALIZATION,4.8,201,68M,1000,Paid,$1.49,Everyone,Personalization
+Reload: The Z-Team,GAME,4.3,1655,91M,100000,Free,0,Everyone 10+,Action
+Rage Z: Multiplayer Zombie FPS Online Shooter,GAME,4.1,11258,44M,500000,Free,0,Mature 17+,Action
+Pixel Z Gunner 3D - Battle Survival Fps,GAME,4.2,11408,96M,1000000,Free,0,Teen,Action
+Saiyan Z: Super SSJ Ultimate Combat,GAME,4.4,306,61M,10000,Free,0,Everyone,Adventure
+Mini DAYZ: Zombie Survival,GAME,4.1,94661,Varies with device,1000000,Free,0,Teen,Action
+Z-Empire: Dead Strike,FAMILY,4.6,99,19M,10000,Free,0,Teen,Strategy
+Free Z Glass GO Keyboard Theme,PERSONALIZATION,4.3,71829,8.8M,5000000,Free,0,Everyone,Personalization
+Zombie Avengers:(Dreamsky)Stickman War Z,GAME,4.3,13604,96M,1000000,Paid,$0.99,Teen,Action
+Z Camera,PHOTOGRAPHY,3.8,142,7.7M,10000,Free,0,Everyone,Photography
+ZArchiver Donate,TOOLS,4.8,1721,Varies with device,10000,Paid,$2.50,Everyone,Tools
+Cardio Z,MEDICAL,4.2,24,10M,100,Paid,$5.99,Everyone,Medical
+GO SMS Pro Z Glass Theme EX,PERSONALIZATION,3.8,24198,2.2M,1000000,Free,0,Everyone,Personalization
+Route Z,GAME,3.9,24697,16M,500000,Free,0,Teen,Action
+Z PIVOT,COMMUNICATION,4.2,0,5.7M,10,Paid,$19.99,Everyone,Communication
+Dragon X Adventure: Warrior Z,GAME,4.3,8537,29M,100000,Free,0,Everyone 10+,Action
+Ultimate Fighter Z,GAME,4.3,180,24M,5000,Free,0,Everyone,Action
+Theme eXp - Black Z Light,PERSONALIZATION,4.3,29540,4.3M,1000000,Free,0,Everyone,Personalization
+Toy Battle Z,FAMILY,4.1,133,48M,10000,Free,0,Everyone,Casual
+Wave Z Live Wallpaper,PERSONALIZATION,4.2,63699,2.3M,5000000,Free,0,Teen,Personalization
+Six Pack in 30 Days - Abs Workout,HEALTH_AND_FITNESS,4.9,272172,13M,10000000,Free,0,Everyone,Health & Fitness
+30 Day Ab Challenge,HEALTH_AND_FITNESS,4.5,1886,7.6M,500000,Free,0,Everyone,Health & Fitness
+Angry Birds Blast,FAMILY,4.6,253115,99M,10000000,Free,0,Everyone,Puzzle
+ab,FAMILY,3.8,10,22M,1000,Free,0,Everyone,Casual
+Ultimate Ab & Core Workouts,HEALTH_AND_FITNESS,4.7,55571,12M,1000000,Free,0,Everyone,Health & Fitness
+Angry Birds Evolution,FAMILY,4.5,384602,88M,10000000,Free,0,Everyone,Role Playing
+Angry Birds Match,FAMILY,4.7,227401,91M,5000000,Free,0,Everyone,Puzzle
+Angry Birds POP Bubble Shooter,FAMILY,4.5,596628,99M,10000000,Free,0,Everyone,Casual
+Abs Workout - Burn Belly Fat with No Equipment,HEALTH_AND_FITNESS,4.8,69279,10M,10000000,Free,0,Everyone,Health & Fitness
+6 Pack Promise - Ultimate Abs,HEALTH_AND_FITNESS,4.6,18921,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+Angry Birds 2,FAMILY,4.6,3881752,57M,100000000,Free,0,Everyone,Casual
+AB Repeat Player,VIDEO_PLAYERS,4.3,1628,18M,100000,Free,0,Everyone,Video Players & Editors
+"Abs, Core & Back Workout Challenge",HEALTH_AND_FITNESS,4.8,3908,33M,100000,Free,0,Everyone,Health & Fitness
+AB Mobile App,HEALTH_AND_FITNESS,3.4,2105,8.2M,100000,Free,0,Everyone,Health & Fitness
+Daily Ab Workout,HEALTH_AND_FITNESS,4.6,2901,Varies with device,50000,Paid,$1.99,Everyone,Health & Fitness
+Angry Birds Rio,GAME,4.4,2610328,46M,100000000,Free,0,Everyone,Arcade
+Angry Birds Epic RPG,FAMILY,4.5,2634605,63M,10000000,Free,0,Everyone,Role Playing
+A-B repeater,VIDEO_PLAYERS,4.4,32,239k,5000,Free,0,Everyone,Video Players & Editors
+Daily Ab Workout - Core & Abs Fitness Exercises,HEALTH_AND_FITNESS,4.4,44939,Varies with device,10000000,Free,0,Everyone,Health & Fitness
+Abs workout 7 minutes,HEALTH_AND_FITNESS,4.6,37224,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+Angry Birds Friends,GAME,4.2,829753,48M,50000000,Free,0,Everyone,Arcade
+30 Day Ab Challenge FREE,HEALTH_AND_FITNESS,4.3,48253,Varies with device,1000000,Free,0,Everyone,Health & Fitness
+AB Blast Match 3,FAMILY,4.3,111,48M,10000,Free,0,Everyone,Puzzle
+AB Click2Shop,SHOPPING,3.8,454,18M,100000,Free,0,Everyone,Shopping
+Math games for kids : times tables - AB Math,FAMILY,3.9,2371,8.3M,500000,Free,0,Everyone,Educational;Education
+AB Crush Match 3,FAMILY,4.3,96,54M,10000,Free,0,Everyone,Casual
+"ABS Workout - Belly workout, 30 days AB",HEALTH_AND_FITNESS,4.8,5103,Varies with device,100000,Free,0,Everyone,Health & Fitness
+AB Match,FAMILY,4.2,9,30M,1000,Free,0,Everyone,Casual
+Math games for kids : times tables training,FAMILY,4.5,630,8.3M,10000,Paid,$1.59,Everyone,Educational;Education
+7 minute abs workout - Daily Ab Workout,HEALTH_AND_FITNESS,4.8,527,23M,100000,Free,0,Everyone,Health & Fitness
+AB Anywhere Mobile Banking,FINANCE,4.1,3,11M,500,Free,0,Everyone,Finance
+5 Minute Ab Workouts,HEALTH_AND_FITNESS,4.6,2067,8.4M,50000,Free,0,Everyone,Health & Fitness
+Angry Birds Go!,GAME,4.2,3846378,82M,50000000,Free,0,Everyone,Racing
+AB Screen Recorder,TOOLS,4.2,533,5.0M,10000,Free,0,Everyone,Tools
+Six Pack Abs Photo Editor,PHOTOGRAPHY,4.0,5967,17M,1000000,Free,0,Everyone,Photography
+Best Blood Type AB: Food Diet & Personality,LIFESTYLE,4.1,3,37M,1000,Free,0,Everyone,Lifestyle
+Angry Birds Star Wars,GAME,4.3,1218055,45M,100000000,Free,0,Everyone,Arcade
+30 Day AB Challenge - Lumowell,HEALTH_AND_FITNESS,4.8,793,40M,10000,Free,0,Everyone,Health & Fitness
+Ab Workouts,HEALTH_AND_FITNESS,4.1,27501,7.0M,1000000,Free,0,Everyone,Health & Fitness
+Ab Workouts - Ab Generator,HEALTH_AND_FITNESS,4.7,21,3.8M,1000,Free,0,Everyone,Health & Fitness
+Chatime AB Rewards,FAMILY,4.2,9,22M,1000,Free,0,Everyone,Entertainment
+Abs workout - 21 Day Fitness Challenge,HEALTH_AND_FITNESS,4.8,18604,15M,1000000,Free,0,Everyone,Health & Fitness
+Ladies' Ab Workout FREE,HEALTH_AND_FITNESS,4.0,12906,8.5M,1000000,Free,0,Everyone,Health & Fitness
+30-Day Ab Challenge Tracker,HEALTH_AND_FITNESS,3.5,224,371k,10000,Free,0,Everyone,Health & Fitness
+Universal AC Remote Control,TOOLS,3.8,40934,5.2M,1000000,Free,0,Everyone,Tools
+AC Freedom,BUSINESS,3.5,537,Varies with device,100000,Free,0,Everyone,Business
+Smart Air Conditioner,TOOLS,3.3,4786,13M,500000,Free,0,Everyone,Tools
+Assassin's Creed Identity,GAME,3.7,42529,92M,500000,Paid,$1.99,Teen,Action
+AC Remote Control,TOOLS,3.3,472,2.0M,100000,Free,0,Everyone,Tools
+Air conditioner remote control,TOOLS,3.4,29854,5.0M,1000000,Free,0,Everyone,Tools
+Smart-AC Universal Remote Free,FAMILY,1.8,3270,1.8M,500000,Free,0,Everyone,Entertainment
+AC REMOTE UNIVERSAL-PRO,FAMILY,1.6,402,1.7M,100000,Free,0,Everyone,Entertainment
+Kenmore Smart AC,LIFESTYLE,1.9,71,24M,5000,Free,0,Everyone,Lifestyle
+AC WIFI,TOOLS,3.6,41,23M,10000,Free,0,Everyone,Tools
+A/C Air Conditioner Remote,TOOLS,3.4,7816,5.1M,1000000,Free,0,Everyone,Tools
+Smart Air Conditioner(CAC),TOOLS,3.2,409,7.9M,50000,Free,0,Everyone,Tools
+Carrier Air Conditioner,TOOLS,2.5,362,7.8M,100000,Free,0,Everyone,Tools
+AC Troubleshooter,TOOLS,4.7,147,4.2M,10000,Free,0,Everyone,Tools
+TOSHIBA Smart AC,TOOLS,2.6,60,18M,10000,Free,0,Everyone,Tools
+Trane Interactive Smart AC,TOOLS,2.8,48,3.3M,10000,Free,0,Everyone,Tools
+AC remote control mobile,TOOLS,3.9,3043,7.7M,100000,Free,0,Everyone,Tools
+"AC Air condition Troubleshoot,Repair,Maintenance",BOOKS_AND_REFERENCE,4.2,27,3.1M,5000,Free,0,Everyone,Books & Reference
+AC Remote for Haier - NOW FREE,TOOLS,3.9,336,27M,50000,Free,0,Everyone,Tools
+Air Conditioner Maintenance,PRODUCTIVITY,4.0,11,220k,5000,Free,0,Everyone,Productivity
+AC Remote for Daikin - NOW FREE,TOOLS,3.5,383,26M,50000,Free,0,Everyone,Tools
+A/C Universal Remote Control,TOOLS,3.1,3263,3.0M,1000000,Free,0,Everyone,Tools
+AC Remote for LG - NOW FREE,TOOLS,3.7,1041,28M,100000,Free,0,Everyone,Tools
+Plug-in app (System AC),TOOLS,3.6,126,11M,10000,Free,0,Everyone,Tools
+LG AC Smart Diagnosis,LIFESTYLE,3.4,377,6.1M,100000,Free,0,Everyone,Lifestyle
+AC Remote for Midea - NOW FREE,TOOLS,4.0,448,26M,100000,Free,0,Everyone,Tools
+Ac remote control,TOOLS,3.7,822,5.0M,50000,Free,0,Everyone,Tools
+A/C REFRIGERANT CAPACITY,BUSINESS,1.7,84,2.1M,10000,Free,0,Everyone,Business
+Remote Control For All AC - Universal Remote,PRODUCTIVITY,2.4,166,6.1M,10000,Free,0,Everyone,Productivity
+All Type Ac Repair & Services,LIFESTYLE,4.3,45,2.2M,10000,Free,0,Everyone,Lifestyle
+AC - Tips & News for Android™,NEWS_AND_MAGAZINES,4.2,23291,14M,1000000,Free,0,Everyone 10+,News & Magazines
+AC Remote Control Simulator,FAMILY,3.3,353,2.3M,100000,Free,0,Everyone,Entertainment
+"Mi Remote controller - for TV, STB, AC and more",TOOLS,4.1,114340,28M,10000000,Free,0,Everyone,Tools
+AcDisplay,PERSONALIZATION,4.1,66473,3.0M,1000000,Free,0,Everyone,Personalization
+AC Mobile Control,HOUSE_AND_HOME,3.4,1450,9.7M,100000,Free,0,Everyone,House & Home
+AC Remote For LG,TOOLS,3.0,1298,3.4M,100000,Free,0,Everyone,Tools
+Universal AC Remote Control Simulator,FAMILY,3.0,119,3.9M,50000,Free,0,Everyone,Entertainment
+Hi-Smart AC,TOOLS,2.2,32,9.4M,1000,Free,0,Everyone,Tools
+AC Remote for Sharp - NOW FREE,TOOLS,3.7,332,26M,50000,Free,0,Everyone,Tools
+AC Remote for Samsung - NOW FREE,TOOLS,3.7,566,27M,100000,Free,0,Everyone,Tools
+Pocket AC,PHOTOGRAPHY,4.8,130,4.4M,1000,Paid,$9.99,Everyone,Photography
+AC Remote for Carrier - NOW FREE,TOOLS,3.7,163,26M,10000,Free,0,Everyone,Tools
+"AC & TV, DVD, Set Top Box - Remote control IR",TOOLS,3.6,3632,3.2M,1000000,Free,0,Everyone,Tools
+ac remote control,TOOLS,3.7,9514,7.0M,500000,Free,0,Everyone,Tools
+Free Adblocker Browser - Adblock & Popup Blocker,COMMUNICATION,4.4,152470,Varies with device,10000000,Free,0,Everyone,Communication
+Ad Detect Plugin - Handy Tool,PRODUCTIVITY,3.8,5107,1.4M,500000,Free,0,Everyone,Productivity
+AppBrain Ad Detector,TOOLS,3.7,9221,1.7M,1000000,Free,0,Everyone,Tools
+"AD - Nieuws, Sport, Regio & Entertainment",NEWS_AND_MAGAZINES,3.7,10369,Varies with device,1000000,Free,0,Everyone,News & Magazines
+Flud (Ad free),VIDEO_PLAYERS,4.8,5639,Varies with device,10000,Paid,$1.49,Everyone,Video Players & Editors
+AdClear Ad blocker for Samsung,TOOLS,4.2,1586,1.5M,500000,Free,0,Everyone,Tools
+Adblock Browser for Android,COMMUNICATION,4.1,121113,39M,10000000,Free,0,Everyone,Communication
+"CM Browser - Ad Blocker , Fast Download , Privacy",COMMUNICATION,4.6,2265084,6.1M,50000000,Free,0,Everyone,Communication
+Adguard Content Blocker,TOOLS,4.1,14491,4.3M,1000000,Free,0,Everyone,Tools
+tTorrent - ad free,VIDEO_PLAYERS,4.3,2976,Varies with device,10000,Paid,$1.99,Everyone,Video Players & Editors
+cronometer (ad free),HEALTH_AND_FITNESS,3.9,1075,8.3M,50000,Paid,$2.99,Everyone,Health & Fitness
+Ad Detector,TOOLS,3.8,208,730k,50000,Free,0,Everyone,Tools
+Adblock Plus for Samsung Internet - Browse safe.,COMMUNICATION,4.0,8769,2.1M,1000000,Free,0,Everyone,Communication
+MyRadar NOAA Weather Radar Ad Free,WEATHER,4.5,3005,26M,10000,Paid,$2.99,Everyone,Weather
+Safe Notes - Secure Ad-free notepad,PRODUCTIVITY,4.6,3362,756k,50000,Free,0,Everyone,Productivity
+Adblock Fast,PRODUCTIVITY,4.1,9914,3.2M,1000000,Free,0,Everyone,Productivity
+FVD Ad-Free,TOOLS,4.4,1774,4.1M,10000,Paid,$1.99,Everyone,Tools
+2000 AD Comics and Judge Dredd,COMICS,3.7,705,20M,50000,Free,0,Teen,Comics
+Anti Adware,TOOLS,3.9,18751,3.6M,1000000,Free,0,Everyone,Tools
+Ad Blocker Turbo - Adblocker Browser,COMMUNICATION,3.9,107,44M,10000,Free,0,Everyone,Communication
+Weather & Radar Pro - Ad-Free,WEATHER,4.5,25243,26M,100000,Paid,$2.99,Everyone,Weather
+ONScripter Plus (Ad Free),GAME,4.5,100,17M,1000,Paid,$3.99,Everyone,Adventure
+Vpn Hosts (ad blocker & no root & support ipv6 ),TOOLS,4.4,319,1.1M,10000,Paid,$2.99,Everyone,Tools
+Google AdSense,PRODUCTIVITY,4.3,52677,2.9M,1000000,Free,0,Everyone,Productivity
+Ad-free Triangle Solver,FAMILY,4.5,118,24M,10000,Free,0,Everyone,Education
+Ez Screen Recorder (no ad),VIDEO_PLAYERS,4.7,8696,14M,100000,Free,0,Everyone,Video Players & Editors
+Best Applock - Locker & No Ads,PRODUCTIVITY,4.7,10672,6.9M,100000,Free,0,Everyone,Productivity
+Local Services ads by Google,BUSINESS,4.1,7,12M,1000,Free,0,Everyone,Business
+Ad Block REMOVER - NEED ROOT,TOOLS,3.3,999,91k,100000,Free,0,Everyone,Tools
+WhatsFake Pro (Ad free),SOCIAL,4.2,204,9.4M,5000,Paid,$0.99,Everyone,Social
+Photo Compress 2.0 - Ad Free,TOOLS,4.1,6267,1.7M,1000000,Free,0,Everyone,Tools
+Ad Removal: thereisonlywe,PRODUCTIVITY,3.4,16,293k,100,Paid,$6.49,Everyone,Productivity
+Brave Browser: Fast AdBlocker,COMMUNICATION,4.3,40241,Varies with device,5000000,Free,0,Everyone,Communication
+Solitaire: Decked Out Ad Free,GAME,4.9,37302,35M,500000,Free,0,Everyone,Card
+"WeatherClear - Ad-free Weather, Minute forecast",WEATHER,4.5,3252,3.8M,50000,Free,0,Everyone,Weather
+Ad Remove Plugin for App2SD,PRODUCTIVITY,4.1,66,17k,1000,Paid,$1.29,Everyone,Productivity
+"Digital Clock : Simple, Tiny, Ad-free Desk Clock.",LIFESTYLE,4.4,317,74k,50000,Free,0,Everyone,Lifestyle
+Google Ads,BUSINESS,4.3,29331,20M,5000000,Free,0,Everyone,Business
+RAM Cleanup Ad-Free Option,TOOLS,4.4,457,1.1M,10000,Paid,$2.99,Everyone,Tools
+Emo Ads Blocker Browser,TOOLS,3.4,1555,4.1M,100000,Free,0,Everyone,Tools
+Bing Ads,BUSINESS,4.1,1828,13M,100000,Free,0,Everyone,Business
+My baby firework (Remove ad),FAMILY,4.1,30,14k,1000,Paid,$0.99,Everyone,Entertainment
+Apps Ads Detector,TOOLS,3.5,315,8.3M,100000,Free,0,Everyone,Tools
+TIMBER AD FILTER - Very useful ad block app,PRODUCTIVITY,3.8,1343,9.0M,100000,Free,0,Everyone,Productivity
+Alchemy Classic Ad Free,FAMILY,4.6,20178,9.0M,100000,Free,0,Everyone,Puzzle
+Mobi Calculator free & AD free!,TOOLS,4.6,77302,Varies with device,5000000,Free,0,Everyone,Tools
+Easy Hotspot Ad Free,TOOLS,5.0,2,3.3M,10,Paid,$0.99,Everyone,Tools
+Flipp - Weekly Shopping,SHOPPING,4.6,85782,Varies with device,10000000,Free,0,Everyone,Shopping
+"AE + Aerie: Jeans, Dresses, Swimsuits & Bralettes",SHOPPING,4.2,20476,28M,1000000,Free,0,Everyone,Shopping
+A&E - Watch Full Episodes of TV Shows,FAMILY,4.0,29708,19M,1000000,Free,0,Teen,Entertainment
+Adobe Premiere Clip,VIDEO_PLAYERS,3.9,39495,59M,5000000,Free,0,Everyone,Video Players & Editors
+Shortcuts for After Effects,FAMILY,3.7,464,1.9M,50000,Free,0,Everyone,Education
+AE Sudoku,FAMILY,4.3,2171,12M,100000,Free,0,Everyone,Puzzle
+ESS Mobile for AE,PRODUCTIVITY,1.9,63,1.8M,5000,Free,0,Everyone,Productivity
+AE Jewels 2: Island Adventures,GAME,4.2,652,30M,10000,Free,0,Everyone,Action
+AE Bubble:Offline Bubble Games,FAMILY,4.2,6973,Varies with device,100000,Free,0,Everyone,Casual
+AE Basketball,SPORTS,4.0,8100,Varies with device,1000000,Free,0,Everyone,Sports
+AE Bingo: Offline Bingo Games,GAME,4.4,61746,Varies with device,500000,Free,0,Teen,Casino
+AE Jewels,GAME,4.2,960,18M,50000,Free,0,Everyone,Action
+AE Spider Solitaire,GAME,4.5,17263,Varies with device,500000,Free,0,Everyone,Card
+AE Coin Mania : Arcade Fun,GAME,4.3,30002,29M,1000000,Free,0,Teen,Casino
+AE Roundy POP,FAMILY,4.4,5262,26M,100000,Free,0,Everyone,Casual
+Mupen64+AE FREE (N64 Emulator),GAME,4.0,41759,12M,1000000,Free,0,Everyone,Arcade
+Mupen64Plus AE (N64 Emulator),GAME,4.2,4569,12M,100000,Paid,$0.99,Everyone,Arcade
+AE Lucky Fishing,GAME,4.3,18277,17M,1000000,Free,0,Teen,Arcade
+AE Video Poker,GAME,4.0,721,18M,50000,Free,0,Teen,Casino
+AE Solitaire,GAME,4.3,1776,26M,50000,Free,0,Everyone,Card
+AE Archer,SPORTS,3.9,8638,Varies with device,500000,Free,0,Everyone,Sports
+AE Blackjack,GAME,4.0,1417,17M,100000,Free,0,Teen,Card
+AE Gun Ball: arcade ball games,GAME,3.7,8581,12M,1000000,Free,0,Everyone,Arcade
+AE Order,TOOLS,4.1,19,317k,1000,Free,0,Everyone,Tools
+TV.AE,FAMILY,3.9,109,7.5M,10000,Free,0,Everyone,Entertainment
+AE 3D MOTOR :Racing Games Free,GAME,4.2,74902,Varies with device,5000000,Free,0,Everyone,Racing
+AE Garage,AUTO_AND_VEHICLES,4.4,64,66M,1000,Free,0,Everyone,Auto & Vehicles
+AE Bulletins,BOOKS_AND_REFERENCE,4.5,14,30M,1000,Free,0,Everyone,Books & Reference
+AE GTO Racing,GAME,3.9,6988,35M,100000,Free,0,Everyone 10+,Racing
+AE 3D Moto 3,GAME,3.9,2588,26M,100000,Free,0,Everyone 10+,Racing
+AE FreeCell,GAME,4.2,358,15M,10000,Free,0,Everyone,Card
+AE City Jump,GAME,4.5,804,27M,10000,Free,0,Everyone,Action
+AE Angry Chef,GAME,4.1,533,39M,10000,Free,0,Everyone 10+,Action
+Ae Allah na Dai (Rasa),BOOKS_AND_REFERENCE,4.7,263,9.1M,10000,Free,0,Everyone,Books & Reference
+Dashboard AE,AUTO_AND_VEHICLES,4.2,0,13M,10,Free,0,Everyone,Auto & Vehicles
+FilmoraGo - Free Video Editor,VIDEO_PLAYERS,4.4,238459,35M,10000000,Free,0,Everyone,Video Players & Editors
+Event Manager - AllEvents.in,EVENTS,4.7,120,5.1M,10000,Free,0,Everyone,Events
+Nasihat - Chalo ae Pyaara,FAMILY,4.7,557,6.7M,10000,Free,0,Everyone,Education
+AE Master Moto,GAME,4.0,17876,37M,1000000,Free,0,Everyone,Racing
+Brica BPRO5 AE,PHOTOGRAPHY,3.9,4726,3.9M,500000,Free,0,Everyone,Photography
+AE Manager,TOOLS,4.0,0,4.0M,100,Free,0,Everyone,Tools
+AE Air Hockey,SPORTS,3.8,926,7.6M,50000,Free,0,Everyone,Sports
+Connect.ae - Local Search UAE,TRAVEL_AND_LOCAL,3.9,194,Varies with device,10000,Free,0,Everyone,Travel & Local
+AE Fishing Hunter,GAME,4.4,14,6.6M,1000,Free,0,Everyone,Adventure
+ActionDirector Video Editor - Edit Videos Fast,VIDEO_PLAYERS,4.5,74531,32M,5000000,Free,0,Everyone,Video Players & Editors
+Ivanti AE Agent,BUSINESS,4.1,1,2.9M,1000,Free,0,Everyone,Business
+AE Checkout Plugin,SHOPPING,3.8,208,78k,10000,Free,0,Everyone,Shopping
+NewTek NDI,PHOTOGRAPHY,3.5,77,1.2M,1000,Paid,$19.99,Everyone,Photography
+AfterFocus,PHOTOGRAPHY,4.2,165224,15M,10000000,Free,0,Everyone,Photography
+AF Link,NEWS_AND_MAGAZINES,4.7,210,18M,10000,Free,0,Everyone,News & Magazines
+AF Hydro,HEALTH_AND_FITNESS,2.0,136,15M,10000,Free,0,Everyone,Health & Fitness
+Gunship III Vietnam People AF,FAMILY,4.3,726,19M,5000,Paid,$4.99,Everyone,Simulation
+AF Comics Reader - Free,COMICS,2.8,5,4.1M,100,Free,0,Everyone,Comics
+Camera FV-5 Lite,PHOTOGRAPHY,4.0,130063,5.6M,10000000,Free,0,Everyone,Photography
+Flim Af Somali Hindi Fanproj,FAMILY,3.9,12,3.5M,1000,Free,0,Everyone,Entertainment
+"Cardiac diagnosis (heart rate, arrhythmia)",MEDICAL,4.2,4559,6.4M,100000,Free,0,Everyone,Medical
+DSLR camera - Auto Focus and Blur Professional,PHOTOGRAPHY,3.4,30,3.0M,10000,Free,0,Everyone,Photography
+AF-STROKE (FREE),MEDICAL,4.5,93,924k,10000,Free,0,Teen,Medical
+Hesab.af - Send money in Afghanistan,FINANCE,4.7,51,11M,1000,Free,0,Everyone,Finance
+AppFinder by AppTap,TOOLS,2.0,2221,4.9M,5000000,Free,0,Everyone,Tools
+iFunny :),FAMILY,4.4,503757,Varies with device,10000000,Free,0,Mature 17+,Entertainment
+Toppen af Danmark,TRAVEL_AND_LOCAL,4.1,8,6.1M,5000,Free,0,Everyone,Travel & Local
+AF-STROKE,MEDICAL,4.2,5,902k,100,Paid,$5.00,Teen,Medical
+i-share AF/KLM (AFKL ishare),SOCIAL,4.3,2,53M,100,Free,0,Teen,Social
+Bazar.af,SHOPPING,4.7,13,1.3M,500,Free,0,Everyone,Shopping
+DSLR Blur Camera Auto Focus,TOOLS,3.3,75,4.7M,10000,Free,0,Everyone,Tools
+Ariana News AF,NEWS_AND_MAGAZINES,4.1,20,3.1M,5000,Free,0,Everyone,News & Magazines
+AF Legendary 2017,BUSINESS,4.1,0,11M,50,Free,0,Teen,Business
+AR effect,PHOTOGRAPHY,4.2,79792,Varies with device,100000000,Free,0,Everyone,Photography
+ASUS PixelMaster Camera,PHOTOGRAPHY,4.4,626366,Varies with device,10000000,Free,0,Everyone,Photography
+AzadBazar.af,SHOPPING,4.3,3,3.7M,100,Free,0,Everyone,Shopping
+easyFocus,PHOTOGRAPHY,3.7,3396,266k,500000,Free,0,Everyone,Photography
+AF Nutrition - Integratori,HEALTH_AND_FITNESS,4.3,6,19M,100,Free,0,Everyone,Health & Fitness
+Open Camera,PHOTOGRAPHY,4.3,116769,2.0M,10000000,Free,0,Everyone,Photography
+Blur Image - DSLR focus effect,PHOTOGRAPHY,3.9,38055,4.1M,5000000,Free,0,Everyone,Photography
+Tafsiir Quraan MP3 Af Soomaali Quraanka Kariimka,LIFESTYLE,5.0,7,3.4M,1000,Free,0,Everyone,Lifestyle
+Camera Pro,PHOTOGRAPHY,4.1,7479,13M,1000000,Free,0,Everyone,Photography
+Rоhi.af,NEWS_AND_MAGAZINES,4.8,46,46M,1000,Free,0,Everyone,News & Magazines
+HD Camera - silent shutter,PHOTOGRAPHY,4.0,26530,3.9M,1000000,Free,0,Everyone,Photography
+AF Our Time to Shine,BUSINESS,4.1,0,11M,100,Free,0,Everyone,Business
+A Better Camera,PHOTOGRAPHY,4.1,76484,Varies with device,5000000,Free,0,Everyone,Photography
+Auto Dslr Photo Effect : Auto Focus Effect,PHOTOGRAPHY,3.8,6,3.5M,1000,Free,0,Everyone,Photography
+"9GAG: Funny Gifs, Pics, Memes & Videos for IGTV",FAMILY,4.6,1450632,Varies with device,10000000,Free,0,Teen,Entertainment
+AF Johannesburg,FAMILY,4.2,3,11M,100,Free,0,Everyone,Education
+PhotoScan by Google Photos,PHOTOGRAPHY,4.3,61990,Varies with device,10000000,Free,0,Everyone,Photography
+Gun Strike Shoot,GAME,4.1,94761,17M,10000000,Free,0,Teen,Action
+All Football - Latest News & Videos,SPORTS,4.6,152653,17M,10000000,Free,0,Everyone,Sports
+50000 Free eBooks & Free AudioBooks,BOOKS_AND_REFERENCE,4.1,52312,11M,5000000,Free,0,Teen,Books & Reference
+AppLock,TOOLS,4.4,4931562,Varies with device,100000000,Free,0,Everyone,Tools
+King of Avalon: Dragon Warfare,FAMILY,4.2,306652,64M,10000000,Free,0,Everyone 10+,Strategy
+What's Up,LIFESTYLE,4.1,23453,10M,1000000,Free,0,Everyone,Lifestyle
+Afterlight,PHOTOGRAPHY,4.3,50893,35M,1000000,Free,0,Everyone,Photography
+Blurfoto : Auto blur photo background & DSLR focus,PHOTOGRAPHY,4.3,2215,12M,500000,Free,0,Everyone,Photography
+Blur,PHOTOGRAPHY,4.0,9013,2.4M,1000000,Free,0,Everyone,Photography
+"AG Contacts, Premium edition",COMMUNICATION,4.5,88,3.7M,500,Paid,$4.99,Everyone,Communication
+Ag PhD Field Guide,BOOKS_AND_REFERENCE,4.1,114,6.3M,10000,Free,0,Everyone,Books & Reference
+AG Drive 3D,GAME,3.8,164,22M,10000,Free,0,Everyone,Adventure
+Apps for SportsBєtting.ag - Bitcoin Welcome here!,SPORTS,4.2,0,10.0M,1000,Free,0,Everyone,Sports
+"AG Contacts, Lite edition",COMMUNICATION,4.5,185,3.7M,5000,Free,0,Everyone,Communication
+Ag Weather Tools,WEATHER,4.2,0,4.6M,500,Free,0,Everyone,Weather
+Trimble Ag Mobile,PRODUCTIVITY,4.1,85,44M,10000,Free,0,Everyone,Productivity
+Ag Tools,TOOLS,4.0,2,18M,1000,Free,0,Everyone,Tools
+Ag PhD Deficiencies,BOOKS_AND_REFERENCE,3.9,20,9.7M,10000,Free,0,Everyone,Books & Reference
+AG Screen Recorder,TOOLS,3.7,7,2.7M,1000,Free,0,Everyone,Tools
+SOLEM AG,TOOLS,4.0,1,51M,1000,Free,0,Everyone,Tools
+AG Subway Simulator Mobile,FAMILY,4.5,623,47M,5000,Paid,$0.99,Everyone,Simulation
+AG Subway Simulator Lite,FAMILY,4.4,6738,56M,100000,Free,0,Everyone,Simulation
+Elim AG,LIFESTYLE,4.1,7,Varies with device,100,Free,0,Everyone,Lifestyle
+EZ Ag Mobile,FINANCE,3.4,19,24M,5000,Free,0,Everyone,Finance
+AG Subway Simulator Pro,FAMILY,4.2,0,Varies with device,1000,Free,0,Everyone,Simulation
+BRL AG,TOOLS,4.0,0,52M,100,Free,0,Everyone,Tools
+Oklahoma Ag Co-op Council,COMMUNICATION,4.2,0,4.9M,10,Free,0,Everyone,Communication
+AG Fast Service Automotive,AUTO_AND_VEHICLES,4.2,5,1.7M,100,Free,0,Everyone,Auto & Vehicles
+Ag PhD Soils,PRODUCTIVITY,2.3,3,16M,1000,Free,0,Everyone,Productivity
+All States Ag Parts,SHOPPING,4.7,68,6.5M,10000,Free,0,Everyone,Shopping
+VR AG Racing for Cardboard,GAME,3.4,13,27M,1000,Free,0,Everyone,Racing
+Safe Ag Systems™,BUSINESS,4.7,3,36M,100,Free,0,Everyone,Business
+Ag PhD Planting Population Calculator,BOOKS_AND_REFERENCE,4.3,0,5.2M,1000,Free,0,Everyone,Books & Reference
+Ag Trucking Mobile App,PRODUCTIVITY,4.2,0,43M,100,Free,0,Everyone,Productivity
+Lakeside AG Moultrie,LIFESTYLE,5.0,3,8.6M,50,Free,0,Everyone,Lifestyle
+Ag Guardian,PRODUCTIVITY,4.2,1,2.0M,100,Free,0,Everyone,Productivity
+Wind & Weather Meter for Ag,WEATHER,4.2,3,14M,1000,Free,0,Everyone,Weather
+Ag Across America,FAMILY,4.2,0,15M,10,Free,0,Everyone,Educational;Education
+Border Ag & Energy,BUSINESS,4.1,0,12M,50,Free,0,Everyone,Business
+Ag-Pro Companies,BUSINESS,4.1,0,45M,50,Free,0,Everyone,Business
+My Ag Report,PRODUCTIVITY,4.2,1,3.2M,50,Free,0,Everyone,Productivity
+Alabama Ag Credit Ag Banking,FINANCE,4.1,0,Varies with device,100,Free,0,Everyone,Finance
+AG EMS Tour,FAMILY,4.2,3,62M,500,Free,0,Everyone,Entertainment
+Mix Tank – Tank Mixing Ag App,PRODUCTIVITY,3.6,64,15M,10000,Free,0,Everyone,Productivity
+Eternal Light AG,SOCIAL,5.0,30,13M,100,Free,0,Teen,Social
+AG test,TOOLS,4.0,3,18M,100,Free,0,Everyone,Tools
+West Central Ag,BUSINESS,4.1,3,1.7M,100,Free,0,Everyone,Business
+Platincoin Wallet - PLC Group AG,LIBRARIES_AND_DEMO,4.3,375,15M,10000,Free,0,Everyone,Libraries & Demo
+Tri-Ag (WV) FCU,FINANCE,4.1,0,2.9M,100,Free,0,Everyone,Finance
+Ag PhD Soybean Diseases,BOOKS_AND_REFERENCE,4.3,0,5.9M,1000,Free,0,Everyone,Books & Reference
+United Ag Cooperative,BUSINESS,4.1,0,4.2M,5,Free,0,Everyone,Business
+Ag Valley Cooperative,BUSINESS,5.0,6,74M,500,Free,0,Everyone,Business
+Michael's AG Sound Board,FAMILY,4.2,0,1.7M,1,Paid,$0.99,Everyone,Entertainment
+Ag-Power,BUSINESS,4.1,0,47M,10,Free,0,Everyone,Business
+Fertilizer Removal By Crop,BOOKS_AND_REFERENCE,4.1,295,6.9M,50000,Free,0,Everyone,Books & Reference
+AG Track,TOOLS,4.1,12,8.7M,100,Free,0,Everyone,Tools
+Denis Brogniart - AH !,FAMILY,4.5,2931,818k,100000,Free,0,Everyone,Entertainment
+Freeland AH,MEDICAL,4.2,0,28M,100,Free,0,Everyone,Medical
+MD PAWS AH,MEDICAL,4.2,0,29M,100,Free,0,Everyone,Medical
+AH Connect (Adventist Health),HEALTH_AND_FITNESS,3.4,5,59M,1000,Free,0,Everyone,Health & Fitness
+Woodland AH,MEDICAL,4.2,0,Varies with device,50,Free,0,Everyone,Medical
+Mukwonago AH,MEDICAL,4.2,1,29M,100,Free,0,Everyone,Medical
+Angelcare AH,MEDICAL,4.2,0,29M,50,Free,0,Everyone,Medical
+WoW AH Tracker,TOOLS,2.9,33,Varies with device,10000,Free,0,Everyone,Tools
+AH Kollection for KLWP,PERSONALIZATION,4.6,644,59M,50000,Free,0,Everyone,Personalization
+Chenoweth AH,MEDICAL,5.0,1,27M,100,Free,0,Everyone,Medical
+Sayers AH,MEDICAL,4.2,0,29M,50,Free,0,Everyone,Medical
+Claus Paws AH,MEDICAL,4.2,1,29M,100,Free,0,Everyone,Medical
+Denis Brogniart - AH 2 !,FAMILY,4.2,4,14M,100,Free,0,Everyone,Entertainment
+Ah! Cutie,FAMILY,3.9,536,10M,10000,Free,0,Everyone,Casual
+AH Alarm Panel,TOOLS,3.9,7,81k,100,Paid,$4.99,Everyone,Tools
+Arrowhead AH App,MEDICAL,5.0,3,28M,100,Free,0,Everyone,Medical
+Ah! Monster,FAMILY,4.1,1998,9.8M,100000,Free,0,Everyone,Casual
+Maricopa AH,MEDICAL,4.2,0,29M,100,Free,0,Everyone,Medical
+Kimbrough AH,MEDICAL,5.0,5,28M,100,Free,0,Everyone,Medical
+The Ah Yeah! Button,FAMILY,3.0,30,318k,5000,Free,0,Everyone,Entertainment
+Bee'ah Employee App,COMMUNICATION,4.0,4,5.4M,100,Free,0,Teen,Communication
+Clarksburg AH,MEDICAL,1.0,1,28M,50,Free,0,Everyone,Medical
+WAH AH,MEDICAL,4.2,0,29M,100,Free,0,Everyone,Medical
+Prestige AH,MEDICAL,4.0,2,29M,100,Free,0,Everyone,Medical
+San Dimas AH,MEDICAL,4.2,0,29M,100,Free,0,Everyone,Medical
+Ah Bailar,FAMILY,4.2,10,3.0M,100,Free,0,Everyone,Entertainment
+Ebenezer AH,MEDICAL,4.0,4,27M,500,Free,0,Everyone,Medical
+Boston AH,MEDICAL,4.2,1,29M,50,Free,0,Everyone,Medical
+AH-1 Viper Cobra Ops - helicopter flight simulator,GAME,3.8,1088,86M,100000,Free,0,Teen,Action
+Ah !,FAMILY,4.2,3,22M,50,Free,0,Everyone,Entertainment
+Kay AH GA,MEDICAL,4.2,0,29M,1,Free,0,Everyone,Medical
+Bayview Hill AH,MEDICAL,4.2,0,29M,50,Free,0,Everyone,Medical
+Hilltop AH,MEDICAL,4.2,0,29M,100,Free,0,Everyone,Medical
+Ah Ha Block,FAMILY,4.2,2,16M,100,Free,0,Everyone,Casual
+AH Lake Villa,MEDICAL,4.2,3,27M,100,Free,0,Everyone,Medical
+Ferguson AH,MEDICAL,4.2,0,29M,100,Free,0,Everyone,Medical
+be'ah,HEALTH_AND_FITNESS,4.3,5,5.7M,10,Free,0,Everyone,Health & Fitness
+Ah! Bird,SPORTS,3.5,1689,5.7M,100000,Free,0,Everyone,Sports
+Downers Grove AH,MEDICAL,4.2,0,29M,100,Free,0,Everyone,Medical
+AH! Soundboard,FAMILY,4.2,11,2.0M,100,Free,0,Everyone,Entertainment
+Sherbourne AH,MEDICAL,4.2,1,29M,50,Free,0,Everyone,Medical
+Cathy AH,TOOLS,4.0,0,20M,1,Free,0,Everyone,Tools
+Monticello AH,MEDICAL,4.2,0,28M,50,Free,0,Everyone,Medical
+Brandon Lakes AH,MEDICAL,2.6,5,27M,100,Free,0,Everyone,Medical
+Forest Crossing AH,MEDICAL,4.2,0,29M,10,Free,0,Everyone,Medical
+Ah! Coins,GAME,3.4,256,9.1M,50000,Free,0,Everyone,Action
+Mitchell AH,MEDICAL,4.2,0,29M,50,Free,0,Everyone,Medical
+AH of Rocky Hill,MEDICAL,4.2,0,29M,100,Free,0,Everyone,Medical
+Replika,FAMILY,4.5,45458,35M,1000000,Free,0,Mature 17+,Entertainment
+Ai illustrator viewer,ART_AND_DESIGN,3.4,486,5.9M,100000,Free,0,Everyone,Art & Design
+Real AI,FAMILY,3.8,949,1.2M,50000,Free,0,Everyone,Entertainment
+The Artificial Intelligence Project (A.I. Chat),FAMILY,3.0,76,39M,5000,Paid,$1.99,Everyone,Simulation
+Virtual Assistant DataBot: Artificial Intelligence,FAMILY,4.4,80927,27M,1000000,Free,0,Everyone,Entertainment
+ALPHA - Artificial Intelligence,FAMILY,4.0,51,3.2M,1000,Free,0,Everyone,Entertainment
+Artificial Intelligence,FAMILY,3.9,339,4.2M,50000,Free,0,Everyone,Education
+Orbita AI — Exciting mobile puzzles & riddles,FAMILY,4.6,116973,31M,1000000,Free,0,Everyone,Puzzle
+SMS AI Bot,TOOLS,3.8,89,3.9M,10000,Free,0,Everyone,Tools
+ChatBot AI Talking Girl,FAMILY,3.8,3597,25M,100000,Free,0,Everyone 10+,Entertainment
+Ai File Viewer,TOOLS,4.0,66,Varies with device,10000,Free,0,Everyone,Tools
+Youper - AI Therapy,MEDICAL,4.6,1976,69M,50000,Free,0,Everyone,Medical
+ParaTek Ai Speech generator,TOOLS,3.6,448,4.3M,50000,Free,0,Everyone,Tools
+Extreme- Personal Voice Assistant,PRODUCTIVITY,4.4,25627,9.8M,1000000,Free,0,Everyone,Productivity
+AI Face Beauty Analysis - IntelliFace (Free),BEAUTY,3.1,40,13M,10000,Free,0,Everyone,Beauty
+Robin - AI Voice Assistant,MAPS_AND_NAVIGATION,4.2,55313,16M,1000000,Free,0,Everyone,Maps & Navigation
+Learn Artificial Intelligence,FAMILY,4.6,27,4.2M,10000,Free,0,Everyone,Education
+AI Benchmark,TOOLS,4.0,97,99M,5000,Free,0,Everyone,Tools
+AI Today : Artificial Intelligence News & AI 101,NEWS_AND_MAGAZINES,5.0,43,2.3M,100,Free,0,Everyone,News & Magazines
+Tomo A.i. Pet Chat Bot,FAMILY,3.3,40,3.6M,1000,Free,0,Everyone,Entertainment
+Puck AI Personal Assistant Robot,PRODUCTIVITY,4.1,22,26M,1000,Free,0,Everyone,Productivity
+Builder (by Engineer.ai),PRODUCTIVITY,3.6,8,3.2M,100,Free,0,Everyone,Productivity
+Chat With Artificial Intelligence,FAMILY,3.2,32,2.8M,1000,Free,0,Everyone,Entertainment
+Friday: Smart Personal Assistant,PRODUCTIVITY,4.4,2087,8.3M,100000,Free,0,Everyone,Productivity
+Picai - Smart AI Camera,PHOTOGRAPHY,4.0,529,Varies with device,100000,Free,0,Everyone,Photography
+Virtual Eye AI,TOOLS,4.4,26,3.8M,500,Free,0,Everyone,Tools
+Lyra Virtual Assistant,PRODUCTIVITY,4.5,41624,3.4M,1000000,Free,0,Everyone,Productivity
+2048(AI),FAMILY,4.3,20,3.5M,1000,Free,0,Everyone,Casual
+ai robot keyboard,PERSONALIZATION,4.7,1891,1.9M,100000,Free,0,Everyone,Personalization
+AI with Python Tutorial,FAMILY,4.4,8,3.3M,5000,Free,0,Everyone,Education
+ai.Bot Box,PRODUCTIVITY,4.2,0,Varies with device,10000,Free,0,Everyone,Productivity
+Adobe Illustrator Draw,PHOTOGRAPHY,4.4,65766,Varies with device,5000000,Free,0,Everyone,Photography
+FaceApp,PHOTOGRAPHY,4.4,346681,7.1M,10000000,Free,0,Everyone,Photography
+Message AI - Write Better Messages (Free),SOCIAL,3.7,3,7.9M,100,Free,0,Everyone,Social
+ChatBolo - AI Chatbot Online,FAMILY,3.3,1407,1.4M,100000,Free,0,Everyone,Entertainment
+Artificial intelligence,FAMILY,4.2,3,1.8M,100,Free,0,Everyone,Entertainment
+MiAI (Artificial Intelligence) Assistant,PRODUCTIVITY,3.7,3,7.5M,100,Free,0,Everyone,Productivity
+AI Draw | Art Filter for Selfie,PHOTOGRAPHY,3.0,20,4.3M,1000,Paid,$2.99,Everyone,Photography
+Turbo AI™ - Personal assistant,PRODUCTIVITY,2.6,91,2.8M,5000,Free,0,Everyone,Productivity
+Message AI - Write Better Messages,TOOLS,4.0,0,7.9M,100,Paid,$2.99,Mature 17+,Tools
+AI Image Recognizer (beta),PHOTOGRAPHY,4.2,0,3.7M,500,Free,0,Everyone,Photography
+AI Sight,PRODUCTIVITY,3.5,43,48M,1000,Free,0,Everyone,Productivity
+Jarvis artificial intelligent,FAMILY,3.9,253,14M,10000,Free,0,Everyone,Entertainment
+Age of AI: War Strategy,FAMILY,4.6,71,5.7M,500,Paid,$2.49,Everyone,Strategy
+DREAM-e: Dream Analysis A.I.,LIFESTYLE,3.8,89,939k,10000,Free,0,Everyone,Lifestyle
+Animal Jam - Play Wild!,FAMILY,4.6,361734,58M,5000000,Free,0,Everyone,Casual;Pretend Play
+AJ Jump: Animal Jam Kangaroos!,GAME,4.4,2975,42M,50000,Paid,$1.99,Everyone,Arcade
+AJ Academy: Amazing Animals,FAMILY,4.5,1564,35M,50000,Free,0,Everyone,Educational;Education
+Dash Tag - Fun Endless Runner!,FAMILY,4.5,6750,43M,100000,Free,0,Everyone,Casual
+Jamaa Amino for Animal Jam,SOCIAL,4.7,3873,63M,10000,Free,0,Teen,Social
+Tunnel Town,FAMILY,4.4,74744,60M,1000000,Free,0,Everyone,Strategy
+AJ+ Beta,NEWS_AND_MAGAZINES,4.1,0,Varies with device,1000,Free,0,Everyone,News & Magazines
+AJ Cam,PHOTOGRAPHY,5.0,44,2.8M,100,Free,0,Everyone,Photography
+AJ Reminders,MAPS_AND_NAVIGATION,4.1,0,3.2M,10,Free,0,Everyone,Maps & Navigation
+tournaments and more.aj.2,COMMUNICATION,4.2,0,4.2M,100,Free,0,Teen,Communication
+Club Penguin Island,FAMILY,2.8,107441,32M,1000000,Free,0,Everyone,Casual;Action & Adventure
+Aj. Vallbona,NEWS_AND_MAGAZINES,4.1,0,22M,10,Free,0,Everyone,News & Magazines
+AJ Official,FAMILY,4.6,31,7.3M,500,Free,0,Everyone,Education
+AJ Bell Youinvest,FINANCE,2.8,135,5.3M,10000,Free,0,Everyone,Finance
+Hey AJ! It's Saturday!,BOOKS_AND_REFERENCE,5.0,12,50M,100,Paid,$3.99,Everyone,Books & Reference
+Selfie With Champion AJ Style,PHOTOGRAPHY,5.0,2,7.5M,500,Free,0,Everyone,Photography
+Baby Game Animal Jam Free,GAME,2.8,9,26M,500,Free,0,Everyone,Board
+AJ Concept Group App,HOUSE_AND_HOME,4.2,0,17M,10,Free,0,Everyone,House & Home
+Blackjack aj Poker,GAME,3.8,8,4.2M,1000,Free,0,Teen,Card
+Bonza Poly Art - Tenkyu Animal Jam for Kids,FAMILY,4.1,22,31M,1000,Free,0,Everyone,Puzzle
+A.J. Styles HD Wallpapers 2018,PHOTOGRAPHY,4.2,1,7.6M,100,Free,0,Everyone,Photography
+AJ Player,VIDEO_PLAYERS,4.8,18,1.7M,100,Free,0,Everyone,Video Players & Editors
+AJ RETAILS,SHOPPING,5.0,9,169k,10,Free,0,Everyone,Shopping
+Hey AJ! It's Bedtime!,FAMILY,5.0,1,63M,10,Paid,$4.99,Everyone,Education
+AJ AUTO,AUTO_AND_VEHICLES,4.2,0,7.7M,10,Free,0,Everyone,Auto & Vehicles
+AJ Percent Off Calculator,SHOPPING,4.4,134,45k,10000,Free,0,Everyone,Shopping
+AJ Nails Supply,SHOPPING,4.3,1,6.6M,100,Free,0,Everyone,Shopping
+Aj.Petra,COMMUNICATION,4.2,5,14M,100,Free,0,Everyone,Communication
+AJ Men's Grooming,LIFESTYLE,5.0,2,22M,100,Free,0,Everyone,Lifestyle
+Watch Face Swiss AJ-6,PERSONALIZATION,4.1,21,3.6M,100,Paid,$0.99,Everyone,Personalization
+AJ Rafael Music Lyrics,FAMILY,4.2,0,8.4M,50,Free,0,Everyone 10+,Entertainment
+AJ Styles HD Wallpapers,ART_AND_DESIGN,4.8,48,25M,5000,Free,0,Everyone,Art & Design
+AJ and Alyssa,LIFESTYLE,4.1,0,475k,100,Free,0,Everyone,Lifestyle
+A.J. Green Wallpapers 4 Fans,LIFESTYLE,4.1,0,4.3M,5,Free,0,Everyone,Lifestyle
+AJ Gray Icon Pack,PERSONALIZATION,4.8,5,35M,50,Paid,$0.99,Everyone,Personalization
+AJ Styles Wallpaper 2018 - AJ Styles HD Wallpaper,ART_AND_DESIGN,4.0,18,3.6M,1000,Free,0,Everyone,Art & Design
+A-J Media Vault,BOOKS_AND_REFERENCE,4.3,1,24M,50,Free,0,Everyone,Books & Reference
+AJ Gray Dark Icon Pack,PERSONALIZATION,5.0,2,35M,10,Paid,$0.99,Everyone,Personalization
+Little Pets Animal Guardians,FAMILY,4.6,18893,91M,100000,Free,0,Everyone,Casual;Pretend Play
+AJ-COMICS,FOOD_AND_DRINK,4.2,0,27M,5,Free,0,Everyone,Food & Drink
+AJ Blue Icon Pack,PERSONALIZATION,5.0,4,31M,50,Paid,$0.99,Everyone,Personalization
+AJ Tracey Music and Lyrics,FAMILY,4.2,0,2.7M,5,Free,0,Teen,Entertainment
+AJ Turquoise Dark Icon Pack,PERSONALIZATION,4.3,0,32M,10,Paid,$0.99,Everyone,Personalization
+AJ렌터카 법인 카셰어링,MAPS_AND_NAVIGATION,4.1,0,27M,10,Free,0,Everyone,Maps & Navigation
+My Wild Pet: Online Animal Sim,FAMILY,4.5,26916,67M,500000,Free,0,Everyone,Casual;Pretend Play
+AJ Rafael Music Lessons,FAMILY,5.0,1,8.2M,10,Free,0,Everyone,Entertainment
+AJ Orange Icon Pack,PERSONALIZATION,4.3,0,30M,10,Paid,$0.99,Everyone,Personalization
+AJ Wallpapers,PERSONALIZATION,4.3,0,3.9M,100,Free,0,Everyone,Personalization
+Aj Di Awaaz,NEWS_AND_MAGAZINES,4.1,9,1.1M,500,Free,0,Everyone,News & Magazines
+How it works: AK-74N,FAMILY,4.4,1031,48M,100000,Free,0,Everyone,Entertainment
+AK-47: Simulator and Shooting,FAMILY,4.0,345,14M,100000,Free,0,Everyone 10+,Simulation
+AK-47 Simulation and Info,FAMILY,4.2,2,18M,100,Free,0,Everyone,Entertainment
+AK-47 Sounds,FAMILY,3.9,656,2.9M,500000,Free,0,Everyone 10+,Entertainment
+AK 47 Live Wallpaper,PERSONALIZATION,4.1,585,4.4M,50000,Free,0,Everyone,Personalization
+Puppy Shooting an AK-47: Platformer Zombie Game,GAME,4.8,21,89M,1000,Free,0,Everyone,Arcade
+AK Interactive,FAMILY,4.3,734,13M,10000,Free,0,Everyone,Entertainment
+AK-47 sounds,FAMILY,3.9,7,3.8M,1000,Free,0,Everyone,Entertainment
+Wallpapers AK 47 Guns,PERSONALIZATION,4.5,37,15M,5000,Free,0,Teen,Personalization
+AK 47 Assault Rifle Wallpapers,PERSONALIZATION,4.3,1,15M,100,Free,0,Teen,Personalization
+AK-47 Assault Rifle,FAMILY,3.7,165,25M,10000,Free,0,Teen,Entertainment
+Crisis Action: 2018 NO.1 FPS,GAME,4.3,807226,34M,10000000,Free,0,Teen,Action
+AK 47 Guns Wallpaper,PERSONALIZATION,4.2,322,6.8M,50000,Free,0,Everyone,Personalization
+AK-47 3D,GAME,3.7,91,24M,10000,Free,0,Everyone,Action
+Book of AK-47,LIFESTYLE,3.8,6,3.4M,500,Free,0,Everyone,Lifestyle
+Weapon stripping 3D,FAMILY,4.6,23971,24M,1000000,Free,0,Everyone,Simulation
+AK-47 Assult Rifle: Gun Shooting Simulator Game,GAME,4.3,1,5.8M,500,Free,0,Everyone,Action
+Ak-47 Wallpapers 2018,PERSONALIZATION,4.3,7,4.9M,500,Free,0,Everyone,Personalization
+Wallpapers New AK 47 Assault Rifle Guns Arms,PERSONALIZATION,4.3,0,16M,100,Free,0,Teen,Personalization
+Weapon AK-74 Live Wallpaper,PERSONALIZATION,3.3,25,46M,1000,Free,0,Everyone,Personalization
+Shoot M-16 vs AK-47 : realistic weapon simulator,FAMILY,3.0,2,33M,100,Free,0,Everyone,Simulation
+Counter Terrorist Attack,GAME,3.9,145931,43M,10000000,Free,0,Teen,Action
+RULES OF SURVIVAL,GAME,4.2,1343106,56M,10000000,Free,0,Teen,Action
+AK47 Assault Rifle,TOOLS,3.9,54,2.8M,10000,Free,0,Everyone,Tools
+Wallpapers AK 74M,PERSONALIZATION,4.3,0,11M,10,Free,0,Teen,Personalization
+Weapons simulator AK-47,FAMILY,4.1,21,26M,5000,Free,0,Everyone,Simulation
+Wallpapers AK 12,PERSONALIZATION,4.3,0,11M,10,Free,0,Teen,Personalization
+AK 47 Lock Screen,PERSONALIZATION,4.6,5,8.8M,500,Free,0,Mature 17+,Personalization
+Gun AK 47,FAMILY,4.2,3,6.2M,1000,Free,0,Everyone,Entertainment
+AK Blackjack,GAME,4.3,4,7.6M,1000,Free,0,Teen,Card
+Jigsaw Puzzles AK 74M,PERSONALIZATION,4.3,0,4.9M,10,Free,0,Mature 17+,Personalization
+AK-47 guns Sounds,FAMILY,4.2,2,5.1M,100,Free,0,Everyone,Entertainment
+AK Phone,COMMUNICATION,4.4,9,4.2M,5000,Free,0,Everyone,Communication
+AK Booster,TOOLS,3.8,71,7.0M,10000,Free,0,Everyone,Tools
+GUN ZOMBIE,GAME,4.4,243121,38M,5000000,Free,0,Teen,Arcade
+Ak Parti Yardım Toplama,SOCIAL,4.3,0,8.7M,0,Paid,$13.99,Teen,Social
+AK Lodi Films,VIDEO_PLAYERS,4.9,23,2.1M,100,Free,0,Everyone,Video Players & Editors
+Gun Mod: Guns in Minecraft PE,FAMILY,3.6,33812,12M,5000000,Free,0,Teen,Entertainment
+Kymco AK 550,AUTO_AND_VEHICLES,4.3,47,58M,1000,Free,0,Everyone,Auto & Vehicles
+AK Math Coach,FAMILY,3.6,283,18M,50000,Free,0,Everyone,Education
+Shoot Strike War Fire,GAME,4.1,82827,20M,10000000,Free,0,Teen,Arcade
+AL.com,NEWS_AND_MAGAZINES,3.4,803,8.0M,50000,Free,0,Everyone 10+,News & Magazines
+University of Alabama,FAMILY,4.5,302,3.0M,50000,Free,0,Everyone,Education
+Alabama Gameday Live,SPORTS,4.7,19,12M,1000,Free,0,Everyone,Sports
+AL.com: Alabama Football News,SPORTS,4.5,459,8.0M,10000,Free,0,Everyone 10+,Sports
+Alabama Road Trips,TRAVEL_AND_LOCAL,4.4,71,28M,10000,Free,0,Everyone,Travel & Local
+Alabama DMV Permit Test - AL,FAMILY,4.3,218,29M,10000,Free,0,Everyone,Education
+Al-Quran (Free),BOOKS_AND_REFERENCE,4.6,218451,4.7M,10000000,Free,0,Everyone,Books & Reference
+Official AL Fishing & Hunting,TRAVEL_AND_LOCAL,4.2,1291,40M,50000,Free,0,Everyone,Travel & Local
+Al Quran (Tafsir & by Word),BOOKS_AND_REFERENCE,4.8,57400,14M,500000,Free,0,Everyone,Books & Reference
+Al-Moazin Lite (Prayer Times),LIFESTYLE,4.6,284670,Varies with device,10000000,Free,0,Everyone,Lifestyle
+Al Quran Indonesia,BOOKS_AND_REFERENCE,4.8,445756,16M,10000000,Free,0,Everyone,Books & Reference
+Al'Quran Bahasa Indonesia,BOOKS_AND_REFERENCE,4.6,361780,9.7M,10000000,Free,0,Everyone,Books & Reference
+Al Quran Al karim,BOOKS_AND_REFERENCE,4.6,41608,49M,1000000,Free,0,Everyone,Books & Reference
+Al jazeera TV,FAMILY,4.6,9952,3.7M,100000,Free,0,Teen,Entertainment
+Al Jazeera English,NEWS_AND_MAGAZINES,4.1,24456,Varies with device,1000000,Free,0,Everyone,News & Magazines
+Al-Muhaffiz,BOOKS_AND_REFERENCE,4.7,2319,27M,50000,Free,0,Everyone,Books & Reference
+Al Quran Audio (Full 30 Juz),FAMILY,4.7,7878,3.6M,1000000,Free,0,Everyone,Education
+Quran for All (Al-Huda Int.),FAMILY,4.8,6696,5.3M,100000,Free,0,Everyone,Education
+AL Voice Recorder,PRODUCTIVITY,3.6,4832,2.4M,1000000,Free,0,Everyone,Productivity
+Ayat - Al Quran,FAMILY,4.7,173394,8.5M,5000000,Free,0,Everyone,Education
+Quran Juz-30 - Mahad al Zahra,FAMILY,4.6,2654,6.7M,100000,Free,0,Everyone,Education
+Al Quran : EAlim - Translations & MP3 Offline,BOOKS_AND_REFERENCE,4.5,96419,Varies with device,5000000,Free,0,Everyone,Books & Reference
+Al Mayadeen,NEWS_AND_MAGAZINES,4.7,13620,9.0M,500000,Free,0,Everyone,News & Magazines
+Al-Quran Al-Muallim,FAMILY,4.5,199,266k,10000,Free,0,Everyone,Education
+We're Working Out - Al Kavadlo,HEALTH_AND_FITNESS,4.3,979,Varies with device,50000,Free,0,Everyone,Health & Fitness
+Al-Quran 30 Juz free copies,BOOKS_AND_REFERENCE,4.5,12322,27M,500000,Free,0,Everyone,Books & Reference
+Koran Read &MP3 30 Juz Offline,BOOKS_AND_REFERENCE,4.8,29551,67M,1000000,Free,0,Everyone,Books & Reference
+Al Quran MP3 - Quran Reading®,FAMILY,4.7,47463,22M,1000000,Free,0,Everyone,Education
+Al'Quran Bahasa Indonesia PRO,BOOKS_AND_REFERENCE,4.7,1340,11M,10000,Paid,$4.49,Everyone,Books & Reference
+Hafizi Quran 15 lines per page,BOOKS_AND_REFERENCE,4.7,55011,68M,1000000,Free,0,Everyone,Books & Reference
+Al-Quran Ahmad Saud Offline,FAMILY,4.7,7116,40M,100000,Free,0,Everyone,Education
+12 Step Meditations & Sober Prayers AA NA AL-ANON,LIFESTYLE,4.7,759,15M,50000,Free,0,Everyone 10+,Lifestyle
+Quran for Android,BOOKS_AND_REFERENCE,4.7,497826,Varies with device,10000000,Free,0,Everyone,Books & Reference
+Al Quran Free - القرآن (Islam),BOOKS_AND_REFERENCE,4.7,1777,23M,50000,Free,0,Everyone,Books & Reference
+Taha Al Junaid Quran Mp3,LIFESTYLE,4.6,518,4.2M,50000,Free,0,Everyone,Lifestyle
+Surah Al-Waqiah,BOOKS_AND_REFERENCE,4.7,1201,2.9M,100000,Free,0,Everyone,Books & Reference
+"Muslim Pro - Prayer Times, Azan, Quran & Qibla",LIFESTYLE,4.7,1133393,Varies with device,10000000,Free,0,Everyone,Lifestyle
+Hisnul Al Muslim - Hisn Invocations & Adhkaar,BOOKS_AND_REFERENCE,4.6,3234,85M,100000,Free,0,Everyone,Books & Reference
+I am rich,LIFESTYLE,3.8,3547,1.8M,100000,Paid,$399.99,Everyone,Lifestyle
+I AM RICH,FAMILY,3.9,1455,1.1M,10000,Free,0,Everyone,Entertainment
+Amazon for Tablets,SHOPPING,4.0,141584,22M,10000000,Free,0,Teen,Shopping
+I am Rich Plus,FAMILY,4.0,856,8.7M,10000,Paid,$399.99,Everyone,Entertainment
+I am rich VIP,LIFESTYLE,3.8,411,2.6M,10000,Paid,$299.99,Everyone,Lifestyle
+I Am Rich Premium,FINANCE,4.1,1867,4.7M,50000,Paid,$399.99,Everyone,Finance
+I am extremely Rich,LIFESTYLE,2.9,41,2.9M,1000,Paid,$379.99,Everyone,Lifestyle
+I am Rich!,FINANCE,3.8,93,22M,1000,Paid,$399.99,Everyone,Finance
+I am rich(premium),FINANCE,3.5,472,965k,5000,Paid,$399.99,Everyone,Finance
+I am Rich Person,LIFESTYLE,4.2,134,1.8M,1000,Paid,$37.99,Everyone,Lifestyle
+I am Rich Premium Plus,FINANCE,4.6,459,2.0M,10000,Paid,$18.99,Everyone,Finance
+I Am Rich Pro,FAMILY,4.4,201,2.7M,5000,Paid,$399.99,Everyone,Entertainment
+I Am Innocent,GAME,4.4,208501,56M,1000000,Free,0,Teen,Adventure
+I am rich (Most expensive app),FINANCE,4.1,129,2.7M,1000,Paid,$399.99,Teen,Finance
+i am rich,BUSINESS,3.9,213,2.9M,1000,Free,0,Everyone,Business
+I Am Rich,FAMILY,3.6,217,4.9M,10000,Paid,$389.99,Everyone,Entertainment
+I am Bread,GAME,4.0,630,20M,10000,Paid,$4.99,Everyone,Adventure
+Where Am I At?,TRAVEL_AND_LOCAL,3.8,39,12M,10000,Free,0,Everyone,Travel & Local
+I am Rich,FINANCE,4.3,180,3.8M,5000,Paid,$399.99,Everyone,Finance
+Where Am I? GPS Loc,TRAVEL_AND_LOCAL,4.6,68,4.2M,10000,Free,0,Everyone,Travel & Local
+I am Millionaire - Richest guy in the town,LIFESTYLE,3.6,126,1.4M,5000,Paid,$2.49,Everyone,Lifestyle
+Coast To Coast AM Insider,NEWS_AND_MAGAZINES,3.9,4581,21M,100000,Free,0,Everyone,News & Magazines
+I AM RICH PRO PLUS,FINANCE,4.0,36,41M,1000,Paid,$399.99,Everyone,Finance
+Where Am I?,TOOLS,4.2,1313,Varies with device,100000,Free,0,Everyone,Tools
+I Am Wizard,FAMILY,4.2,1493,57M,100000,Free,0,Everyone,Strategy
+What Am I? - Brain Teasers,GAME,4.2,4537,15M,100000,Free,0,Everyone,Trivia
+Who am I? (Biblical),GAME,4.5,5849,5.1M,500000,Free,0,Everyone,Trivia
+DWWW 774 Ultimate AM Radio,NEWS_AND_MAGAZINES,4.7,327,31M,10000,Free,0,Everyone,News & Magazines
+Anno: Build an Empire,FAMILY,3.5,33944,28M,1000000,Free,0,Everyone 10+,Strategy
+Vikings: an Archer's Journey,GAME,4.5,10256,39M,1000000,Free,0,Everyone,Action
+Final Fantasy XV: A New Empire,FAMILY,4.0,484858,Varies with device,10000000,Free,0,Everyone 10+,Strategy
+Trell: An app for Explorers | Best Wanderlust App,LIFESTYLE,4.6,8004,34M,100000,Free,0,Teen,Lifestyle
+Virtual Families 2,FAMILY,4.2,636228,Varies with device,10000000,Free,0,Everyone,Casual
+The Sims™ FreePlay,FAMILY,4.3,931503,31M,10000000,Free,0,Teen,Simulation
+My Emma :),FAMILY,4.1,245839,76M,10000000,Free,0,Everyone,Casual
+League of Gamers - Be an E-Sports Legend!,SPORTS,4.5,68072,40M,5000000,Free,0,Everyone,Sports
+Draw a Stickman: EPIC Free,GAME,4.2,210317,46M,10000000,Free,0,Everyone 10+,Adventure
+My Horse,FAMILY,4.5,1333338,8.7M,10000000,Free,0,Everyone,Casual
+My Boo - Your Virtual Pet Game,FAMILY,4.4,899748,80M,10000000,Free,0,Everyone,Casual
+Create apps fast with beautiful design and no code,BUSINESS,3.7,23729,24M,1000000,Free,0,Everyone,Business
+THE KING OF FIGHTERS-A 2012(F),GAME,4.4,406511,21M,5000000,Free,0,Teen,Action
+Text free - Free Text + Call,SOCIAL,4.3,315390,Varies with device,10000000,Free,0,Everyone,Social
+Diary with lock password,LIFESTYLE,4.3,179139,9.7M,5000000,Free,0,Everyone,Lifestyle
+Fast like a Fox,GAME,4.3,104389,12M,5000000,Free,0,Everyone,Adventure
+Google Photos,PHOTOGRAPHY,4.5,10847682,Varies with device,1000000000,Free,0,Everyone,Photography
+Scoompa Video - Slideshow Maker and Video Editor,PHOTOGRAPHY,4.5,559931,Varies with device,10000000,Free,0,Everyone,Photography
+Girls Craft: Exploration,FAMILY,3.8,130689,57M,5000000,Free,0,Everyone 10+,Simulation
+The PCH App,LIFESTYLE,4.5,234971,81M,1000000,Free,0,Everyone,Lifestyle
+Legend - Animate Text in Video,SOCIAL,4.5,228737,Varies with device,10000000,Free,0,Everyone,Social
+"Resume Builder Free, 5 Minute CV Maker & Templates",BUSINESS,4.4,72202,6.7M,1000000,Free,0,Everyone,Business
+AO Surgery Reference,MEDICAL,4.7,2570,3.8M,100000,Free,0,Everyone,Medical
+ao,FAMILY,3.5,14145,5.9M,1000000,Free,0,Everyone,Strategy
+AO/OTA Fracture Classification,MEDICAL,4.9,25,46M,5000,Free,0,Everyone,Medical
+AO Player,EVENTS,4.0,9,3.3M,1000,Free,0,Everyone,Events
+Ao Oni2,GAME,4.1,21223,48M,1000000,Free,0,Teen,Adventure
+A. O. Smith,TOOLS,4.2,32,33M,10000,Free,0,Everyone,Tools
+AO-EVENT,BUSINESS,4.1,0,42M,100,Free,0,Everyone,Business
+Arena of Valor: 5v5 Arena Game,GAME,4.4,438911,99M,10000000,Free,0,Teen,Action
+PlacarTv Futebol Ao Vivo,COMMUNICATION,4.1,2063,4.5M,100000,Free,0,Everyone,Communication
+Virtual lover,FAMILY,4.6,45771,28M,1000000,Free,0,Mature 17+,Entertainment
+The Hunt for the Lost Treasure,FAMILY,4.6,7148,8.1M,100000,Paid,$2.99,Everyone,Adventure;Brain Games
+Attack the Light,FAMILY,4.7,19209,21M,100000,Paid,$2.99,Everyone,Role Playing;Action & Adventure
+Princess Closet : Otome games free dating sim,FAMILY,4.5,29495,56M,1000000,Free,0,Teen,Simulation
+Gravidez ao Vivo,MEDICAL,4.2,61,Varies with device,1000,Paid,$2.99,Everyone,Medical
+365Scores - Live Scores,SPORTS,4.6,666246,25M,10000000,Free,0,Everyone,Sports
+PES 2018 PRO EVOLUTION SOCCER,SPORTS,4.4,1721943,26M,10000000,Free,0,Everyone,Sports
+Mobile Legends: Bang Bang,GAME,4.4,8219586,99M,100000000,Free,0,Teen,Action
+Heroes of Order & Chaos,FAMILY,4.2,690148,25M,10000000,Free,0,Teen,Strategy
+Kill Shot Bravo: Sniper FPS,GAME,4.4,579519,99M,10000000,Free,0,Mature 17+,Action
+Tennis Champion 3D - Online Sports Game,SPORTS,4.0,170973,43M,5000000,Free,0,Everyone,Sports
+Carnivores: Dinosaur Hunter,GAME,4.2,62636,17M,1000000,Free,0,Teen,Action
+High School Simulator 2017,FAMILY,4.2,123136,80M,5000000,Free,0,Mature 17+,Simulation
+Hopeless Land: Fight for Survival,GAME,4.2,250197,44M,5000000,Free,0,Teen,Action
+SofaScore Live Score,SPORTS,4.8,221722,Varies with device,10000000,Free,0,Everyone,Sports
+Virtual Cigarette Smoking (prank),FAMILY,3.7,29838,Varies with device,5000000,Free,0,Mature 17+,Entertainment
+Scanning body and undressing people,FAMILY,3.4,1012,12M,100000,Free,0,Teen,Entertainment
+Ultimate Tennis,SPORTS,4.3,183004,100M,10000000,Free,0,Everyone,Sports
+Legion of Heroes,FAMILY,4.3,143087,69M,1000000,Free,0,Everyone 10+,Role Playing
+Soccer Star 2018 Top Leagues · MLS Soccer Games,SPORTS,4.6,652940,90M,10000000,Free,0,Teen,Sports
+Heroes Arena,GAME,4.2,336386,88M,10000000,Free,0,Everyone 10+,Action
+virtual lover 3D,FAMILY,4.6,5195,64M,100000,Free,0,Mature 17+,Entertainment
+Range Master: Sniper Academy,SPORTS,4.1,91935,39M,10000000,Free,0,Everyone,Sports
+DINO HUNTER: DEADLY SHORES,GAME,4.4,1381624,54M,10000000,Free,0,Teen,Action
+FC Barcelona Official App,SPORTS,4.6,92522,56M,5000000,Free,0,Everyone,Sports
+Can Your Pet? : Returns - Teen,FAMILY,4.3,45370,14M,1000000,Free,0,Teen,Simulation
+GUYZ - Gay Chat & Gay Dating,SOCIAL,4.4,41269,Varies with device,1000000,Free,0,Mature 17+,Social
+Bubbu – My Virtual Pet,FAMILY,4.7,394842,75M,10000000,Free,0,Everyone,Casual;Pretend Play
+3D Tennis,SPORTS,4.2,1008012,13M,50000000,Free,0,Everyone,Sports
+Start the Hunt for the Lost Treasure,FAMILY,3.8,302,8.1M,10000,Free,0,Everyone,Puzzle;Brain Games
+Treasure Hunt Hidden Objects Adventure Game,FAMILY,4.3,1231,Varies with device,100000,Free,0,Everyone,Puzzle
+Scanning under clothes (prank),FAMILY,3.7,1443,20M,100000,Free,0,Mature 17+,Entertainment
+WGT Golf Game by Topgolf,SPORTS,4.3,148083,57M,10000000,Free,0,Everyone,Sports
+3D Holograms Joke,FAMILY,2.9,31596,31M,5000000,Free,0,Teen,Simulation
+Weaphones™ Gun Sim Free Vol 1,FAMILY,4.3,598975,39M,10000000,Free,0,Everyone,Simulation
+Hidden Objects Treasure Hunt Adventure Games,FAMILY,4.3,275,29M,10000,Free,0,Everyone,Puzzle
+Live Camera Viewer ★ World Webcam & IP Cam Streams,TRAVEL_AND_LOCAL,4.0,64164,3.6M,10000000,Free,0,Everyone,Travel & Local
+Body scanner (prank),FAMILY,3.3,16063,3.8M,1000000,Free,0,Teen,Casual
+AP Mobile - Breaking News,NEWS_AND_MAGAZINES,4.5,76616,4.6M,1000000,Free,0,Everyone 10+,News & Magazines
+AP ENPS Mobile,PRODUCTIVITY,4.1,22,545k,5000,Free,0,Everyone,Productivity
+AP® Guide,FAMILY,5.0,3,2.1M,1000,Free,0,Everyone,Education
+WiFi Access Point (hotspot),COMMUNICATION,3.9,684,61k,100000,Free,0,Everyone,Communication
+AP Mobile,FAMILY,4.6,117,13M,10000,Free,0,Everyone,Education
+AP Manager,TOOLS,4.0,177,2.8M,10000,Free,0,Everyone,Tools
+AP App for Android™,NEWS_AND_MAGAZINES,3.6,188,9.9M,10000,Free,0,Everyone,News & Magazines
+Access Point Finder,LIFESTYLE,4.0,22,2.5M,10000,Free,0,Everyone,Lifestyle
+AP English Language: Practice Tests and Flashcards,FAMILY,4.5,19,5.4M,5000,Free,0,Everyone,Education
+AP Mobile 104,BUSINESS,4.1,0,14M,100,Free,0,Everyone,Business
+AP Planner,FAMILY,2.9,45,1.3M,5000,Free,0,Everyone,Education
+Access Point Browser,TOOLS,4.2,25,2.5M,1000,Free,0,Everyone,Tools
+AP Installer,TOOLS,4.5,23,283k,5000,Free,0,Everyone,Tools
+Access Point Proximity,TOOLS,4.0,5,2.3M,1000,Free,0,Everyone,Tools
+Study AP World History,FAMILY,4.6,513,1.6M,10000,Free,0,Everyone,Education
+UniFi,TOOLS,4.7,11018,25M,500000,Free,0,Everyone,Tools
+Ap Video Downloader for fb New 2018,TOOLS,4.2,676,5.4M,100000,Free,0,Everyone,Tools
+AP Government Review,FAMILY,4.7,3,1.5M,1000,Paid,$2.99,Everyone,Education
+"ap,wifi testing,iperf,ping,android,Bluetooth,tcp",TOOLS,4.7,3,5.3M,10,Paid,$2.99,Everyone,Tools
+HotSpot Tethering Free/WiFi AP,TOOLS,3.9,478,2.0M,100000,Free,0,Everyone,Tools
+AP Chemistry Prep: Practice Tests and Flashcards,FAMILY,4.7,55,5.4M,10000,Free,0,Everyone,Education
+AP Flashcards,FAMILY,3.7,88,41M,10000,Free,0,Everyone,Education
+AP World History: Practice Tests and Flashcards,FAMILY,4.8,21,5.4M,5000,Free,0,Everyone,Education
+Access Point Names,COMMUNICATION,4.0,138,2.4M,10000,Free,0,Everyone,Communication
+"AP Biology Prep: Practice Tests, Flashcards",FAMILY,4.6,87,5.4M,10000,Free,0,Everyone,Education
+AP Biology Study Guide + Quiz,FAMILY,4.4,105,9.0M,10000,Free,0,Everyone,Education
+Reuters News,NEWS_AND_MAGAZINES,4.3,13166,25M,1000000,Free,0,Everyone 10+,News & Magazines
+500 AP World History Questions,FAMILY,4.7,7,1.2M,100,Paid,$9.99,Everyone,Education
+AP Themes for Kustom/KLWP,PERSONALIZATION,3.6,5,45M,500,Paid,$1.49,Everyone,Personalization
+AP Physics 1 Prep: Practice Tests and Flashcards,FAMILY,4.4,29,5.3M,5000,Free,0,Everyone,Education
+Fate GO Ap Counter,TOOLS,4.6,70,3.2M,1000,Free,0,Everyone,Tools
+iScore5 AP Psych,FAMILY,2.9,10,73M,100,Paid,$4.99,Everyone,Educational
+Glanceable Ap Watch Face,PERSONALIZATION,4.3,0,11M,5,Paid,$0.99,Everyone,Personalization
+AP Psychology Prep: Practice Tests and Flashcards,FAMILY,4.5,242,5.4M,50000,Free,0,Everyone,Education
+meStudying: AP English Lit,FAMILY,5.0,1,655k,10,Paid,$4.99,Everyone,Education
+APN Settings,TOOLS,3.7,3743,5.6M,1000000,Free,0,Everyone,Tools
+AEE AP,PHOTOGRAPHY,4.2,4,17M,1000,Free,0,Everyone,Photography
+AP Math & Computer Science,FAMILY,3.7,37,9.5M,5000,Free,0,Everyone,Education
+AP Series Solution Pro,FAMILY,4.2,0,7.4M,0,Paid,$1.99,Everyone,Education
+AP Statistics Prep: Practice Tests and Flashcards,FAMILY,4.2,19,5.4M,5000,Free,0,Everyone,Education
+eChallan Andhra Pradesh (AP),SOCIAL,3.0,5,2.6M,1000,Free,0,Teen,Social
+AP Art History Flashcards,FAMILY,5.0,1,96M,10,Paid,$29.99,Mature 17+,Education
+True Skate,SPORTS,4.4,129409,73M,1000000,Paid,$1.99,Everyone,Sports
+AP European History: Practice Tests and Flashcards,FAMILY,4.7,7,5.4M,1000,Free,0,Everyone,Education
+AdventureQuest 3D MMO,FAMILY,4.3,22667,35M,1000000,Free,0,Teen,Role Playing
+AdventureQuest Dragons,FAMILY,3.9,10114,48M,100000,Free,0,Everyone,Casual
+AQ: First Contact,FAMILY,4.2,0,Varies with device,50000,Free,0,Everyone,Strategy
+Battle Gems (AdventureQuest),FAMILY,4.4,48427,Varies with device,500000,Free,0,Everyone 10+,Puzzle
+Undead Assault,GAME,4.3,4704,37M,100000,Free,0,Everyone 10+,Arcade
+AQ Service,BUSINESS,4.1,4,17M,10,Free,0,Everyone,Business
+AQ wisdom +,TOOLS,4.0,0,35M,100,Free,0,Everyone,Tools
+AQ SMS Notify,TOOLS,4.0,0,2.3M,10,Free,0,Everyone,Tools
+AQ Math Facts,FAMILY,4.2,1,16M,1,Paid,$2.99,Everyone,Educational
+Adventure Quest World Mobile Quiz,FAMILY,4.6,28,26M,500,Free,0,Everyone,Puzzle
+Aqw&3d Design Notes Manager,FAMILY,4.5,11,2.9M,500,Free,0,Everyone,Entertainment
+AQ Aspergers Test,MEDICAL,3.9,265,714k,10000,Free,0,Everyone,Medical
+Guess the Class 🔥 AQW,GAME,4.7,57,12M,1000,Free,0,Everyone,Word
+Puffin Web Browser,COMMUNICATION,4.3,541661,Varies with device,10000000,Free,0,Everyone,Communication
+AQ Ria Retail,FAMILY,5.0,4,52M,50,Free,0,Everyone,Education
+Accounting Quiz (AQ) Malaysia,FAMILY,5.0,25,Varies with device,1000,Free,0,Everyone,Education
+AQ Guards,PRODUCTIVITY,4.2,0,3.2M,10,Free,0,Everyone,Productivity
+Wowkwis aq Ka'qaquj,FAMILY,5.0,1,49M,10,Free,0,Everyone,Education;Education
+AQ Coach,SPORTS,4.2,0,28M,5,Free,0,Everyone,Sports
+AQ Dentals,HEALTH_AND_FITNESS,4.3,0,12M,10,Free,0,Everyone,Health & Fitness
+AccuWeather: Daily Forecast & Live Weather Reports,WEATHER,4.4,2052407,Varies with device,50000000,Free,0,Everyone,Weather
+中国語 AQリスニング,FAMILY,4.2,21,17M,5000,Free,0,Everyone,Education
+ClanHQ,COMMUNICATION,2.7,560,37M,10000,Free,0,Everyone,Communication
+QuickShortcutMaker,PERSONALIZATION,4.6,41000,2.0M,1000000,Free,0,Everyone,Personalization
+Moovit: Bus Time & Train Time Live Info,MAPS_AND_NAVIGATION,4.4,616742,Varies with device,10000000,Free,0,Everyone,Maps & Navigation
+Iron Blade,GAME,4.4,161637,82M,10000000,Free,0,Mature 17+,Action
+QR Droid,PRODUCTIVITY,4.1,349151,Varies with device,50000000,Free,0,Everyone,Productivity
+QR BARCODE SCANNER,TOOLS,3.8,169369,Varies with device,10000000,Free,0,Everyone,Tools
+Dungeon Boss – Strategy RPG,FAMILY,4.4,218881,37M,5000000,Free,0,Everyone 10+,Role Playing
+Questland: Turn Based RPG,FAMILY,4.6,31134,48M,1000000,Free,0,Everyone 10+,Role Playing
+Order & Chaos 2: 3D MMO RPG,FAMILY,4.1,242722,54M,10000000,Free,0,Teen,Role Playing
+Dungeon Quest,FAMILY,4.5,244039,46M,5000000,Free,0,Everyone 10+,Role Playing
+Dungeon Hunter 5 – Action RPG,FAMILY,4.2,720685,51M,10000000,Free,0,Teen,Role Playing
+"Grow Stone Online : 2d pixel RPG, MMORPG game",FAMILY,4.7,84389,48M,1000000,Free,0,Everyone,Role Playing
+Evil Apples: A Dirty Card Game,GAME,4.3,137696,55M,5000000,Free,0,Mature 17+,Word
+Megatramp - a Story of Success!,FAMILY,4.3,322976,Varies with device,5000000,Free,0,Teen,Simulation
+Knightfall™ AR,FAMILY,4.2,254,25M,10000,Free,0,Teen,Strategy
+Ghost Snap AR Horror Survival,GAME,3.8,898,33M,100000,Free,0,Teen,Adventure
+The Walking Dead: Our World,GAME,4.0,22435,100M,1000000,Free,0,Teen,Action
+Jurassic World™ Alive,FAMILY,4.3,308944,70M,5000000,Free,0,Everyone 10+,Simulation
+Snaappy – 3D fun AR core communication platform,SOCIAL,4.6,16801,Varies with device,1000000,Free,0,Everyone,Social
+Sketchfab,FAMILY,4.3,906,9.2M,50000,Free,0,Mature 17+,Entertainment
+Ingress,GAME,4.3,391325,43M,10000000,Free,0,Everyone,Adventure
+My Tamagotchi Forever,FAMILY,4.3,28735,91M,1000000,Free,0,Everyone,Casual
+"Egg, Inc.",FAMILY,4.7,580160,29M,5000000,Free,0,Everyone,Simulation
+Houzz Interior Design Ideas,HOUSE_AND_HOME,4.6,353813,Varies with device,10000000,Free,0,Everyone,House & Home
+Flat Pack,GAME,4.4,862,44M,100000,Free,0,Everyone 10+,Action
+Crayola Color Blaster,GAME,3.8,17,30M,1000,Free,0,Everyone,Arcade
+Guns of Boom - Online Shooter,GAME,4.6,1226514,99M,10000000,Free,0,Teen,Action
+Guns Royale - Multiplayer Blocky Battle Royale,GAME,4.6,19070,90M,100000,Free,0,Everyone 10+,Action
+Build.com - Shop Home Improvement & Expert Advice,HOUSE_AND_HOME,4.5,118,72M,50000,Free,0,Everyone,House & Home
+Wayfair - Shop All Things Home,SHOPPING,4.5,20247,47M,5000000,Free,0,Everyone,Shopping
+NYTimes - Latest News,NEWS_AND_MAGAZINES,3.9,63640,23M,10000000,Free,0,Everyone 10+,News & Magazines
+"Overstock – Home Decor, Furniture Shopping",SHOPPING,4.4,25717,Varies with device,1000000,Free,0,Teen,Shopping
+Stack It AR,GAME,3.8,1363,26M,100000,Free,0,Everyone,Arcade
+"ARuler - AR Ruler app, Measure tools",TOOLS,4.3,1602,5.0M,100000,Free,0,Everyone,Tools
+SNOW - AR Camera,PHOTOGRAPHY,4.3,1017237,Varies with device,50000000,Free,0,Everyone,Photography
+Monster Park AR - Jurassic Dinosaurs in Real World,FAMILY,3.7,128,20M,10000,Free,0,Everyone,Entertainment
+AR Remote Car,FAMILY,3.2,1354,30M,100000,Free,0,Everyone,Simulation
+Solar System AR ( ARCore ),FAMILY,4.0,211,37M,10000,Free,0,Everyone,Entertainment
+Super AR,FAMILY,3.8,410,28M,10000,Free,0,Teen,Entertainment
+Spacecraft AR,FAMILY,4.4,83,85M,10000,Free,0,Everyone,Education
+Assemblr - Create 3D Models (Sandbox AR),FAMILY,3.8,1745,Varies with device,1000000,Free,0,Everyone,Simulation
+MCRAFT AR - EDITOR,FAMILY,3.4,131,22M,5000,Free,0,Everyone,Simulation
+Jenga® AR,FAMILY,2.9,53,82M,10000,Free,0,Everyone,Puzzle
+Nightenfell: Shared AR,GAME,4.5,20,65M,1000,Paid,$0.99,Everyone 10+,Action
+Portal AR - Step Into Scotland,TRAVEL_AND_LOCAL,3.7,25,43M,5000,Free,0,Everyone,Travel & Local
+Arcraft - AR Sandbox,GAME,3.8,469,80M,10000,Free,0,Everyone,Adventure
+Augment - 3D Augmented Reality,BUSINESS,4.1,25195,21M,1000000,Free,0,Everyone,Business
+Satellite AR,BOOKS_AND_REFERENCE,4.1,9636,93k,1000000,Free,0,Everyone,Books & Reference
+Figment AR,FAMILY,3.7,22,90M,5000,Free,0,Everyone,Entertainment
+AR Tank Battle,GAME,3.6,153,67M,10000,Free,0,Everyone,Action
+AR Dragon Pet,FAMILY,4.2,0,Varies with device,50000,Free,0,Everyone,Casual
+Paint Space AR,FAMILY,3.0,17,32M,1000,Free,0,Everyone,Entertainment
+"Just a Line - Draw Anywhere, with AR",FAMILY,4.1,1152,2.7M,100000,Free,0,Everyone,Entertainment
+AR Toybox - Augmented Reality Demos,FAMILY,3.8,20,36M,1000,Free,0,Everyone,Simulation
+"Mind Map AR, Augmented Reality ARCore Mind Mapping",PRODUCTIVITY,4.2,29,35M,5000,Free,0,Everyone,Productivity
+【Miku AR Camera】Mikuture,FAMILY,4.4,36268,41M,1000000,Free,0,Teen,Entertainment
+AR Toys: Playground Sandbox | Remote Car,FAMILY,4.5,153,Varies with device,10000,Free,0,Everyone,Simulation
+Summer Camp Island AR,FAMILY,3.6,740,71M,50000,Free,0,Everyone,Simulation
+AR Sport Cars,FAMILY,3.6,284,70M,10000,Free,0,Everyone,Simulation
+AS - News and sports results.,SPORTS,3.7,20879,22M,1000000,Free,0,Everyone,Sports
+MARCA - Diario Líder Deportivo,SPORTS,3.9,76340,14M,5000000,Free,0,Everyone,Sports
+"AS - Diario online deportivo. Fútbol, motor y más",NEWS_AND_MAGAZINES,4.1,0,6.0M,50,Free,0,Everyone,News & Magazines
+SleepCloud Backup for Sleep as Android,LIFESTYLE,4.2,2563,Varies with device,100000,Free,0,Everyone,Lifestyle
+AS Guía de las Ligas 2017-2018,SPORTS,4.1,4374,53M,100000,Free,0,Everyone,Sports
+Sleep as Android Unlock,LIFESTYLE,4.5,23966,872k,1000000,Paid,$5.99,Everyone,Lifestyle
+Sleep as Android Gear Addon,HEALTH_AND_FITNESS,2.8,961,1.3M,100000,Free,0,Everyone,Health & Fitness
+Sleep as Android Garmin Addon,HEALTH_AND_FITNESS,2.6,114,1.6M,10000,Free,0,Everyone,Health & Fitness
+"Sleep as Android: Sleep cycle tracker, smart alarm",LIFESTYLE,4.3,246201,Varies with device,10000000,Free,0,Everyone,Lifestyle
+Sonic the Hedgehog™ Classic,GAME,4.4,125652,56M,10000000,Free,0,Everyone,Action
+The Aether: Life as a God,FAMILY,4.1,1407,3.4M,100000,Free,0,Everyone 10+,Role Playing
+CAPTCHA Pack for Sleep as Android,LIFESTYLE,4.0,448,3.1M,50000,Free,0,Everyone,Lifestyle
+Pacific Navy Fighter C.E. (AS),GAME,4.3,11379,20M,500000,Free,0,Everyone 10+,Arcade
+Lullaby Add-on for Sleep as Android,HEALTH_AND_FITNESS,3.9,2057,6.2M,50000,Paid,$1.99,Everyone,Health & Fitness
+Sleep as Microsoft Band Add-On,LIFESTYLE,3.5,28,121k,1000,Free,0,Everyone,Lifestyle
+Ear Agent: Super Hearing,COMMUNICATION,3.7,42329,Varies with device,5000000,Free,0,Everyone,Communication
+Ninja Turtles: Legends,FAMILY,4.3,344283,95M,10000000,Free,0,Teen,Role Playing
+Timely Alarm Clock,LIFESTYLE,4.3,258717,9.4M,10000000,Free,0,Everyone,Lifestyle
+PDF Viewer & Book Reader,PRODUCTIVITY,4.1,40437,Varies with device,5000000,Free,0,Everyone,Productivity
+My OldBoy! Free - GBC Emulator,GAME,4.2,51787,Varies with device,5000000,Free,0,Everyone,Arcade
+My Boy! Free - GBA Emulator,GAME,4.3,531074,2.5M,10000000,Free,0,Everyone,Arcade
+Google Voice,COMMUNICATION,4.2,171052,Varies with device,10000000,Free,0,Everyone,Communication
+Choices: Stories You Play,FAMILY,4.6,807155,93M,10000000,Free,0,Teen,Simulation
+Samsung Health,HEALTH_AND_FITNESS,4.3,480208,70M,500000000,Free,0,Everyone,Health & Fitness
+WiFi Baby Monitor - NannyCam,VIDEO_PLAYERS,4.1,29867,1.7M,5000000,Free,0,Everyone,Video Players & Editors
+Maleficent Free Fall,FAMILY,4.4,450013,37M,10000000,Free,0,Everyone,Puzzle
+Star Wars™: Force Arena,FAMILY,4.4,228130,70M,5000000,Free,0,Everyone 10+,Strategy
+Runtastic Sleep Better: Sleep Cycle & Smart Alarm,HEALTH_AND_FITNESS,4.1,111465,Varies with device,5000000,Free,0,Everyone,Health & Fitness
+Google Pay,FINANCE,4.2,348132,Varies with device,100000000,Free,0,Everyone,Finance
+Alarm Clock Plus★,LIFESTYLE,4.4,155693,Varies with device,5000000,Free,0,Everyone,Lifestyle
+Image 2 Wallpaper,TOOLS,4.3,81668,Varies with device,5000000,Free,0,Everyone,Tools
+PS4 Second Screen,FAMILY,2.4,11773,3.3M,1000000,Free,0,Everyone,Entertainment
+Alarm Clock: Stopwatch & Timer,PRODUCTIVITY,4.5,870928,16M,50000000,Free,0,Everyone,Productivity
+Ringtone Maker,PERSONALIZATION,4.3,495748,Varies with device,50000000,Free,0,Everyone,Personalization
+SAMURAI vs ZOMBIES DEFENSE,GAME,4.5,407788,19M,5000000,Free,0,Everyone,Action
+Seen,FAMILY,4.5,118285,22M,1000000,Free,0,Teen,Simulation
+Google Allo,COMMUNICATION,4.3,347086,Varies with device,10000000,Free,0,Everyone,Communication
+Plants vs. Zombies™ Heroes,FAMILY,4.4,379245,68M,10000000,Free,0,Everyone,Casual;Action & Adventure
+CM FILE MANAGER HD,PRODUCTIVITY,4.3,144873,Varies with device,10000000,Free,0,Everyone,Productivity
+Ringdroid,VIDEO_PLAYERS,4.4,326232,Varies with device,50000000,Free,0,Everyone,Video Players & Editors
+Twilight: Blue light filter,HEALTH_AND_FITNESS,4.6,318134,Varies with device,5000000,Free,0,Everyone,Health & Fitness
+AT&T THANKS®,FAMILY,3.4,2445,34M,500000,Free,0,Everyone,Entertainment
+Galaxy at War Online,FAMILY,3.9,65119,46M,1000000,Free,0,Everyone 10+,Strategy
+Kingdoms at War: Hardcore PVP,FAMILY,4.3,34898,92M,1000000,Free,0,Teen,Strategy
+Five Nights at Freddy's 4 Demo,GAME,4.4,889425,45M,10000000,Free,0,Teen,Action
+Five Nights at Freddy's 3 Demo,GAME,4.5,1041836,50M,10000000,Free,0,Teen,Action
+Fandom: Five Nights at Freddys,FAMILY,4.4,17945,9.5M,1000000,Free,0,Mature 17+,Entertainment
+MLB At Bat,SPORTS,4.2,82857,Varies with device,5000000,Free,0,Everyone,Sports
+Nights at Cube Pizzeria 3D – 2,GAME,4.0,47151,36M,5000000,Free,0,Everyone 10+,Action
+World at War: WW2 Strategy MMO,FAMILY,4.3,107765,78M,5000000,Free,0,Everyone 10+,Strategy
+HotelTonight: Book amazing deals at great hotels,TRAVEL_AND_LOCAL,4.4,57556,Varies with device,5000000,Free,0,Everyone,Travel & Local
+Five Tries At Love Dating Sim,FAMILY,4.2,37165,22M,1000000,Free,0,Teen,Simulation
+Rivals at War: 2084,FAMILY,4.0,174127,48M,5000000,Free,0,Teen,Simulation
+Multiple Videos at Same Time,VIDEO_PLAYERS,4.4,4706,1.5M,1000000,Free,0,Everyone,Video Players & Editors
+Five Nights at Freddy's 2,FAMILY,4.6,73919,40M,500000,Paid,$2.99,Teen,Strategy
+Coloring Book at Five Nights,FAMILY,4.0,532,6.5M,100000,Free,0,Everyone,Educational
+Rivals at War: Firefight,GAME,4.4,344819,51M,5000000,Free,0,Teen,Action
+Five nights at Minecraft,FAMILY,3.5,9335,12M,1000000,Free,0,Everyone,Entertainment
+Five Nights at Freddy's,GAME,4.6,100805,50M,1000000,Paid,$2.99,Teen,Action
+Nights at Cube Pizzeria 3D – 3,FAMILY,4.0,15875,40M,1000000,Free,0,Teen,Simulation
+7 Nights at Pixel Pizzeria - 2,GAME,4.0,23168,54M,1000000,Free,0,Teen,Adventure
+Nights at Slender Pizzeria 3D,GAME,4.1,2628,45M,100000,Free,0,Teen,Adventure
+DIRECTV,FAMILY,4.1,235486,63M,10000000,Free,0,Teen,Entertainment
+One Night at Golden Freddy's,GAME,3.3,2717,4.0M,100000,Free,0,Teen,Action
+DIRECTV for Tablets,FAMILY,3.9,24123,69M,1000000,Free,0,Teen,Entertainment
+Nights at Cube Pizzeria 3D – 4,GAME,4.1,7728,39M,500000,Free,0,Teen,Adventure
+Five Nights at Neighbor House,GAME,4.2,2180,55M,100000,Free,0,Everyone 10+,Action
+Asylum Night Shift - Five Nights Survival,GAME,4.0,59223,46M,5000000,Free,0,Teen,Action
+Five Nights at Freddy's: SL,GAME,4.5,16162,99M,100000,Paid,$2.99,Teen,Action
+Two Nights at jumpscare,GAME,3.8,596,91M,100000,Free,0,Teen,Adventure
+Five Nights at Pizzeria,GAME,3.5,1976,21M,100000,Free,0,Teen,Action
+Block Battles: Heroes at War - Multiplayer PVP,GAME,4.3,6698,46M,500000,Free,0,Everyone 10+,Action
+Five Nights at Freddy's 4,GAME,4.6,21266,45M,100000,Paid,$2.99,Teen,Action
+Five Nights at Flappy's,GAME,4.7,4041,24M,10000,Free,0,Everyone,Arcade
+5 Nights at Cube Pizzeria City,GAME,3.8,2691,52M,100000,Free,0,Teen,Adventure
+Five Nights at Freddy's 3,GAME,4.7,27856,50M,100000,Paid,$2.99,Teen,Action
+Undertale AU Amino,SOCIAL,4.8,5369,63M,50000,Free,0,Teen,Social
+au,FAMILY,3.2,9126,5.8M,1000000,Free,0,Everyone,Strategy
+Audiobooks from Audible,BOOKS_AND_REFERENCE,4.5,568922,Varies with device,100000000,Free,0,Teen,Books & Reference
+Au Mobile: Audition Chính Hiệu,GAME,3.9,85278,23M,1000000,Free,0,Mature 17+,Music
+AU Mobile Indonesia,GAME,3.6,16521,23M,1000000,Free,0,Everyone,Music
+Au Bon Pain,FOOD_AND_DRINK,3.7,70,26M,10000,Free,0,Everyone,Food & Drink
+Au Pair Legend,LIFESTYLE,4.4,28,8.8M,1000,Free,0,Everyone,Lifestyle
+Super Dancer,GAME,4.1,91667,27M,1000000,Free,0,Everyone,Arcade
+AU Results - AU COE Corner,FAMILY,4.0,664,2.1M,100000,Free,0,Everyone,Education
+"view.com.au - Buy, Rent or Research Real Estate",LIFESTYLE,3.1,212,12M,50000,Free,0,Everyone,Lifestyle
+Au Weather Free,WEATHER,4.0,1185,5.0M,100000,Free,0,Everyone,Weather
+BringGo AU & NZ,MAPS_AND_NAVIGATION,2.8,440,23M,10000,Paid,$0.99,Everyone,Maps & Navigation
+AU Spark,FAMILY,3.7,681,8.2M,10000,Free,0,Everyone,Education
+Rugby AU,SPORTS,2.7,17,14M,1000,Free,0,Everyone,Sports
+Learners Test Free: AU Driver Knowledge Test (DKT),FAMILY,3.9,623,8.5M,100000,Free,0,Everyone,Education
+"realestate.com.au - Buy, Rent & Sell Property",HOUSE_AND_HOME,3.8,14657,Varies with device,1000000,Free,0,Everyone,House & Home
+Au-allstar for KR,GAME,3.6,2433,47M,100000,Free,0,Everyone,Music
+STUCOR - AU,FAMILY,4.5,1827,12M,100000,Free,0,Everyone,Education
+loans.com.au Smart Money,FINANCE,3.5,30,17M,1000,Free,0,Everyone,Finance
+AU Students Zone (Result 2016),FAMILY,4.0,97,3.9M,10000,Free,0,Everyone,Education
+Top #5 Bσσkie in AU,SPORTS,4.2,0,10.0M,100,Free,0,Everyone,Sports
+AU Results 2017 Auzone,FAMILY,3.8,762,4.1M,100000,Free,0,Everyone,Education
+Au Pair,SOCIAL,3.6,58,15M,10000,Free,0,Everyone,Social
+AU Call Blocker - Block Unwanted Calls Texts 2018,COMMUNICATION,4.2,16,3.3M,1000,Free,0,Everyone,Communication
+realcommercial.com.au,BUSINESS,4.4,128,6.7M,50000,Free,0,Everyone,Business
+Powershop AU,TOOLS,4.0,498,11M,10000,Free,0,Everyone,Tools
+Australia Newspapers - AU News Apps,NEWS_AND_MAGAZINES,4.7,48,4.1M,1000,Free,0,Everyone,News & Magazines
+news.com.au,NEWS_AND_MAGAZINES,4.1,1,3.7M,100,Free,0,Everyone,News & Magazines
+Media Sosial TNI AU,SOCIAL,4.3,88,4.3M,1000,Free,0,Everyone,Social
+Dance On Mobile,FAMILY,4.1,23609,31M,1000000,Free,0,Teen,Casual
+Super Dancer VN,GAME,4.0,24312,25M,500000,Free,0,Everyone,Music
+Alerte au gogol,FAMILY,4.2,14,2.0M,1000,Free,0,Everyone,Entertainment
+Neuvaine au Saint-Esprit,LIFESTYLE,4.7,57,5.8M,10000,Free,0,Everyone,Lifestyle
+Neuvaines et prières au Coeur Sacré de Jésus,LIFESTYLE,4.1,17,3.7M,5000,Free,0,Everyone,Lifestyle
+SMS Au revoir,FAMILY,4.2,17,1.7M,5000,Free,0,Everyone,Entertainment
+allhomes.com.au,HOUSE_AND_HOME,3.8,874,12M,100000,Free,0,Everyone,House & Home
+Jobs in Canada - Emplois au Canada,BUSINESS,5.0,2,14M,1000,Free,0,Teen,Business
+Predator Calls for Hunting AU,SPORTS,4.4,27,78M,10000,Free,0,Everyone,Sports
+Romance et Mystères au Lycée,FAMILY,4.2,350,6.4M,10000,Free,0,Teen,Entertainment
+Au Rubis les bijoutiers,LIFESTYLE,4.1,0,10M,100,Free,0,Everyone,Lifestyle
+Love Dance,GAME,4.0,29462,44M,1000000,Free,0,Teen,Music
+mon guide au bank populaire -infos et instructions,FINANCE,4.1,4,1.5M,1000,Free,0,Teen,Finance
+Avatar Musik,GAME,3.8,159063,85M,1000000,Free,0,Everyone,Music
+Job'Of - Emploi au Cameroun,BUSINESS,4.1,294,9.8M,10000,Free,0,Everyone,Business
+Mali 7 - Actualités au Mali,NEWS_AND_MAGAZINES,4.3,697,5.7M,50000,Free,0,Everyone,News & Magazines
+Gâteau au yaourt,FOOD_AND_DRINK,4.2,38,3.7M,10000,Free,0,Everyone,Food & Drink
+AVG AntiVirus 2018 for Android Security,TOOLS,4.5,6207063,Varies with device,100000000,Free,0,Everyone,Tools
+AV Tools,TOOLS,4.4,631,Varies with device,100000,Free,0,Everyone,Tools
+Total AV,PRODUCTIVITY,3.4,617,46M,100000,Free,0,Everyone,Productivity
+日本AV历史,BOOKS_AND_REFERENCE,4.1,215,30M,10000,Free,0,Teen,Books & Reference
+AV Buddy Free,FAMILY,4.1,25,47M,5000,Free,0,Everyone,Education
+AV HD Video Player,FAMILY,3.8,6,23M,1000,Free,0,Everyone,Entertainment
+AV Tools Pro,TOOLS,4.3,35,Varies with device,1000,Paid,$2.49,Everyone,Tools
+Avakin Life - 3D virtual world,FAMILY,4.4,1275373,91M,10000000,Free,0,Teen,Role Playing
+AV-IPTV,VIDEO_PLAYERS,4.4,43,44M,1000,Free,0,Everyone,Video Players & Editors
+Video Player All Format,VIDEO_PLAYERS,4.8,258277,Varies with device,10000000,Free,0,Everyone,Video Players & Editors
+"HD Video Player (wmv,avi,mp4,flv,av,mpg,mkv)2017",VIDEO_PLAYERS,3.3,171,4.8M,10000,Free,0,Everyone,Video Players & Editors
+Baby Monitor AV,COMMUNICATION,3.3,1434,9.5M,100000,Free,0,Everyone,Communication
+HD Video Player - Video & MP3 Player | AV Player |,VIDEO_PLAYERS,4.4,22,19M,5000,Free,0,Everyone,Video Players & Editors
+Remote for Onkyo AV Receivers & Smart TV/Blu-Ray,TOOLS,3.7,701,7.3M,100000,Free,0,Everyone,Tools
+LG AV REMOTE,TOOLS,3.4,2420,1.8M,1000000,Free,0,Everyone,Tools
+App Seguridad AV Villas,FINANCE,2.3,251,5.7M,50000,Free,0,Everyone,Finance
+Gogo Vision (Biz Av),FAMILY,3.3,11,7.3M,1000,Free,0,Teen,Entertainment
+Ai-Ball AV Recorder,PHOTOGRAPHY,2.7,90,4.0M,5000,Paid,$2.99,Everyone,Photography
+AV Phone,COMMUNICATION,4.2,4,3.7M,1000,Free,0,Everyone,Communication
+Norton Security and Antivirus,TOOLS,4.6,1170641,26M,10000000,Free,0,Everyone,Tools
+AV Pro Voice Changer,FAMILY,3.5,174,5.6M,50000,Free,0,Everyone,Entertainment
+Remote For Pioneer AV Receivers and Blu-Ray,TOOLS,3.4,150,7.3M,50000,Free,0,Everyone,Tools
+AV Phonetics,FAMILY,4.3,259,49M,10000,Free,0,Everyone,Education
+AV MAX,LIFESTYLE,4.1,9,8.7M,1000,Free,0,Everyone,Lifestyle
+Kaspersky Mobile Antivirus: AppLock & Web Security,TOOLS,4.7,2598579,49M,50000000,Free,0,Everyone,Tools
+"Mobile Security: Antivirus, Web Scan & App Lock",PRODUCTIVITY,4.4,574719,20M,10000000,Free,0,Everyone,Productivity
+MyAV Remote for Denon & Marantz AV Receivers,LIFESTYLE,3.8,250,7.3M,50000,Free,0,Everyone,Lifestyle
+EML UPnP-AV Control Point,VIDEO_PLAYERS,3.0,78,322k,10000,Free,0,Everyone,Video Players & Editors
+Kinot & Eichah for Tisha B'Av,BOOKS_AND_REFERENCE,4.4,98,6.3M,10000,Free,0,Everyone,Books & Reference
+Samsung TV AV Guide 2016,TOOLS,4.2,27,3.4M,5000,Free,0,Everyone,Tools
+Professional AV Solution & Products information,PRODUCTIVITY,4.5,24,22M,1000,Free,0,Everyone,Productivity
+AV High School District,FAMILY,3.5,91,25M,10000,Free,0,Everyone,Education
+Bitdefender Antivirus Free,TOOLS,4.5,78629,6.3M,1000000,Free,0,Everyone,Tools
+DEER HUNTER 2018,GAME,4.3,955614,82M,10000000,Free,0,Teen,Action
+Kinot Tisha'a Be'av - Ashkenaz,LIFESTYLE,4.5,82,8.7M,5000,Free,0,Everyone,Lifestyle
+AV Anthony's,FOOD_AND_DRINK,4.2,0,10M,50,Free,0,Everyone,Food & Drink
+"Avast Cleanup & Boost, Phone Cleaner, Optimizer",TOOLS,4.5,648380,24M,10000000,Free,0,Everyone,Tools
+AW - free video calls and chat,COMMUNICATION,4.0,7317,Varies with device,1000000,Free,0,Teen,Communication
+Aw Restaurant,FAMILY,4.8,4,43M,100,Free,0,Everyone,Casual
+Nougat Android 7 Launcher : AW,PERSONALIZATION,4.3,0,Varies with device,100000,Free,0,Everyone,Personalization
+AW Screen Recorder No Root,VIDEO_PLAYERS,4.3,1659,3.7M,100000,Free,0,Everyone,Video Players & Editors
+A&W Restaurants,FOOD_AND_DRINK,1.7,14,13M,1000,Free,0,Everyone,Food & Drink
+Add Watermark Free,PHOTOGRAPHY,4.3,18325,Varies with device,1000000,Free,0,Everyone,Photography
+AW Tozer Devotionals - Daily,BOOKS_AND_REFERENCE,4.2,8,3.9M,5000,Free,0,Everyone,Books & Reference
+AW Toolbox,BUSINESS,4.1,3,13M,100,Paid,$19.90,Everyone,Business
+Analog Clock AW Plus-7,TOOLS,4.2,725,3.0M,100000,Free,0,Everyone,Tools
+Analog Clock AW-7,TOOLS,4.3,2158,3.0M,100000,Free,0,Everyone,Tools
+MediBeat for AW - Android (1),HEALTH_AND_FITNESS,4.3,2,Varies with device,500,Free,0,Everyone,Health & Fitness
+Armored Warfare: Assault,GAME,4.0,7718,46M,100000,Free,0,Everyone,Action
+Watch AW-7,TOOLS,4.2,249,3.0M,50000,Free,0,Everyone,Tools
+AW TeamUp,NEWS_AND_MAGAZINES,4.6,9,17M,500,Free,0,Everyone,News & Magazines
+Auction Wars : Storage King,GAME,4.1,29062,63M,1000000,Free,0,Everyone,Casino
+AW Training,FAMILY,4.6,11,17M,1000,Free,0,Everyone,Education
+Digital Clock AW-7,TOOLS,4.1,484,2.9M,100000,Free,0,Everyone,Tools
+Analog and Digital Clock AW-7,TOOLS,4.0,202,2.9M,50000,Free,0,Everyone,Tools
+AW Connect,FAMILY,4.2,0,26M,10,Free,0,Everyone,Education
+Analog Clock AW-7 PRO,TOOLS,3.3,40,2.7M,1000,Paid,$1.99,Everyone,Tools
+AW Reader: news & apps [Dutch],NEWS_AND_MAGAZINES,4.1,1948,Varies with device,100000,Free,0,Everyone,News & Magazines
+AW,FAMILY,4.2,0,Varies with device,5,Free,0,Everyone 10+,Strategy
+AW CAMERA,TOOLS,4.0,2,24M,100,Free,0,Everyone,Tools
+AW Browser with Chrome Custom Tabs,TOOLS,4.0,9,4.7M,500,Free,0,Everyone,Tools
+Analog and Digital Clock AW-7PRO,TOOLS,4.0,4,2.7M,100,Paid,$1.99,Everyone,Tools
+AW Radio,FAMILY,4.2,1,1.7M,100,Free,0,Teen,Entertainment
+Roman Clock AW-7,TOOLS,4.4,52,3.0M,5000,Free,0,Everyone,Tools
+Square Analog Clock AW-7,TOOLS,4.2,294,3.0M,50000,Free,0,Everyone,Tools
+iSniper 3D Arctic Warfare,GAME,3.8,35572,Varies with device,1000000,Free,0,Teen,Arcade
+AirWatch Agent,BUSINESS,3.1,20973,31M,5000000,Free,0,Everyone,Business
+Handbreit by a.w.niemeyer,NEWS_AND_MAGAZINES,4.1,21,36M,1000,Free,0,Everyone,News & Magazines
+Tozer Devotional -Series 1,BOOKS_AND_REFERENCE,5.0,5,4.3M,1000,Free,0,Everyone,Books & Reference
+Modern Action Commando 3D,GAME,4.2,492,63M,100000,Free,0,Teen,Action
+HCP Anywhere,BUSINESS,4.7,114,8.6M,5000,Free,0,Everyone,Business
+Call of Duty®: Heroes,GAME,4.4,1604146,57M,10000000,Free,0,Teen,Action
+Ultimate Watch 2 watch face,PERSONALIZATION,4.6,285,Varies with device,10000,Paid,$0.99,Everyone,Personalization
+Amber Weather,WEATHER,4.4,260137,13M,10000000,Free,0,Everyone 10+,Weather
+Advanced Warfare Guns,FAMILY,2.9,2079,5.6M,100000,Free,0,Everyone,Entertainment
+AirWatch Inbox,BUSINESS,2.7,8346,Varies with device,1000000,Free,0,Everyone,Business
+News.aw,NEWS_AND_MAGAZINES,4.1,1,1.0M,10,Free,0,Everyone,News & Magazines
+Pujie Black Watch Face for Android Wear OS,PERSONALIZATION,4.6,7264,Varies with device,100000,Paid,$1.99,Everyone,Personalization
+Bits Watch Face,PRODUCTIVITY,4.0,6205,Varies with device,100000,Free,0,Everyone,Productivity
+Video Editor,VIDEO_PLAYERS,3.8,1156,23M,100000,Free,0,Everyone,Video Players & Editors
+The Pursuit of God,BOOKS_AND_REFERENCE,4.8,6,1.6M,1000,Free,0,Everyone,Books & Reference
+Food-Aw - Order Food Online in Aruba,FOOD_AND_DRINK,5.0,1,24M,100,Free,0,Everyone,Food & Drink
+F05WatchFace for Android Wear,PRODUCTIVITY,3.9,127,5.9M,1000,Paid,$0.99,Everyone,Productivity
+ByssWeather for Wear OS,WEATHER,4.2,19666,Varies with device,1000000,Free,0,Everyone,Weather
+AW - Le News di AndroidWorld,NEWS_AND_MAGAZINES,4.1,2808,Varies with device,100000,Free,0,Everyone,News & Magazines
+Anime Expo 2018,FAMILY,4.7,54,44M,10000,Free,0,Everyone,Entertainment
+Adventure Xpress,FAMILY,4.2,24775,30M,100000,Free,0,Everyone 10+,Puzzle
+AXE.IO - Brutal Survival Battleground,GAME,4.2,3845,76M,500000,Free,0,Everyone 10+,Arcade
+Dynamics AX,BUSINESS,3.7,244,976k,10000,Free,0,Everyone,Business
+AX Player -Nougat Video Player,VIDEO_PLAYERS,4.1,15765,10M,1000000,Free,0,Everyone,Video Players & Editors
+Armani Exchange Connected,LIFESTYLE,4.1,305,44M,10000,Free,0,Everyone,Lifestyle
+Axe Champ,GAME,3.8,141,19M,10000,Free,0,Everyone,Arcade
+AX Battery Saver,FINANCE,4.6,4546,3.0M,100000,Free,0,Everyone,Finance
+Axe Champ Hit,GAME,4.3,1,15M,100,Free,0,Everyone,Arcade
+Axe Champion,GAME,4.4,21,15M,5000,Free,0,Everyone,Arcade
+Vikings Stickman Axe Fighting,GAME,4.2,924,43M,100000,Free,0,Everyone,Arcade
+AX Video Player,VIDEO_PLAYERS,4.4,569,2.6M,50000,Free,0,Everyone,Video Players & Editors
+Katalogen.ax,COMMUNICATION,4.2,1,172k,100,Free,0,Everyone,Communication
+Axe,FAMILY,4.2,18,24M,1000,Free,0,Everyone,Simulation
+Axetatic - Axe Throwing Game,GAME,4.6,29,31M,1000,Free,0,Everyone 10+,Arcade
+Axe Champs! Wars,GAME,5.0,8,25M,50,Free,0,Everyone,Arcade
+Tips Microsoft Dynamics Ax,PRODUCTIVITY,4.2,1,2.3M,500,Free,0,Everyone,Productivity
+Axe Knight,GAME,4.5,52,33M,5000,Free,0,Everyone,Action
+AX Timesheets App for Dynamics,BUSINESS,4.1,0,9.0M,10,Free,0,Everyone,Business
+Axxess AX-DSP,TOOLS,3.5,17,7.4M,5000,Free,0,Everyone,Tools
+AX Window,TOOLS,4.0,0,19M,5,Free,0,Everyone,Tools
+Axxess Updater,TOOLS,3.9,56,2.3M,10000,Free,0,Everyone,Tools
+The Vikings,GAME,4.4,15806,42M,1000000,Free,0,Teen,Arcade
+Axe Spinner,FAMILY,3.0,2,Varies with device,10,Free,0,Everyone,Casual
+INTERACTIVE CALCULUS PRO,FAMILY,4.2,0,3.3M,10,Paid,$0.99,Everyone,Education
+Knife&Axe Throwing,GAME,3.1,440,9.1M,50000,Free,0,Everyone,Arcade
+Stickman and Axe,GAME,4.4,69,2.8M,50000,Free,0,Teen,Action
+Axe Throw: Flip Champ Axes Champion Throwing Games,GAME,4.3,1,13M,50,Free,0,Everyone,Arcade
+Q7 SmartWatch,HEALTH_AND_FITNESS,3.0,94,30M,10000,Free,0,Everyone,Health & Fitness
+Workflow Approvals App AX 2012,BUSINESS,4.1,2,3.0M,100,Free,0,Everyone,Business
+Tips & Tricks Dynamics AX 365,PRODUCTIVITY,4.2,1,2.2M,100,Free,0,Everyone,Productivity
+Axe Man,GAME,3.7,53,14M,1000,Free,0,Everyone,Adventure
+AX Watch for WatchMaker,PERSONALIZATION,4.3,2,238k,1,Paid,$0.99,Everyone,Personalization
+Throw Knife,FAMILY,3.7,291,37M,100000,Free,0,Everyone,Simulation
+Dead Zombie Evil Killer:Axe,GAME,3.9,71,52M,10000,Free,0,Teen,Action
+INTERACTIVE CALCULUS FOR MATHS AND PHYSICS,FAMILY,4.8,53,4.4M,1000,Free,0,Everyone,Education
+AX-PIC Pedidos,TOOLS,4.0,1,Varies with device,1000,Free,0,Everyone,Tools
+AX!OM,LIFESTYLE,4.1,5,28M,50,Free,0,Everyone,Lifestyle
+Zlax.io Zombs Luv Ax,GAME,4.6,6344,32M,500000,Free,0,Everyone,Action
+AX Selfie,LIFESTYLE,4.6,10,3.4M,500,Free,0,Everyone,Lifestyle
+Ax 3 Domaines,SPORTS,4.5,12,23M,1000,Free,0,Everyone,Sports
+Clash of Axe: Flippy Lumberjack Action X,GAME,4.3,6,61M,1000,Free,0,Everyone,Action
+Flippy Axe : Flip The Knife & Axe Simulator,GAME,5.0,7,15M,100,Free,0,Everyone,Arcade
+Axe Clicker,FAMILY,4.3,10446,64M,500000,Free,0,Everyone,Casual
+Cyborg AX-001,GAME,4.3,0,Varies with device,50,Free,0,Everyone 10+,Action
+Axe Wallpaper,PERSONALIZATION,4.7,9,12M,100,Free,0,Teen,Personalization
+Woodman Deluxe,GAME,4.0,82,4.4M,5000,Free,0,Everyone,Action
+Ay,VIDEO_PLAYERS,3.8,11,3.6M,5000,Free,0,Teen,Video Players & Editors
+A-Y Collection,SHOPPING,5.0,2,2.9M,100,Free,0,Teen,Shopping
+AY Sing,BOOKS_AND_REFERENCE,4.8,111,10M,5000,Free,0,Everyone,Books & Reference
+Ay Up,FAMILY,4.5,11,7.2M,100,Free,0,Everyone,Entertainment
+"AY Recorder - Screen Recorder, Live, Video Editor",TOOLS,4.3,12,3.8M,500,Free,0,Everyone,Tools
+¡Ay Caramba!,FAMILY,4.2,0,549k,1,Paid,$1.99,Everyone,Education
+Ay Sabz Gunbad Waly,VIDEO_PLAYERS,4.1,4,3.9M,1000,Free,0,Everyone,Video Players & Editors
+Ay Yıldız - Xperia Live Theme,PERSONALIZATION,4.3,0,2.9M,10,Paid,$0.99,Everyone,Personalization
+25 Mins Ako ay may lobo Etc Pinoy Kid Song Offline,FAMILY,4.2,0,42M,10,Free,0,Mature 17+,Entertainment
+camera zoom moon,PHOTOGRAPHY,3.7,1213,1.1M,500000,Free,0,Everyone,Photography
+Ako ay may lobo Pinoy Kid Song Offline,FAMILY,4.2,0,9.7M,1,Free,0,Mature 17+,Entertainment
+Ay Yıldız Analog Saat,PERSONALIZATION,4.3,37,1.7M,1000,Free,0,Everyone,Personalization
+Ay Telekom Oim,LIFESTYLE,4.1,6,13M,100,Free,0,Everyone,Lifestyle
+Holy Quran Mehmet Emin Ay,LIFESTYLE,4.1,649,55M,10000,Free,0,Everyone,Lifestyle
+Ay Yıldız Duvar Kağıtları,PERSONALIZATION,4.3,3,6.5M,100,Free,0,Everyone,Personalization
+Ay Hasnain k Nana Milad Naat,BOOKS_AND_REFERENCE,4.3,72,1.9M,10000,Free,0,Everyone,Books & Reference
+Mehmet Emin Ay İlahileri,FAMILY,4.2,0,5.1M,10,Free,0,Everyone,Entertainment
+¡Ay Metro!,GAME,3.8,489,36M,10000,Free,0,Everyone 10+,Arcade
+AY Oakmont,HEALTH_AND_FITNESS,4.3,0,11M,10,Free,0,Everyone,Health & Fitness
+YAKALA AY,GAME,4.3,0,14M,1,Paid,$0.99,Everyone,Arcade
+Lunar Calendar,LIFESTYLE,4.5,484,Varies with device,1000,Paid,$4.99,Mature 17+,Lifestyle
+Pinoy Kid Song Ako ay may Lobo,FAMILY,4.6,23,17M,10000,Free,0,Everyone,Education
+Lunar Calendar Lite,LIFESTYLE,4.1,2954,Varies with device,100000,Free,0,Mature 17+,Lifestyle
+Ay Mohabbat Teri Khatir Novel,BOOKS_AND_REFERENCE,4.2,27,4.3M,10000,Free,0,Everyone,Books & Reference
+AY Recruitment,BUSINESS,4.1,1,4.0M,10,Free,0,Everyone,Business
+Quran Khmer Offline AY,FAMILY,5.0,41,4.0M,1000,Free,0,Everyone,Education
+Ay Yıldız Keyboard,TOOLS,4.0,26,3.0M,1000,Free,0,Everyone,Tools
+AY EMLAK,BUSINESS,4.1,8,1.2M,10,Free,0,Teen,Business
+Ay Vamos - PJ. Balvin - Piano,GAME,4.3,0,29M,5,Free,0,Everyone,Arcade
+Google Play Games,FAMILY,4.3,7168735,Varies with device,1000000000,Free,0,Teen,Entertainment
+Ay Peruk,BUSINESS,4.1,0,3.4M,1,Free,0,Everyone,Business
+Sun & Moon AR Locator,WEATHER,3.3,115,5.1M,10000,Free,0,Everyone,Weather
+Display Phone Screen On TV,TOOLS,3.6,9895,2.7M,1000000,Free,0,Everyone,Tools
+San Andreas Crime Stories,GAME,4.0,162530,97M,10000000,Free,0,Mature 17+,Racing
+Masha and The Bear,FAMILY,4.0,39779,19M,5000000,Free,0,Everyone,Video Players & Editors;Music & Video
+Miami crime simulator,GAME,4.0,254518,100M,10000000,Free,0,Mature 17+,Action
+ai.type Free Emoji Keyboard,PERSONALIZATION,4.3,647721,Varies with device,10000000,Free,0,Everyone,Personalization
+Strange Hero: Future Battle,GAME,4.2,88901,73M,10000000,Free,0,Teen,Action
+Gangster Town: Vice District,FAMILY,4.3,65146,100M,10000000,Free,0,Mature 17+,Simulation
+iMediaShare – Photos & Music,VIDEO_PLAYERS,4.2,104551,18M,10000000,Free,0,Everyone,Video Players & Editors
+Earth & Moon in HD Gyro 3D Parallax Live Wallpaper,PERSONALIZATION,4.5,66321,18M,5000000,Free,0,Everyone,Personalization
+Mad Day - Truck Distance Game,GAME,4.3,29270,44M,5000000,Free,0,Everyone,Action
+AZ Screen Recorder - No Root,VIDEO_PLAYERS,4.6,751911,Varies with device,10000000,Free,0,Everyone,Video Players & Editors
+AZ Browser. Private & Download,COMMUNICATION,4.4,1520,5.2M,100000,Free,0,Everyone,Communication
+AZ Lottery Players Club,FAMILY,4.2,97,8.9M,10000,Free,0,Everyone,Entertainment
+AZ Plugin 2 (newest),LIBRARIES_AND_DEMO,4.2,11087,34M,1000000,Free,0,Everyone,Libraries & Demo
+Kids A-Z,FAMILY,4.2,26426,30M,1000000,Free,0,Everyone,Education;Education
+AZ Camera - Manual Pro Cam,PHOTOGRAPHY,3.4,2332,1.6M,100000,Free,0,Everyone,Photography
+A-Z App Store,PRODUCTIVITY,3.2,2728,4.4M,500000,Free,0,Everyone,Productivity
+AZ Screen Recorder pro,TOOLS,4.0,60,3.7M,5000,Free,0,Everyone,Tools
+Permit Test AZ Arizona MVD DOT,FAMILY,4.6,227,11M,10000,Free,0,Everyone,Education
+AZ PLAYER HD,TOOLS,3.2,24,4.7M,10000,Free,0,Everyone,Tools
+Long Realty AZ Home Search,LIFESTYLE,4.4,132,33M,10000,Free,0,Everyone,Lifestyle
+NB|AZ Mobile Banking,FINANCE,4.0,463,13M,10000,Free,0,Everyone,Finance
+Movie Downloader Torrent : Az Torrent,VIDEO_PLAYERS,4.7,70,14M,1000,Free,0,Everyone,Video Players & Editors
+A-Z Screen Recorder -,VIDEO_PLAYERS,4.1,17,3.7M,500,Free,0,Everyone,Video Players & Editors
+AZ Immune Related AEManagement,MEDICAL,3.7,3,7.3M,500,Free,0,Everyone,Medical
+Alphabet A-Z,FAMILY,3.9,306,Varies with device,100000,Free,0,Everyone,Casual
+AZ Rockets,GAME,4.2,162,37M,10000,Free,0,Everyone,Arcade
+NB|AZ Business Mobile Banking,FINANCE,4.1,44,13M,1000,Free,0,Everyone,Finance
+Az Content,FAMILY,3.5,24,13M,10000,Free,0,Everyone,Entertainment
+Catalyst AZ,FAMILY,4.8,12,8.4M,500,Free,0,Teen,Education
+Casino AZ/Talking Stick Resort,TRAVEL_AND_LOCAL,4.3,201,45M,10000,Free,0,Everyone,Travel & Local
+Graffiti Letters (A-Z),LIFESTYLE,3.9,386,7.9M,50000,Free,0,Everyone,Lifestyle
+GPS.AZ,MAPS_AND_NAVIGATION,4.1,30,4.2M,1000,Free,0,Everyone,Maps & Navigation
+First Credit Union (AZ) Mobile,FINANCE,3.5,100,11M,10000,Free,0,Everyone,Finance
+Arizona Mobile,FAMILY,4.3,285,6.2M,10000,Free,0,Everyone,Education
+AZ Mobile Gizmo,BUSINESS,4.4,16,3.7M,1000,Free,0,Everyone,Business
+Az Video Status,FAMILY,4.8,13,6.0M,100,Free,0,Everyone,Entertainment
+"Arizona Statutes, ARS (AZ Law)",BOOKS_AND_REFERENCE,3.9,9,8.8M,1000,Free,0,Everyone,Books & Reference
+Explore Sedona & Northern AZ,TRAVEL_AND_LOCAL,3.8,43,22M,10000,Free,0,Everyone,Travel & Local
+Arizona DMV Permit Test - AZ,FAMILY,4.2,109,30M,10000,Free,0,Everyone,Education
+Oxford A-Z of English Usage,BOOKS_AND_REFERENCE,4.0,5300,11M,1000000,Free,0,Everyone,Books & Reference
+Cures A-Z,HEALTH_AND_FITNESS,4.0,265,4.1M,100000,Free,0,Everyone,Health & Fitness
+AZ Practice Test & Questions,FAMILY,4.4,13,3.4M,1000,Free,0,Everyone,Education
+Arizona Trail,TRAVEL_AND_LOCAL,4.7,65,13M,5000,Free,0,Everyone,Travel & Local
+Ultrasound A-Z,FAMILY,4.5,112,39M,10000,Free,0,Everyone,Education
+A-Z Punjabi Songs & Music Videos 2018,FAMILY,4.3,367,5.1M,100000,Free,0,Everyone,Entertainment
+Manga AZ - Manga Comic Reader,COMICS,3.3,126,4.7M,5000,Free,0,Teen,Comics
+Barista Coffee Dictionary A-Z,LIFESTYLE,4.3,127,5.5M,10000,Free,0,Everyone,Lifestyle
+Phoenix and Arizona Cameras,TRAVEL_AND_LOCAL,4.1,134,5.3M,10000,Free,0,Everyone,Travel & Local
+AZ REMOTE CONTROL,TOOLS,2.1,149,2.8M,50000,Free,0,Everyone,Tools
+Greater London A-Z 2016,TRAVEL_AND_LOCAL,3.7,40,9.0M,1000,Paid,$8.49,Everyone,Travel & Local
+British Airways,TRAVEL_AND_LOCAL,4.2,25726,51M,1000000,Free,0,Everyone,Travel & Local
+Ba Financial Calculator plus,FINANCE,4.4,31,206k,1000,Paid,$3.99,Everyone,Finance
+Financial Calculator BA Chien.,FINANCE,4.2,23,954k,500,Paid,$3.99,Everyone,Finance
+BA4You,BUSINESS,2.1,87,26M,5000,Free,0,Everyone,Business
+BA Pro Financial Calculator,FINANCE,2.4,36,9.4M,1000,Paid,$1.99,Everyone,Finance
+BA Calculator,PRODUCTIVITY,4.1,22,2.4M,5000,Free,0,Everyone,Productivity
+ba,FAMILY,3.1,1734,5.8M,500000,Free,0,Everyone,Strategy
+Ra Ga Ba,GAME,5.0,2,20M,1,Paid,$1.49,Everyone,Arcade
+Experience BA,TRAVEL_AND_LOCAL,4.1,6,17M,100,Free,0,Everyone,Travel & Local
+Ba Cristi,GAME,3.5,196,35M,10000,Free,0,Everyone,Adventure
+Ba ba black sheep offline Video,PARENTING,4.2,20,17M,10000,Free,0,Everyone,Parenting
+BA SALES,COMMUNICATION,4.2,0,2.9M,1,Free,0,Everyone,Communication
+Goody.ba,FAMILY,4.7,303,42M,10000,Free,0,Everyone,Entertainment
+BA Status,TRAVEL_AND_LOCAL,4.1,0,5.1M,100,Free,0,Everyone,Travel & Local
+Alif Ba Ta Bullseye,FAMILY,4.2,1,16M,5,Paid,$1.99,Everyone,Educational
+BA Accesible,HEALTH_AND_FITNESS,4.3,31,4.7M,1000,Free,0,Everyone,Health & Fitness
+Learn alif ba ta,FAMILY,4.8,23,35M,10000,Free,0,Everyone,Educational;Education
+Learn Quran with Elif Ba,FAMILY,4.2,3,12M,100,Paid,$1.49,Everyone,Education
+Arabic Alif Ba Ta For Kids,FAMILY,4.5,226,26M,100000,Free,0,Everyone,Education;Education
+Arabic Alphabet Alif Ba Ta Wooden Blocks,FAMILY,4.6,66,17M,10000,Free,0,Everyone,Educational;Education
+Let's Learn Alif Ba Ta,FAMILY,4.6,32,60M,10000,Free,0,Everyone,Education
+Sufara.ba,FAMILY,4.9,285,25M,10000,Free,0,Everyone,Education
+Elif Ba - Learn The Holy Quran,FAMILY,4.8,1491,38M,50000,Free,0,Everyone,Education
+Instant Ba-dum-tss,FAMILY,4.0,13,2.0M,1000,Free,0,Everyone,Entertainment
+Ba Zi Fortune,LIFESTYLE,3.9,592,2.5M,100000,Free,0,Everyone,Lifestyle
+BA VPN - Free Unlimited VPN,FAMILY,4.1,181,9.2M,10000,Free,0,Everyone,Entertainment
+Ba dum tss - Rimshot widget,COMICS,4.1,690,444k,50000,Free,0,Everyone,Comics
+Alif Ba Ta Song - Arabic Kids,FAMILY,4.5,227,15M,50000,Free,0,Everyone,Educational;Education
+Fitness Dance for Zum.ba Workout Exercise,HEALTH_AND_FITNESS,4.2,287,12M,50000,Free,0,Everyone,Health & Fitness
+Cafe.ba,NEWS_AND_MAGAZINES,4.0,677,4.4M,10000,Free,0,Everyone,News & Magazines
+058.ba,NEWS_AND_MAGAZINES,4.4,27,14M,100,Free,0,Everyone,News & Magazines
+Loreal - BA Makeup,TOOLS,1.9,8,6.7M,1000,Free,0,Everyone,Tools
+PROFESSOR SEE-BA LINGUAGENS E SUAS TECNOLOGIAS,PRODUCTIVITY,4.2,0,3.7M,10,Paid,$2.99,Everyone,Productivity
+Poteau BA,FAMILY,4.2,3,4.0M,500,Free,0,Everyone,Education
+Elif Ba Oyunu,TOOLS,3.7,26,2.2M,5000,Free,0,Everyone,Tools
+Ain Arabic Kids Alif Ba ta,FAMILY,4.2,0,33M,0,Paid,$2.99,Everyone,Education
+Bedouin Rivals,FAMILY,4.2,79826,Varies with device,1000000,Free,0,Everyone 10+,Strategy
+Klix.ba,NEWS_AND_MAGAZINES,4.0,3647,5.7M,100000,Free,0,Everyone,News & Magazines
+PBA® Bowling Challenge,SPORTS,4.3,242096,87M,10000000,Free,0,Everyone,Sports
+Avios for Android,TRAVEL_AND_LOCAL,2.5,862,30M,100000,Free,0,Everyone,Travel & Local
+Banana Kong,GAME,4.4,3452530,68M,100000000,Free,0,Everyone,Action
+BA 3 Banjarmasin,SOCIAL,4.3,2,5.9M,10,Free,0,Teen,Social
+American Airlines,TRAVEL_AND_LOCAL,3.7,16973,Varies with device,5000000,Free,0,Everyone,Travel & Local
+Elifba Quran Learning Game,FAMILY,4.7,1424,19M,100000,Free,0,Everyone,Educational
+Space Shooter : Galaxy Attack,GAME,4.6,169661,40M,10000000,Free,0,Everyone,Arcade
+Hunt Buddy BC,SPORTS,4.4,172,49M,5000,Paid,$2.99,Everyone,Sports
+"Survival Mobile:10,000 BC",FAMILY,4.3,7441,52M,500000,Free,0,Everyone 10+,Strategy
+iHunter BC,SPORTS,4.4,55,63M,1000,Paid,$4.49,Everyone,Sports
+Anthem BC Anywhere,MEDICAL,2.6,496,24M,100000,Free,0,Everyone,Medical
+iFish BC,SPORTS,3.6,25,6.0M,1000,Paid,$3.99,Everyone,Sports
+BC Connect,FAMILY,3.8,11,17M,1000,Free,0,Everyone,Education
+Ice Crush 10.000 B.C.,FAMILY,4.4,31,4.2M,100,Paid,$0.99,Everyone,Casual
+BC Navigator,FAMILY,4.4,21,32M,1000,Free,0,Everyone,Education
+BC Lotto Check,FAMILY,3.0,10,717k,5000,Free,0,Everyone,Entertainment
+Transit: Real-Time Transit App,MAPS_AND_NAVIGATION,4.2,43252,Varies with device,5000000,Free,0,Everyone,Maps & Navigation
+BC Liquor Stores,LIFESTYLE,3.7,492,4.3M,50000,Free,0,Everyone,Lifestyle
+BC MVA Fines,BOOKS_AND_REFERENCE,5.0,5,7.2M,50,Paid,$1.75,Everyone,Books & Reference
+British Columbia Transit Info,MAPS_AND_NAVIGATION,4.1,0,5.0M,100,Free,0,Everyone 10+,Maps & Navigation
+BC Hospital Wait Times,MEDICAL,4.2,8,1.2M,500,Free,0,Everyone,Medical
+"Town of Princeton, BC",PRODUCTIVITY,4.8,4,31M,100,Free,0,Everyone,Productivity
+Explore British Columbia - BC Travel Guide,TRAVEL_AND_LOCAL,4.4,7,17M,500,Free,0,Everyone,Travel & Local
+Bridge Constructor Stunts FREE,FAMILY,4.1,36151,46M,1000000,Free,0,Everyone,Simulation
+BC's Pizza,LIFESTYLE,4.7,113,20M,1000,Free,0,Everyone,Lifestyle
+Baby Connect (activity log),PARENTING,4.7,8343,8.3M,50000,Paid,$4.99,Everyone,Parenting
+BC Wildfire,TOOLS,3.3,27,5.0M,5000,Free,0,Everyone,Tools
+BC Slots - The Lost Reels FREE,GAME,4.0,209,22M,10000,Free,0,Teen,Casino
+BC Mobile Intro - Americas,LIFESTYLE,4.1,0,3.1M,50,Free,0,Everyone,Lifestyle
+Car Driving Theory Test BC,FAMILY,4.2,0,2.2M,10,Paid,$1.49,Everyone,Education
+Truck Driving Test Class 3 BC,FAMILY,1.0,1,2.0M,50,Paid,$1.49,Everyone,Education
+BC Highways - Road Conditions,TRAVEL_AND_LOCAL,4.4,382,12M,10000,Free,0,Everyone,Travel & Local
+BC Camera,PHOTOGRAPHY,4.2,5,5.5M,500,Free,0,Everyone,Photography
+BC iptv player,VIDEO_PLAYERS,4.4,8,14M,1000,Free,0,Everyone,Video Players & Editors
+Business Calendar Pro,PRODUCTIVITY,4.6,27135,Varies with device,100000,Paid,$4.99,Everyone,Productivity
+"Victoria, BC | Tour City",TRAVEL_AND_LOCAL,4.3,20,15M,1000,Free,0,Everyone,Travel & Local
+BC Wildflowers,FAMILY,4.4,7,81M,1000,Free,0,Everyone,Education
+Bc Vod,VIDEO_PLAYERS,4.1,1,62M,100,Free,0,Everyone,Video Players & Editors
+BC Hockey,SPORTS,3.7,20,8.9M,1000,Free,0,Everyone,Sports
+Outdoor Movies BC,EVENTS,2.9,7,Varies with device,500,Free,0,Everyone,Events
+British Columbia Tourist Places (Guide),TRAVEL_AND_LOCAL,4.0,1,3.0M,100,Free,0,Everyone,Travel & Local
+PMHNP-BC Pocket Prep,MEDICAL,4.4,112,13M,1000,Free,0,Everyone,Medical
+British Columbia License,FAMILY,3.3,14,11M,1000,Free,0,Everyone,Education
+BC browser,BUSINESS,4.1,1,3.4M,100,Free,0,Everyone,Business
+PPCNP-BC Pocket Prep,MEDICAL,4.2,3,12M,50,Free,0,Everyone,Medical
+AP Calculus BC Practice Test,FAMILY,4.2,4,29M,500,Free,0,Everyone,Education
+BackCountry Navigator TOPO GPS PRO,MAPS_AND_NAVIGATION,4.5,6230,Varies with device,100000,Paid,$11.99,Everyone,Maps & Navigation
+BC Pizza,LIFESTYLE,2.3,3,2.6M,500,Free,0,Everyone,Lifestyle
+Railroad Radio Vancouver BC,FAMILY,5.0,4,1.7M,100,Free,0,Teen,Entertainment
+AP Calculus BC: Practice Tests and Flashcards,FAMILY,3.6,5,5.4M,1000,Free,0,Everyone,Education
+Aura Hair Group BC,BEAUTY,4.3,0,Varies with device,100,Free,0,Everyone,Beauty
+Bridge Constructor Playground FREE,FAMILY,3.9,137377,30M,5000000,Free,0,Everyone,Simulation
+"BDCast - Bangla Live TV,Radio",FAMILY,4.4,7461,31M,1000000,Free,0,Everyone,Entertainment
+bd's Mongolian Grill,LIFESTYLE,4.2,120,14M,10000,Free,0,Everyone,Lifestyle
+BD Briight: Your Diabetes Personal Assistant,MEDICAL,4.8,17,37M,5000,Free,0,Everyone,Medical
+Jagobd - Bangla TV(Official),FAMILY,4.3,39109,4.0M,1000000,Free,0,Everyone,Entertainment
+Business Dictionary,BUSINESS,4.2,5988,Varies with device,500000,Free,0,Everyone,Business
+BD Data Plan (3G & 4G),COMMUNICATION,4.4,10341,6.9M,500000,Free,0,Everyone,Communication
+বাংলা টিভি প্রো BD Bangla TV,FAMILY,4.3,193,14M,10000,Free,0,Everyone,Entertainment
+BD tools,TOOLS,4.0,21,210k,10000,Free,0,Everyone,Tools
+BD Provider App,HEALTH_AND_FITNESS,1.4,45,13M,5000,Free,0,Everyone,Health & Fitness
+"Izneo, Read Manga, Comics & BD",COMICS,3.3,1476,18M,500000,Free,0,Teen,Comics
+BD Radio TV Free List,FAMILY,4.3,539,13M,50000,Free,0,Everyone,Entertainment
+BD Simplist Through Their Eyes,FAMILY,4.2,1,38M,10,Free,0,Everyone,Simulation
+BD Online News,NEWS_AND_MAGAZINES,4.6,30,3.8M,1000,Free,0,Everyone,News & Magazines
+BD Bank Interest,FINANCE,4.7,289,3.2M,5000,Free,0,Everyone,Finance
+BD Earn Pro,FAMILY,4.2,540,3.2M,10000,Free,0,Everyone,Entertainment
+Comics Reader,COMICS,3.9,4496,609k,100000,Free,0,Everyone,Comics
+Upohar BD,BUSINESS,3.4,9,1.7M,1000,Free,0,Everyone,Business
+Electricity Bill Calculator BD,PRODUCTIVITY,4.3,247,4.0M,10000,Free,0,Everyone,Productivity
+BD Fishpedia,BOOKS_AND_REFERENCE,4.8,123,6.5M,1000,Free,0,Everyone,Books & Reference
+BD Attendance,PRODUCTIVITY,4.8,93,14M,1000,Free,0,Everyone,Productivity
+BD All Sim Offer,BOOKS_AND_REFERENCE,4.5,197,2.8M,10000,Free,0,Everyone,Books & Reference
+BD TYCOON,FAMILY,3.3,16,33M,500,Free,0,Everyone,Simulation
+BD Sports Box & TV,FAMILY,4.2,5,3.3M,500,Free,0,Everyone,Entertainment
+Tour BD (Bahir Dar Map),MAPS_AND_NAVIGATION,4.9,49,3.9M,100,Free,0,Everyone,Maps & Navigation
+BD Field Force,PRODUCTIVITY,4.2,41,15M,1000,Free,0,Everyone,Productivity
+BD CRICKET LIVE,SPORTS,4.6,1238,9.5M,100000,Free,0,Everyone,Sports
+BD All Results,FAMILY,4.1,205,7.3M,50000,Free,0,Everyone,Education
+BD Online Passport Application,FAMILY,4.6,12,2.4M,5000,Free,0,Everyone,Education
+BD Internet Packages (Updated),COMMUNICATION,4.0,474,3.0M,50000,Free,0,Everyone,Communication
+Live Radio BD,FAMILY,4.2,69,3.5M,10000,Free,0,Everyone,Entertainment
+iCard BD Plus,SOCIAL,5.0,2,2.4M,500,Free,0,Everyone,Social
+BD Dialer,COMMUNICATION,4.1,29,13M,10000,Free,0,Everyone,Communication
+"Youboox - Livres, BD et magazines",BOOKS_AND_REFERENCE,3.7,4071,Varies with device,500000,Free,0,Teen,Books & Reference
+BANGLA TV 3G/4G,SPORTS,4.1,142,5.3M,100000,Free,0,Everyone,Sports
+Earn Money BD,FINANCE,3.8,103,6.9M,5000,Free,0,Everyone,Finance
+BD Hospital's,FAMILY,4.7,12,2.3M,100,Free,0,Everyone,Education
+Rabbithole,FAMILY,3.5,3347,15M,100000,Free,0,Everyone,Entertainment
+Educationboard Results BD,FAMILY,4.0,983,7.2M,100000,Free,0,Everyone,Education
+BD Online Shop,BUSINESS,4.2,63,13M,5000,Free,0,Everyone,Business
+Remote for Samsung TV & BluRay Players (Read Desc),TOOLS,3.3,1988,7.3M,500000,Free,0,Everyone,Tools
+Vehicle Case Checker BD,TOOLS,3.7,29,3.3M,10000,Free,0,Everyone,Tools
+Remote for Sony TV & Sony Blu-Ray Players MyAV,TOOLS,3.4,3491,7.3M,1000000,Free,0,Everyone,Tools
+Remote for Panasonic TV+BD+AVR,TOOLS,3.7,533,7.3M,100000,Free,0,Everyone,Tools
+Exam Result BD,FAMILY,5.0,2,2.6M,500,Free,0,Everyone,Education
+BD Live Call,COMMUNICATION,4.4,7,308k,5000,Free,0,Everyone,Communication
+Helping BD,LIFESTYLE,5.0,15,4.5M,100,Free,0,Everyone,Lifestyle
+Best Browser BD social networking,COMMUNICATION,4.8,6,21M,10,Free,0,Everyone,Communication
+Traffic signs BD,COMMUNICATION,4.4,7,5.3M,500,Free,0,Everyone,Communication
+BD Internet Package Activator,NEWS_AND_MAGAZINES,4.9,13,2.3M,100,Free,0,Everyone,News & Magazines
+be Produbanco,FINANCE,4.0,967,22M,100000,Free,0,Everyone,Finance
+Millionaire : Who want to be?,GAME,4.4,4396,40M,100000,Free,0,Everyone,Trivia
+Photo Editor by BeFunky,PHOTOGRAPHY,4.5,192851,Varies with device,10000000,Free,0,Everyone,Photography
+Be My Eyes - Helping the blind,LIFESTYLE,4.9,8418,21M,500000,Free,0,Everyone,Lifestyle
+Be My Princess: PARTY,FAMILY,4.4,9443,21M,100000,Free,0,Teen,Simulation
+BeautyPlus - Easy Photo Editor & Selfie Camera,PHOTOGRAPHY,4.4,3156484,53M,100000000,Free,0,Everyone,Photography
+Movement BE,SOCIAL,5.0,20,1.2M,100,Free,0,Teen,Social
+Be Stronger,HEALTH_AND_FITNESS,4.8,787,53M,1000,Paid,$1.99,Everyone,Health & Fitness
+Be My Love Animated Keyboard,PERSONALIZATION,4.6,838,11M,50000,Free,0,Teen,Personalization
+Be My Princess 2,FAMILY,4.3,2806,27M,100000,Free,0,Teen,Entertainment
+Millionaire Quiz Free: Be Rich,FAMILY,3.8,66033,6.8M,10000000,Free,0,Everyone,Casual
+Be the Manager 2018 - Football Strategy,SPORTS,4.3,7557,7.4M,100000,Free,0,Everyone,Sports
+Be like Me - Hay Nhu Toi,PERSONALIZATION,4.3,44,3.5M,1000,Free,0,Teen,Personalization
+Be Fabulous PHOTO BOOTH,PHOTOGRAPHY,4.1,560,1.7M,10000,Free,0,Everyone,Photography
+RadarNow!,WEATHER,4.5,54090,4.0M,5000000,Free,0,Everyone,Weather
+Be My Princess,FAMILY,4.2,3103,8.8M,100000,Free,0,Teen,Entertainment
+Fat No More - Be the Biggest Loser in the Gym!,FAMILY,3.8,48545,38M,1000000,Free,0,Everyone,Casual
+Be Like Bill - Maker,FAMILY,4.3,18,1.7M,1000,Free,0,Everyone,Entertainment
+Top Eleven 2018 - Be a Soccer Manager,SPORTS,4.4,3451011,Varies with device,50000000,Free,0,Everyone,Sports
+Free GPS Navigation,MAPS_AND_NAVIGATION,4.2,618562,Varies with device,50000000,Free,0,Everyone,Maps & Navigation
+Be the Manager 2016 (football),SPORTS,4.2,4330,6.1M,100000,Free,0,Everyone,Sports
+Hair Salon - Fun Games,FAMILY,3.8,484226,27M,50000000,Free,0,Teen,Casual
+Adobe Photoshop Fix,PHOTOGRAPHY,4.2,28390,38M,5000000,Free,0,Everyone,Photography
+Make your Be Like Bill,COMICS,4.0,78,2.8M,5000,Free,0,Everyone,Comics
+Be like Bill Generator,FAMILY,4.2,67,6.5M,5000,Free,0,Teen,Entertainment
+Be you GO Launcher Theme,PERSONALIZATION,4.3,1580,3.6M,100000,Free,0,Everyone,Personalization
+"Star Girl - Fashion, Makeup & Dress Up",FAMILY,4.3,556929,53M,10000000,Free,0,Teen,Casual
+Be Like Bro - Compilation,FAMILY,4.4,146,3.9M,10000,Free,0,Teen,Entertainment
+Bowmasters,GAME,4.7,1535581,Varies with device,50000000,Free,0,Teen,Action
+YAY - TBH,SOCIAL,4.1,2520,12M,100000,Free,0,Teen,Social
+The Sims™ Mobile,FAMILY,4.5,559597,89M,10000000,Free,0,Teen,Simulation
+Find My Friends,SOCIAL,4.2,305367,46M,10000000,Free,0,Everyone,Social
+Beauty Idol: Fashion Queen,GAME,4.3,128367,54M,1000000,Free,0,Everyone,Arcade
+Unseen - No Last Seen,TOOLS,4.4,103909,9.2M,5000000,Free,0,Everyone,Tools
+OK K.O.! Lakewood Plaza Turbo,FAMILY,4.5,76608,24M,1000000,Free,0,Everyone 10+,Action;Action & Adventure
+Hard Time (Prison Sim),GAME,4.3,275843,41M,10000000,Free,0,Teen,Adventure
+She Will Be Loved Lyrics,FAMILY,4.2,2,705k,100,Free,0,Everyone,Entertainment
+Nick,FAMILY,4.2,123309,25M,10000000,Free,0,Everyone 10+,Entertainment;Music & Video
+Battlefield™ Companion,GAME,4.0,263907,62M,10000000,Free,0,Everyone 10+,Action
+Wolf of the BF:Commando MOBILE,GAME,3.4,32,27M,1000,Paid,$0.99,Everyone 10+,Arcade
+BF at Sea Refueled,GAME,4.4,1849,37M,10000,Free,0,Everyone,Board
+BF Movies Fun,FAMILY,3.8,63,3.7M,10000,Free,0,Teen,Entertainment
+BF Browser by Betfilter - Stop Gambling Today!,COMMUNICATION,3.0,39,4.6M,10000,Free,0,Everyone,Communication
+My BF App,COMMUNICATION,4.1,141,9.9M,50000,Free,0,Everyone,Communication
+Funny videos for whatsapp,VIDEO_PLAYERS,4.4,3066,9.0M,1000000,Free,0,Everyone,Video Players & Editors
+BF games,FAMILY,4.1,262,29M,50000,Free,0,Everyone,Puzzle
+BF 3d Wallpapers,FAMILY,4.1,256,2.5M,100000,Free,0,Teen,Entertainment
+Hot Bhojpuri Video songs,FAMILY,4.1,28892,6.3M,5000000,Free,0,Teen,Entertainment
+Bullet Force,GAME,4.5,634159,58M,10000000,Free,0,Teen,Action
+GF - BF Chat Stories - Hindi English Convesation,FAMILY,4.1,32,4.1M,10000,Free,0,Everyone,Education
+BF Scale Health Fitness Tool,HEALTH_AND_FITNESS,2.2,19,9.6M,1000,Free,0,Everyone,Health & Fitness
+BF-Calc,TOOLS,3.9,428,3.8M,100000,Free,0,Everyone,Tools
+BF 4 Guns,FAMILY,4.0,1542,13M,50000,Free,0,Everyone,Entertainment
+My Virtual Boyfriend,FAMILY,4.3,105,51M,1000,Paid,$0.99,Teen,Casual
+Sexy Hot Detector Prank,FAMILY,3.9,17067,2.7M,5000000,Free,0,Everyone,Casual
+BF Combat: Genesis,GAME,4.0,3322,82M,100000,Free,0,Mature 17+,Action
+"Women""s Health Tips(Breast,Face,Body,weight lose)",HEALTH_AND_FITNESS,4.2,2509,5.0M,1000000,Free,0,Mature 17+,Health & Fitness
+Combat BF: Black Ops 3,GAME,4.2,7699,83M,500000,Free,0,Mature 17+,Action
+BF Beautiful Nature,FAMILY,3.6,5,2.5M,1000,Free,0,Mature 17+,Entertainment
+BF 3d Images,FAMILY,4.3,19,2.5M,1000,Free,0,Teen,Entertainment
+Jigsaw Puzzles Bus Scania BF,FAMILY,4.2,3,6.6M,1000,Free,0,Teen,Puzzle
+BF 3d View Wallpapers,FAMILY,4.2,4,2.5M,1000,Free,0,Teen,Entertainment
+Hot Bhojpuri Video Song 2018 - Free Movies,FAMILY,4.4,447,3.7M,100000,Free,0,Mature 17+,Entertainment
+Body Scanner xray Real Camera Prank Entertaintment,FAMILY,2.6,17,4.6M,5000,Free,0,Everyone,Entertainment
+BF Frontline City,GAME,4.1,29798,80M,1000000,Free,0,Mature 17+,Action
+Bf Light,BUSINESS,4.1,6,11M,1000,Free,0,Everyone,Business
+Droid PRoCon BF3,TOOLS,3.5,412,2.6M,5000,Paid,$0.99,Everyone,Tools
+BF Abstract 3d Pictures,FAMILY,4.2,72,2.5M,10000,Free,0,Teen,Entertainment
+CE BF,LIFESTYLE,4.1,0,24M,50,Free,0,Everyone,Lifestyle
+Freedom Christian BF,LIFESTYLE,4.1,0,12M,10,Free,0,Everyone,Lifestyle
+Random Love (BF),FAMILY,3.7,3,10M,50,Free,0,Everyone,Entertainment
+BeFunky Photo Editor Pro,PHOTOGRAPHY,4.5,4724,Varies with device,50000,Paid,$1.99,Everyone,Photography
+Virtual Boyfriend Chat,FAMILY,2.4,407,306k,50000,Free,0,Mature 17+,Entertainment
+BF Family user,BUSINESS,4.1,8,26M,100,Free,0,Everyone,Business
+Talking Boyfriend,FAMILY,2.9,1073,2.8M,100000,Free,0,Everyone,Entertainment
+Faketalk - Chatbot,GAME,4.2,63056,8.1M,1000000,Free,0,Teen,Word
+XXX DISTILLERY,BUSINESS,4.2,509,3.2M,100000,Free,0,Everyone,Business
+Cute Questions BF,LIFESTYLE,4.0,3,3.3M,1000,Free,0,Everyone,Lifestyle
+BG Score,SPORTS,2.6,64,1.6M,10000,Free,0,Everyone,Sports
+BG Advisor™,TOOLS,4.4,7,5.6M,1000,Free,0,Everyone,Tools
+BG Products,AUTO_AND_VEHICLES,4.8,4,4.5M,500,Free,0,Everyone,Auto & Vehicles
+BG LINKED (BGLINKED),SOCIAL,4.7,22,11M,1000,Free,0,Everyone,Social
+BG Monitor Diabetes,MEDICAL,4.4,643,2.8M,10000,Free,0,Everyone,Medical
+BG Monitor Diabetes Pro,MEDICAL,4.6,87,2.8M,500,Paid,$5.99,Everyone,Medical
+HTC Sense Input-BG,TOOLS,2.7,198,2.8M,100000,Free,0,Everyone,Tools
+Photo BG Changer,PHOTOGRAPHY,3.8,11,17M,1000,Free,0,Everyone,Photography
+BG TV App,FAMILY,1.7,6,2.9M,100,Free,0,Everyone,Entertainment
+BG BRIDAL GALLERY,LIFESTYLE,4.6,17,19M,1000,Free,0,Everyone,Lifestyle
+HTC Sense Input - BG,TOOLS,3.3,218,4.1M,10000,Free,0,Everyone,Tools
+BG Editor,PHOTOGRAPHY,4.2,0,8.4M,5,Free,0,Everyone,Photography
+BG Sports News,NEWS_AND_MAGAZINES,4.1,41,5.0M,1000,Free,0,Everyone,News & Magazines
+Board Game Stats: Play tracking for tabletop games,LIFESTYLE,4.6,275,3.9M,5000,Paid,$2.99,Everyone,Lifestyle
+Bg TV Online,FAMILY,2.3,50,2.8M,10000,Free,0,Everyone,Entertainment
+"PhotoLayers〜Superimpose,Eraser",PHOTOGRAPHY,4.5,81219,2.6M,10000000,Free,0,Everyone,Photography
+Zdravei.BG,SOCIAL,4.3,6,6.1M,1000,Free,0,Mature 17+,Social
+BG+Phone Backup,PRODUCTIVITY,4.8,16,2.6M,1000,Free,0,Everyone,Productivity
+BGKontakti London BG Kontakti,SOCIAL,4.3,4,8.9M,500,Free,0,Everyone,Social
+ReactNative BG Geolocation,TOOLS,5.0,5,9.1M,1000,Free,0,Everyone,Tools
+BG TV Stations,FAMILY,4.2,0,2.9M,100,Free,0,Everyone,Entertainment
+BG video - floating video - background video,VIDEO_PLAYERS,4.1,64,2.0M,5000,Free,0,Everyone,Video Players & Editors
+BG TV Program,FAMILY,4.2,1,2.8M,100,Free,0,Everyone,Entertainment
+BG Cable TV,FAMILY,4.2,5,2.8M,1000,Free,0,Everyone,Entertainment
+BG Middle East,AUTO_AND_VEHICLES,4.2,1,9.4M,10,Free,0,Everyone,Auto & Vehicles
+Blender BG - Photo Blend With Background,PHOTOGRAPHY,4.2,0,7.8M,100,Free,0,Everyone,Photography
+BG MUSIC PLAYER - MUSIC PLAYER,VIDEO_PLAYERS,4.1,0,8.6M,100,Free,0,Everyone,Video Players & Editors
+Sommelier.BG,FOOD_AND_DRINK,4.2,0,Varies with device,10,Free,0,Teen,Food & Drink
+BG Future School,FAMILY,4.9,16,10M,100,Free,0,Everyone,Education
+Cordova BG Geolocation,MAPS_AND_NAVIGATION,3.0,4,Varies with device,1000,Free,0,Everyone,Maps & Navigation
+Simple Photo BG Changer,TOOLS,4.0,1,5.1M,10,Free,0,Everyone,Tools
+BGKontakti Bayern BG Kontakti,SOCIAL,4.3,32,7.8M,1000,Free,0,Everyone,Social
+BGKontakti Vienna BG Kontakti,SOCIAL,4.8,111,5.9M,1000,Free,0,Everyone,Social
+CARS.bg,AUTO_AND_VEHICLES,4.5,276,1.7M,100000,Free,0,Everyone,Auto & Vehicles
+bgtime.tv,VIDEO_PLAYERS,3.4,694,Varies with device,50000,Free,0,Everyone,Video Players & Editors
+BG Torneos,SPORTS,4.2,7,2.3M,100,Free,0,Everyone,Sports
+YourTube Video Views BG,VIDEO_PLAYERS,4.1,8,2.5M,500,Free,0,Everyone,Video Players & Editors
+BG Television,FAMILY,4.2,3,2.8M,500,Free,0,Everyone,Entertainment
+Cъновник BG,BOOKS_AND_REFERENCE,4.3,13,4.1M,1000,Free,0,Everyone,Books & Reference
+Auto Background Changer,PHOTOGRAPHY,4.0,35188,6.2M,1000000,Free,0,Everyone,Photography
+Block Gun 3D: Call of Destiny,GAME,3.7,31883,20M,1000000,Free,0,Teen,Action
+BG Remover & Eraser Pro,TOOLS,2.2,4,4.8M,500,Free,0,Everyone,Tools
+BG Metro - Red voznje,TRAVEL_AND_LOCAL,4.8,89,Varies with device,1000,Free,0,Everyone,Travel & Local
+BG Cricket,SPORTS,4.2,6,24M,500,Free,0,Everyone,Sports
+BG Guide,TRAVEL_AND_LOCAL,5.0,3,2.4M,100,Free,0,Everyone,Travel & Local
+Bg Radios - Bulgarian radio stations online,FAMILY,4.2,8,13M,1000,Free,0,Everyone,Entertainment
+Micro.bg Cloud POS System,BUSINESS,4.1,6,Varies with device,100,Free,0,Everyone,Business
+BG-FLEET,TOOLS,4.0,0,1.8M,10,Free,0,Everyone,Tools
+trip.bg,TRAVEL_AND_LOCAL,4.5,103,9.8M,1000,Free,0,Everyone,Travel & Local
+Dete.bg,NEWS_AND_MAGAZINES,4.1,0,29M,100,Free,0,Everyone,News & Magazines
+BLOOD & GLORY: IMMORTALS,GAME,4.3,101762,11M,1000000,Free,0,Teen,Action
+Change photo background,PHOTOGRAPHY,3.8,28660,6.4M,5000000,Free,0,Everyone,Photography
+Es-Bg Offline Voice Translator,TRAVEL_AND_LOCAL,4.1,1,87M,10,Paid,$1.49,Everyone,Travel & Local
+Baldur's Gate: Enhanced Edition,FAMILY,4.5,20101,7.8M,100000,Paid,$9.99,Teen,Role Playing
+Shadow Fight 2 Special Edition,GAME,4.5,10440,86M,50000,Paid,$4.99,Teen,Action
+ePazar.bg,SHOPPING,4.3,28,2.1M,1000,Free,0,Everyone,Shopping
+Revita.bg,HEALTH_AND_FITNESS,4.8,10,4.0M,10,Free,0,Everyone,Health & Fitness
+Background Eraser,PHOTOGRAPHY,4.5,267378,1.9M,10000000,Free,0,Everyone,Photography
+ePay.bg,FINANCE,4.4,2017,2.4M,100000,Free,0,Everyone,Finance
+Top Novini BG,NEWS_AND_MAGAZINES,4.1,2,2.9M,100,Free,0,Everyone,News & Magazines
+Block Gun 3D: Ghost Ops,GAME,3.9,142693,21M,5000000,Free,0,Teen,Action
+"Music for Youtube - Tube Music BG, Red+",VIDEO_PLAYERS,4.3,47,8.7M,1000,Free,0,Teen,Video Players & Editors
+Bg+ Call Blocker,TOOLS,4.3,80,1.7M,10000,Free,0,Everyone,Tools
+BG Blurry HD Wallpapers,FAMILY,4.2,1,5.1M,10,Free,0,Everyone,Entertainment
+Background Changer & Eraser,PHOTOGRAPHY,4.0,2076,11M,500000,Free,0,Teen,Photography
+Stolica.bg,NEWS_AND_MAGAZINES,4.1,1,1.3M,50,Free,0,Everyone,News & Magazines
+Cut Out : Background Eraser and background changer,PHOTOGRAPHY,4.1,7118,9.2M,1000000,Free,0,Everyone,Photography
+mySugr: the blood sugar tracker made just for you,MEDICAL,4.6,21187,35M,1000000,Free,0,Everyone,Medical
+Photo Background Changer 2018 - Blur Background,LIFESTYLE,3.7,34079,9.2M,5000000,Free,0,Everyone,Lifestyle
+BGCN TV,VIDEO_PLAYERS,3.4,4334,4.9M,100000,Free,0,Everyone,Video Players & Editors
+ScorePal,TOOLS,4.5,1439,15M,10000,Free,0,Everyone,Tools
+Backgammon NJ for Android,GAME,4.4,1644,15M,10000,Paid,$7.99,Everyone,Board
+BG Burger,FOOD_AND_DRINK,4.2,1,19M,10,Free,0,Everyone,Food & Drink
+JOBS.bg,BUSINESS,4.4,1630,2.2M,100000,Free,0,Everyone,Business
+CSCS BG (в български),FAMILY,2.4,7,2.1M,100,Paid,$3.99,Everyone,Education
+LEGO ® Batman: Beyond Gotham,FAMILY,4.1,10758,8.0M,100000,Paid,$4.99,Everyone 10+,Adventure;Action & Adventure
+Backgrounds HD (Wallpapers),PERSONALIZATION,4.6,2390099,Varies with device,100000000,Free,0,Teen,Personalization
+Blood Glucose Tracker,HEALTH_AND_FITNESS,4.6,9612,3.5M,100000,Free,0,Everyone,Health & Fitness
+Baldur's Gate II,FAMILY,4.3,5442,16M,50000,Paid,$9.99,Teen,Role Playing
+Rento - Dice Board Game Online,GAME,4.3,205830,63M,10000000,Free,0,Everyone,Board
+Learn Bulgarian Free,FAMILY,4.7,3049,Varies with device,50000,Free,0,Everyone,Education
+N+ News Bulgaria,NEWS_AND_MAGAZINES,4.1,2,10M,50,Free,0,Everyone,News & Magazines
+Remix Second Hand,SHOPPING,4.2,867,7.5M,100000,Free,0,Everyone,Shopping
+Ultimate Background Eraser,PHOTOGRAPHY,4.3,14453,21M,1000000,Free,0,Everyone,Photography
+OnTrack Diabetes,MEDICAL,4.3,6079,1.8M,500000,Free,0,Everyone,Medical
+Blur Image Background,PHOTOGRAPHY,3.9,129268,11M,10000000,Free,0,Everyone,Photography
+ALL-IN-ONE PACKAGE TRACKING,PRODUCTIVITY,4.7,167406,18M,1000000,Free,0,Everyone,Productivity
+Survival Run with Bear Grylls,GAME,4.2,128579,Varies with device,5000000,Free,0,Everyone,Action
+VIP Backgammon Free : Play Backgammon Online,GAME,4.1,389,Varies with device,10000,Free,0,Teen,Board
+Grabo.bg,SHOPPING,4.6,8175,3.2M,100000,Free,0,Everyone,Shopping
+BusyBox Pro,TOOLS,4.7,8114,Varies with device,100000,Paid,$2.49,Everyone,Tools
+GEM™,TOOLS,4.3,6,33M,500,Free,0,Everyone,Tools
+Diabetes Connect,MEDICAL,4.5,4027,8.4M,100000,Free,0,Everyone,Medical
+B&H Photo Video Pro Audio,SHOPPING,4.6,17180,31M,1000000,Free,0,Everyone,Shopping
+BH by Kinomap,HEALTH_AND_FITNESS,2.9,141,22M,10000,Free,0,Everyone,Health & Fitness
+BH Cosmetics,BEAUTY,4.0,2,3.6M,1000,Free,0,Everyone,Beauty
+BH Bikes Premium,SPORTS,3.0,26,15M,1000,Free,0,Everyone,Sports
+B&H Kids AR,BOOKS_AND_REFERENCE,3.9,286,18M,10000,Free,0,Everyone,Books & Reference
+BH Bikes GPS Locator,SPORTS,4.2,0,10M,10,Free,0,Everyone,Sports
+BH Patrole,AUTO_AND_VEHICLES,4.8,27,2.5M,500,Free,0,Everyone,Auto & Vehicles
+CINEMA.BH,FAMILY,3.9,11,16M,1000,Free,0,Everyone,Entertainment
+DSLR Photography Training apps,PHOTOGRAPHY,4.0,675,15M,100000,Free,0,Everyone,Photography
+Radio Belo Horizonte,FAMILY,4.2,0,4.3M,10,Free,0,Mature 17+,Entertainment
+BH Online,FINANCE,4.1,0,4.6M,10,Free,0,Everyone,Finance
+Belo Horizonte Map offline,TRAVEL_AND_LOCAL,4.1,11,18M,1000,Free,0,Everyone,Travel & Local
+Bh Public School,FAMILY,5.0,2,8.7M,10,Free,0,Everyone,Education
+BH Mission Playbook,TRAVEL_AND_LOCAL,4.1,0,22M,100,Free,0,Everyone,Travel & Local
+BH INVEST,FINANCE,4.1,7,1.1M,500,Free,0,Everyone,Finance
+Comunidad BH,FAMILY,4.2,23,4.8M,1000,Free,0,Everyone,Entertainment
+VIVA BH,TOOLS,4.0,2055,2.6M,100000,Free,0,Everyone,Tools
+Discípulos em BH,SOCIAL,4.3,24,5.2M,100,Free,0,Everyone,Social
+Barbers.BH,LIFESTYLE,5.0,2,6.0M,10,Free,0,Everyone,Lifestyle
+BH - Fitness & Nutrition,HEALTH_AND_FITNESS,4.3,0,43M,1,Free,0,Everyone,Health & Fitness
+Lexus Tech BH Service Pro,LIFESTYLE,4.1,0,904k,10,Free,0,Teen,Lifestyle
+Photo Editor - BPhoto,PHOTOGRAPHY,4.5,42,20M,1000,Free,0,Everyone,Photography
+BH Challenge - Museum of the Jewish People,FAMILY,4.8,12,28M,1000,Free,0,Everyone,Education
+B'H BURGER HEIM,LIFESTYLE,4.1,0,20M,10,Free,0,Everyone,Lifestyle
+B y H Niños ES,BOOKS_AND_REFERENCE,4.6,53,16M,5000,Free,0,Everyone,Books & Reference
+ZUL - Rotativo Digital BH,AUTO_AND_VEHICLES,4.2,29,Varies with device,10000,Free,0,Everyone,Auto & Vehicles
+Coomotaxi BH,BUSINESS,4.1,94,8.7M,5000,Free,0,Everyone,Business
+BH Mail,COMMUNICATION,3.4,7,6.0M,1000,Free,0,Everyone,Communication
+FitConsole,HEALTH_AND_FITNESS,2.6,219,1.8M,50000,Free,0,Everyone,Health & Fitness
+Run on Earth,HEALTH_AND_FITNESS,2.4,577,3.7M,50000,Free,0,Everyone,Health & Fitness
+BH Rocking,TRAVEL_AND_LOCAL,4.1,13,3.2M,100,Free,0,Everyone,Travel & Local
+Newegg Mobile,SHOPPING,4.5,35479,16M,1000000,Free,0,Everyone,Shopping
+Battleheart Legacy,FAMILY,4.6,7420,7.4M,50000,Paid,$4.99,Teen,Role Playing
+Treadmill Workouts Free (P),HEALTH_AND_FITNESS,3.3,10,3.3M,1000,Free,0,Everyone,Health & Fitness
+ZiraatBank BH,FINANCE,4.1,58,3.5M,10000,Free,0,Everyone,Finance
+Digital Tourist BH Itinerary,TRAVEL_AND_LOCAL,4.6,19,14M,500,Free,0,Everyone,Travel & Local
+BH Táxi,BUSINESS,3.9,91,8.9M,5000,Free,0,Everyone,Business
+BH Connect,SOCIAL,4.3,0,32M,1,Free,0,Teen,Social
+Out of Bounds BH Demo,GAME,4.3,3,14M,10,Free,0,Everyone,Action
+EduNAV.BH,FAMILY,4.2,3,3.8M,50,Free,0,Everyone,Education
+BH Açaí,FOOD_AND_DRINK,4.2,3,4.7M,100,Free,0,Everyone,Food & Drink
+BH Recepti,FOOD_AND_DRINK,4.2,3,9.9M,500,Free,0,Everyone,Food & Drink
+Bi en Línea,FINANCE,4.0,5055,17M,100000,Free,0,Everyone,Finance
+Gayvox - Gay Lesbian Bi Dating,SOCIAL,3.4,3640,9.1M,500000,Free,0,Mature 17+,Social
+Microsoft Power BI–Business data analytics,BUSINESS,4.5,1819,10M,100000,Free,0,Everyone,Business
+BI Mobile Banking,FINANCE,4.0,180,27M,10000,Free,0,Everyone,Finance
+BI News,NEWS_AND_MAGAZINES,5.0,22,25M,1000,Free,0,Everyone,News & Magazines
+BI SmartLINK,BUSINESS,3.6,16,33M,5000,Free,0,Everyone,Business
+BI-LO,LIFESTYLE,3.5,43,30M,10000,Free,0,Everyone,Lifestyle
+Bitmoji – Your Personal Emoji,FAMILY,4.6,2312084,Varies with device,100000000,Free,0,Teen,Entertainment
+Sisense Mobile BI,BUSINESS,4.9,23,28M,1000,Free,0,Everyone,Business
+"Starg - Gay, Same Sex, Bi",DATING,3.7,66,7.3M,10000,Free,0,Mature 17+,Dating
+Propel BI APP,BUSINESS,5.0,3,23M,100,Free,0,Everyone,Business
+BI Office,BUSINESS,4.0,76,201k,10000,Free,0,Everyone,Business
+BI-LO Rx,LIFESTYLE,3.9,77,Varies with device,10000,Free,0,Everyone,Lifestyle
+BI APP,FINANCE,5.0,2,2.7M,100,Free,0,Everyone,Finance
+Oracle BI Mobile,BUSINESS,4.0,282,7.7M,10000,Free,0,Everyone,Business
+Bi-Tank Ads Free,GAME,4.3,0,Varies with device,1,Paid,$0.99,Everyone,Arcade
+bi-Cube Mobile Token,TOOLS,4.0,5,21M,1000,Free,0,Everyone,Tools
+Business Intelligence & Data,FAMILY,4.9,7,3.5M,1000,Free,0,Everyone,Education
+BI Mobile,FINANCE,4.4,337,3.3M,10000,Free,0,Everyone,Finance
+Grindr - Gay chat,SOCIAL,3.6,284795,31M,10000000,Free,0,Mature 17+,Social
+Zoho Reports - Mobile BI,BUSINESS,4.7,45,12M,5000,Free,0,Everyone,Business
+Power BI Ultimate Orientation,FAMILY,4.3,12,8.1M,5000,Free,0,Everyone,Education
+Pool Billiards Classic - bi a,SPORTS,3.9,5644,14M,1000000,Free,0,Everyone,Sports
+Lesbian Chat & Dating - SPICY,SOCIAL,4.5,63765,11M,1000000,Free,0,Mature 17+,Social
+"Moco - Chat, Meet People",DATING,4.2,313769,Varies with device,10000000,Free,0,Mature 17+,Dating
+Bi-Tank,GAME,4.6,12,18M,50,Free,0,Everyone,Arcade
+Hot or Not - Find someone right now,DATING,4.1,305737,Varies with device,10000000,Free,0,Mature 17+,Dating
+happn – Local dating app,LIFESTYLE,4.3,1118201,Varies with device,10000000,Free,0,Mature 17+,Lifestyle
+Dictionary.com: Find Definitions for English Words,BOOKS_AND_REFERENCE,4.6,899010,Varies with device,10000000,Free,0,Everyone,Books & Reference
+MinT BI,PRODUCTIVITY,4.2,0,2.9M,10,Free,0,Everyone,Productivity
+BI Barcode Scanner,PRODUCTIVITY,4.2,0,473k,10,Paid,$0.99,Everyone,Productivity
+MeetMe: Chat & Meet New People,SOCIAL,4.2,1259723,76M,50000000,Free,0,Mature 17+,Social
+TED,FAMILY,4.6,181961,18M,10000000,Free,0,Everyone 10+,Education
+"Learn English Vocabulary - 6,000 Words",FAMILY,4.5,205914,54M,10000000,Free,0,Everyone,Education
+English Dictionary - Offline,BOOKS_AND_REFERENCE,4.4,341234,30M,10000000,Free,0,Everyone 10+,Books & Reference
+Zalo – Video Call,COMMUNICATION,4.2,1042170,Varies with device,50000000,Free,0,Everyone,Communication
+Bible KJV,BOOKS_AND_REFERENCE,4.5,42729,Varies with device,5000000,Free,0,Everyone,Books & Reference
+All Language Translator,TOOLS,4.0,29944,2.1M,5000000,Free,0,Everyone,Tools
+Bike Rivals,GAME,4.2,212067,48M,10000000,Free,0,Everyone,Racing
+Bingo Party - Free Bingo Games,GAME,4.7,155694,92M,1000000,Free,0,Teen,Board
+OkCupid Dating,DATING,4.1,285838,15M,10000000,Free,0,Mature 17+,Dating
+Little Big City 2,FAMILY,4.4,344383,30M,10000000,Free,0,Everyone,Casual
+"Mint: Budget, Bills, Finance",FINANCE,4.3,129305,Varies with device,5000000,Free,0,Everyone,Finance
+English Grammar Test,FAMILY,4.6,104676,2.6M,5000000,Free,0,Everyone,Education
+BJ's Wholesale Club,SHOPPING,4.2,4099,17M,100000,Free,0,Everyone,Shopping
+BJ’s Mobile App,SHOPPING,4.0,4722,35M,500000,Free,0,Everyone,Shopping
+BJ's Express Scan,SHOPPING,2.3,69,11M,10000,Free,0,Everyone,Shopping
+BJ's Bingo & Gaming Casino,GAME,4.5,501,65M,10000,Free,0,Teen,Casino
+BJ-UFO,FAMILY,3.6,226,25M,50000,Free,0,Everyone,Casual
+BJ Bridge Pro 2018,GAME,4.4,17,4.8M,500,Paid,$4.49,Everyone,Card
+BJ Bridge Free (2018),GAME,3.9,20,4.8M,10000,Free,0,Everyone,Card
+BJ & Jamie,FAMILY,3.9,13,17M,100,Free,0,Everyone,Entertainment
+The Daily BJ,HEALTH_AND_FITNESS,4.8,38,24M,500,Free,0,Everyone,Health & Fitness
+BJ-FPV,FAMILY,4.2,16,26M,1000,Free,0,Everyone,Casual
+BJ Bridge Acol Beginner 2018,GAME,3.7,11,4.8M,5000,Free,0,Everyone,Card
+BJ Memo Widget,PRODUCTIVITY,4.0,616,175k,50000,Free,0,Everyone,Productivity
+BJ Grand Salon Mobile App,BEAUTY,4.3,1,15M,100,Free,0,Everyone,Beauty
+BJ Bridge Standard American 2018,GAME,1.0,1,4.9M,1000,Free,0,Everyone,Card
+BJ Strategy Tester,GAME,4.3,1,8.8M,100,Free,0,Everyone,Casino
+Eating Show - Food BJ,FAMILY,4.4,103,36M,10000,Free,0,Everyone,Simulation
+Virtual DJ Sound Mixer,TOOLS,4.2,4010,8.7M,500000,Free,0,Everyone,Tools
+Cards Casino:Video Poker & BJ,GAME,4.7,325,23M,10000,Free,0,Teen,Casino
+DJ Music Pad,FAMILY,3.6,35121,5.1M,5000000,Free,0,Everyone,Entertainment
+BJ-DRONE,FAMILY,4.2,1,23M,100,Free,0,Everyone,Entertainment
+"Real Casino:Slot,Keno,BJ,Poker",GAME,4.1,341,26M,50000,Free,0,Teen,Casino
+AfreecaTV,VIDEO_PLAYERS,3.3,381023,53M,10000000,Free,0,Everyone,Video Players & Editors
+BJ - Confidential,COMMUNICATION,4.2,0,3.2M,10,Free,0,Teen,Communication
+Basic Strategy Training BJ 21,GAME,4.3,0,23M,500,Free,0,Teen,Casino
+HON. B.J. ACS COLLEGE ALE,FAMILY,5.0,3,1.8M,100,Free,0,Mature 17+,Education
+One Launcher,PERSONALIZATION,4.3,26601,5.4M,1000000,Free,0,Everyone,Personalization
+BJ Toys,SHOPPING,4.7,55,8.0M,500,Free,0,Everyone,Shopping
+Alumni BJ,SOCIAL,4.3,2,5.4M,100,Free,0,Everyone,Social
+"뽕티비 - 개인방송, 인터넷방송, BJ방송",VIDEO_PLAYERS,4.1,414,59M,100000,Free,0,Mature 17+,Video Players & Editors
+BJ card game blackjack,GAME,4.3,3,21M,500,Free,0,Teen,Card
+BMH-BJ Congregation,LIFESTYLE,4.1,0,5.1M,10,Free,0,Everyone,Lifestyle
+BJ's Community SoundBoard,FAMILY,4.2,0,Varies with device,5,Free,0,Teen,Entertainment
+Real DJ Simulator,FAMILY,4.0,68664,55M,10000000,Free,0,Everyone,Simulation
+BJ TIKET,BUSINESS,4.1,3,3.4M,10,Free,0,Everyone,Business
+BLACKJACK!,GAME,4.4,524467,33M,10000000,Free,0,Teen,Casino
+Blackjack Verite Drills,GAME,4.6,17,4.7M,100,Paid,$14.00,Teen,Casino
+BJ Foods,BUSINESS,5.0,3,1.5M,10,Free,0,Everyone,Business
+Blackjack,GAME,4.3,52199,Varies with device,1000000,Free,0,Teen,Casino
+3D DJ – DJ Mixer 2018,FAMILY,4.3,6333,30M,1000000,Free,0,Everyone,Entertainment
+BJ Adams,BUSINESS,4.1,1,26M,5,Free,0,Everyone,Business
+Phonics Puzzles,FAMILY,3.8,4,54M,100,Paid,$2.99,Everyone,Educational
+Spider grinder in screen funny,FAMILY,4.1,956,10M,100000,Free,0,Teen,Entertainment
+BJJ Roadmap by Stephan Kesting,SPORTS,4.6,969,3.6M,10000,Free,0,Everyone,Sports
+KISW 99.9 FM SEATTLE,FAMILY,4.0,1469,5.2M,100000,Free,0,Everyone,Entertainment
+BlackJack -21 Casino Card Game,GAME,4.7,2066,25M,100000,Free,0,Teen,Casino
+Metal Detector Pro 2015,TOOLS,3.6,1166,350k,100000,Free,0,Everyone,Tools
+BlackJack 21 Pro,GAME,4.5,26744,51M,500000,Free,0,Teen,Casino
+24 megapixel hd camera,PHOTOGRAPHY,4.0,802,5.1M,100000,Free,0,Everyone,Photography
+Ultimate BlackJack 3D FREE,GAME,4.1,1686,4.6M,100000,Free,0,Teen,Casino
+BURGER KING® App,LIFESTYLE,4.0,41747,39M,5000000,Free,0,Everyone,Lifestyle
+BURGER KING® MOBILE APP,LIFESTYLE,3.8,19221,13M,5000000,Free,0,Everyone,Lifestyle
+BK Chat,COMMUNICATION,4.2,6,31M,1000,Free,0,Teen,Communication
+BURGER KING® Puerto Rico,FOOD_AND_DRINK,4.5,2448,19M,100000,Free,0,Everyone,Food & Drink
+Free Coupons for Burger King,LIFESTYLE,2.8,17,3.1M,5000,Free,0,Everyone,Lifestyle
+BK Manager,NEWS_AND_MAGAZINES,4.1,19,17M,5000,Free,0,Everyone,News & Magazines
+Power Widget,TOOLS,4.2,928,383k,10000,Paid,$1.99,Everyone,Tools
+BK Murli Offline April 2017,LIFESTYLE,4.8,33,2.4M,5000,Free,0,Everyone,Lifestyle
+Read it easy for BK,LIFESTYLE,5.0,1,3.2M,50,Free,0,Everyone,Lifestyle
+BK Video Status,FAMILY,5.0,13,2.1M,100,Free,0,Everyone,Entertainment
+bk Group Mobile,BUSINESS,4.1,1,30M,50,Free,0,Everyone,Business
+SLANGY-Perfect BK World Theme,PERSONALIZATION,4.3,1,14M,50,Paid,$4.85,Everyone,Personalization
+BK Formula Calculator 2,TOOLS,4.0,4,12M,100,Free,0,Everyone,Tools
+Service Disabler,TOOLS,4.3,534,3.0M,100000,Free,0,Everyone,Tools
+BK Photography,PHOTOGRAPHY,4.3,20,4.8M,1000,Free,0,Everyone,Photography
+Keyboard Theme Dusk BK Purple,PERSONALIZATION,4.5,248,2.8M,10000,Free,0,Mature 17+,Personalization
+Coupons for Burger King,FOOD_AND_DRINK,4.5,41,4.0M,500,Free,0,Teen,Food & Drink
+BK Formula Calculator,TOOLS,5.0,6,11M,100,Free,0,Everyone,Tools
+VK,SOCIAL,3.8,5793284,Varies with device,100000000,Free,0,Mature 17+,Social
+Korean English Translator,FAMILY,4.4,634,1.8M,100000,Free,0,Everyone,Education
+Dr Bk Sachin bhai,LIFESTYLE,5.0,19,3.1M,1000,Free,0,Everyone,Lifestyle
+Audio Murli Glossary For BK,FAMILY,4.7,39,20M,1000,Free,0,Everyone,Education
+SKIN BK,PRODUCTIVITY,4.2,0,33M,10,Free,0,Everyone,Productivity
+BK Traffic Control cum Chart,SOCIAL,4.7,549,17M,10000,Free,0,Teen,Social
+Hungry Girl Diet Bk. Companion,HEALTH_AND_FITNESS,2.2,4,28M,1000,Free,0,Everyone,Health & Fitness
+Daily Murli Saar Widget,SOCIAL,4.6,308,454k,10000,Free,0,Everyone,Social
+BK Suraj bhai,LIFESTYLE,4.6,9,3.1M,1000,Free,0,Everyone,Lifestyle
+BK Shivani Videos,LIFESTYLE,4.7,29,3.2M,1000,Free,0,Everyone,Lifestyle
+BK News Channel,VIDEO_PLAYERS,4.6,277,6.8M,10000,Free,0,Everyone,Video Players & Editors
+BK Dinos,FAMILY,4.4,30,99M,5000,Free,0,Everyone,Entertainment
+Make a burger king,FAMILY,3.8,125,17M,10000,Free,0,Everyone,Casual
+King Burger Dash,FAMILY,3.6,445,12M,50000,Free,0,Everyone,Casual
+Official Madhuban Murli,LIFESTYLE,4.9,301,25M,10000,Free,0,Everyone,Lifestyle
+Baba Yaad Hai?(BK's),FAMILY,4.8,160,13M,10000,Free,0,Everyone,Entertainment
+Bk Bee Sales Manager,BUSINESS,4.1,0,2.1M,5,Paid,$0.99,Everyone,Business
+Burger King Foot Lettuce,FAMILY,4.4,150,5.9M,10000,Free,0,Everyone,Entertainment
+BK Arogyam Task Track,BUSINESS,5.0,8,3.7M,100,Free,0,Everyone,Business
+BK murli today (Mobile Murli) - Gyan,FAMILY,4.8,100,4.5M,5000,Free,0,Everyone,Education
+Capital Bk Mobile Business Dep,FINANCE,4.1,1,4.1M,100,Free,0,Everyone,Finance
+BK Travel Solutions,EVENTS,4.4,1,11M,100,Free,0,Everyone,Events
+BK Murli Dictionary (H to E),FAMILY,4.6,106,3.9M,10000,Free,0,Everyone,Education
+Bk Usha behn,LIFESTYLE,5.0,10,3.0M,1000,Free,0,Everyone,Lifestyle
+BkEmu - BK-0010/11M emulator,FAMILY,4.6,222,1.4M,10000,Free,0,Everyone,Entertainment
+BK Gold App,FINANCE,5.0,4,11M,50,Free,0,Everyone,Finance
+Of the wall Arapaho bk,COMMUNICATION,4.2,0,12M,5,Free,0,Everyone,Communication
+Burger King Italia,LIFESTYLE,4.0,4160,30M,500000,Free,0,Everyone,Lifestyle
+Red Embrace (BL/Yaoi Game),FAMILY,4.3,616,25M,10000,Free,0,Teen,Casual
+Blood Domination - BL Game,GAME,4.5,415,52M,10000,Free,0,Mature 17+,Adventure
+Yaoi Ooku: Distorted Love,FAMILY,4.0,2614,6.3M,100000,Free,0,Mature 17+,Simulation
+Yaoi Novels - Shounen ai Book&fiction,FAMILY,3.2,304,4.7M,10000,Free,0,Teen,Entertainment
+Cerulean Heart,FAMILY,4.6,2683,25M,10000,Free,0,Mature 17+,Simulation
+BL 女性向け恋愛ゲーム◆俺プリクロス,FAMILY,4.2,3379,62M,100000,Free,0,Mature 17+,Simulation
+WebComics,COMICS,4.8,33783,6.4M,1000000,Free,0,Teen,Comics
+Lezhin Comics - Daily Releases,COMICS,3.0,28447,15M,1000000,Free,0,Teen,Comics
+Heirs & Graces,GAME,4.3,125,70M,5000,Free,0,Teen,Adventure
+BL Driver,MAPS_AND_NAVIGATION,3.9,230,12M,10000,Free,0,Everyone,Maps & Navigation
+Daily Manga - Comic & Webtoon,COMICS,3.2,1462,7.1M,100000,Free,0,Mature 17+,Comics
+Gaydorado,FAMILY,3.9,8419,47M,100000,Free,0,Teen,Role Playing
+Chess of Blades (BL/Yaoi Game) (No VA),FAMILY,4.8,4,23M,10,Paid,$14.99,Teen,Casual
+TappyToon Comics & Webtoons,COMICS,3.5,4205,10M,100000,Free,0,Teen,Comics
+SecondSecret ‐「恋を読む」BLノベルゲーム‐,GAME,4.4,1563,40M,50000,Free,0,Teen,Adventure
+Lust in Terror Manor - The Truth Unveiled | Otome,GAME,4.1,355,53M,10000,Free,0,Teen,Adventure
+BL 女性向け恋愛ゲーム◆ごくメン,FAMILY,4.2,1901,8.2M,100000,Free,0,Mature 17+,Simulation
+あなカレ【BL】無料ゲーム,FAMILY,4.7,6073,8.5M,100000,Free,0,Mature 17+,Simulation
+K-Rain BL,TOOLS,4.0,9,33M,1000,Free,0,Everyone,Tools
+감성학원 BL 첫사랑,COMICS,4.4,190,34M,10000,Free,0,Everyone,Comics
+Chess of Blades (Demo),FAMILY,4.2,45,23M,1000,Free,0,Teen,Casual
+BL Flowers Digital,SHOPPING,5.0,21,2.5M,100,Free,0,Everyone,Shopping
+BL 1-Click Camera - Free,PHOTOGRAPHY,3.5,52,1.8M,10000,Free,0,Everyone,Photography
+Manga Books,COMICS,3.8,7326,Varies with device,500000,Free,0,Adults only 18+,Comics
+BL 1-Click Camera,PHOTOGRAPHY,4.2,4,1.4M,100,Paid,$3.99,Everyone,Photography
+OTOME of Ikemen cafe,FAMILY,4.5,1318,24M,50000,Free,0,Teen,Simulation
+BL info,TRAVEL_AND_LOCAL,4.1,98,2.0M,5000,Free,0,Everyone,Travel & Local
+BL File Explorer,TOOLS,4.0,1,421k,50,Paid,$1.99,Everyone,Tools
+BL IP-Camera,TOOLS,4.3,15,1.2M,100,Paid,$3.99,Everyone,Tools
+BL Carrier,BUSINESS,4.1,0,11M,10,Free,0,Everyone,Business
+Skill Tree - BL Pre Sequel,FAMILY,4.3,855,7.0M,10000,Free,0,Teen,Entertainment
+BL Holo Theme,PERSONALIZATION,4.4,18,2.1M,500,Paid,$2.00,Everyone,Personalization
+BL Portfolio,PHOTOGRAPHY,4.2,4,16M,100,Free,0,Everyone,Photography
+Skywatch BL,WEATHER,4.2,15,10M,1000,Free,0,Everyone,Weather
+B-L Animal Hospital,MEDICAL,4.2,1,28M,100,Free,0,Everyone,Medical
+BL Banking DES,FINANCE,4.1,3,5.5M,100,Free,0,Everyone,Finance
+BL ONLINE PERSONAL TRAINING,HEALTH_AND_FITNESS,4.3,0,41M,5,Free,0,Everyone,Health & Fitness
+BL Community Icon Pack,PERSONALIZATION,4.0,289,2.7M,10000,Free,0,Everyone,Personalization
+BL Mobile Banking,FINANCE,4.3,23,93M,1000,Free,0,Everyone,Finance
+MEGA MAN MOBILE,GAME,4.0,267,40M,10000,Paid,$1.99,Everyone,Action
+BL Taxi,MAPS_AND_NAVIGATION,4.9,124,3.4M,1000,Free,0,Everyone,Maps & Navigation
+BL!TZ - Endless,GAME,4.7,21,9.0M,100,Free,0,Everyone,Arcade
+AC-BL,COMMUNICATION,4.2,0,4.3M,50,Free,0,Everyone,Communication
+BL-ED: From BLUE to RED,GAME,4.3,3,2.9M,10,Free,0,Everyone,Arcade
+B L Enterprises,FINANCE,4.1,2,6.9M,10,Free,0,Everyone,Finance
+BL PowerPoint Remote,TOOLS,4.3,33,1.0M,500,Paid,$3.99,Everyone,Tools
+BL Kennedy Theme,PERSONALIZATION,4.2,279,1.1M,10000,Free,0,Everyone,Personalization
+Teen Patti by BL Games,GAME,4.1,496,39M,100000,Free,0,Teen,Card
+BBM - Free Calls & Messages,COMMUNICATION,4.3,12843436,Varies with device,100000000,Free,0,Everyone,Communication
+BeyondMenu Food Delivery,FOOD_AND_DRINK,4.7,51543,Varies with device,1000000,Free,0,Everyone,Food & Drink
+bm offers,LIFESTYLE,3.2,320,31M,50000,Free,0,Everyone,Lifestyle
+B.M.Snowboard Free,SPORTS,3.9,9765,14M,1000000,Free,0,Everyone,Sports
+BM Wallet,FINANCE,4.2,798,29M,50000,Free,0,Everyone,Finance
+BM Online OEC Verification,TOOLS,4.1,783,4.2M,100000,Free,0,Everyone,Tools
+Business Mitra (BM),BUSINESS,4.9,13,5.3M,100,Free,0,Everyone,Business
+Bm,FAMILY,4.2,1,1.7M,100,Free,0,Everyone,Puzzle
+Basket Manager 2018 Pro,SPORTS,3.7,84,6.3M,1000,Paid,$2.99,Everyone,Sports
+bm Wallet,FINANCE,3.5,196,27M,10000,Free,0,Everyone,Finance
+BatControl Pro,TOOLS,4.9,83,3.1M,500,Paid,$3.99,Everyone,Tools
+Myjob@BM,SOCIAL,4.3,1,Varies with device,100,Free,0,Teen,Social
+DMR BrandMeister Tool,COMMUNICATION,3.3,78,2.5M,10000,Free,0,Everyone,Communication
+"Borneo Bible, BM Bible",BOOKS_AND_REFERENCE,4.9,659,5.0M,10000,Free,0,Everyone,Books & Reference
+Basket Manager 2018 Free,SPORTS,3.4,1520,6.3M,50000,Free,0,Everyone,Sports
+MOD Black for BM,BOOKS_AND_REFERENCE,4.3,2,7.8M,100,Free,0,Everyone,Books & Reference
+Basket Manager 2017 Free,SPORTS,4.5,2710,4.8M,100000,Free,0,Everyone,Sports
+BM Box,BOOKS_AND_REFERENCE,4.3,28,Varies with device,1000,Free,0,Everyone,Books & Reference
+BM SPM Practice,FAMILY,5.0,6,9.2M,1000,Free,0,Everyone,Education
+BM FlexCheck,AUTO_AND_VEHICLES,3.5,2,34M,100,Free,0,Everyone,Auto & Vehicles
+TuenMun BM,TOOLS,4.0,6,47M,1000,Free,0,Everyone,Tools
+bm-Events,SOCIAL,4.3,0,8.1M,10,Free,0,Teen,Social
+Poop Tracker - Toilet Log,HEALTH_AND_FITNESS,4.4,622,2.5M,10000,Free,0,Everyone,Health & Fitness
+B&M Stores,SHOPPING,3.7,192,36M,100000,Free,0,Everyone,Shopping
+BM CRM,SHOPPING,4.3,0,10M,5,Free,0,Everyone,Shopping
+Mobilight-BM,FINANCE,4.8,6,6.2M,500,Free,0,Everyone,Finance
+iFORA BM,MEDICAL,4.2,3,10M,100,Free,0,Everyone,Medical
+Basket Manager 2016 Free,SPORTS,4.3,1879,4.4M,100000,Free,0,Everyone,Sports
+BM Pharmacy,HEALTH_AND_FITNESS,4.9,42,18M,1000,Free,0,Everyone,Health & Fitness
+postit.bm,SHOPPING,4.3,1,16M,500,Free,0,Everyone,Shopping
+orderin.bm,FOOD_AND_DRINK,4.2,0,Varies with device,1,Free,0,Everyone,Food & Drink
+BM Assets,FINANCE,4.1,6,9.9M,500,Free,0,Everyone,Finance
+BM Interventi,PRODUCTIVITY,4.2,2,22M,10,Free,0,Everyone,Productivity
+BM Tahmin: Ücretsiz İddaa Tahminleri,SPORTS,4.2,7,1.9M,500,Free,0,Everyone,Sports
+RIV-BM FPV,FAMILY,4.2,0,26M,10,Free,0,Everyone,Entertainment
+BM Physiotherapy Clinic,HEALTH_AND_FITNESS,5.0,3,9.3M,100,Free,0,Everyone,Health & Fitness
+BBMoji - Your personalized BBM Stickers,COMMUNICATION,4.3,8827,Varies with device,1000000,Free,0,Everyone,Communication
+Dormi - Baby Monitor,PARENTING,4.3,11760,Varies with device,1000000,Free,0,Everyone,Parenting
+På sporet ABC (BM),FAMILY,4.2,2,28M,1000,Free,0,Everyone,Educational
+BAMMS for BM 1Park,PRODUCTIVITY,4.2,7,10M,50,Free,0,Everyone,Productivity
+Bet Master Pro Soccer Predictions,SPORTS,4.4,328,11M,10000,Free,0,Everyone,Sports
+MbH BM,MEDICAL,1.0,1,2.3M,100,Free,0,Everyone,Medical
+Basket Manager 2016 Pro,SPORTS,4.5,117,4.4M,1000,Paid,$0.99,Everyone,Sports
+Anime Mod for BM,BOOKS_AND_REFERENCE,4.3,0,8.0M,100,Free,0,Everyone,Books & Reference
+BAMMS for BM SQ,PRODUCTIVITY,4.0,2,10M,10,Free,0,Everyone,Productivity
+BM speed test,TOOLS,5.0,1,3.7M,10,Free,0,Everyone,Tools
+Word Hunt,GAME,4.9,59,21M,500,Free,0,Everyone,Word
+Basket Manager 2017 Pro,SPORTS,4.7,163,4.6M,1000,Paid,$0.99,Everyone,Sports
+NOOK: Read eBooks & Magazines,BOOKS_AND_REFERENCE,4.5,155466,Varies with device,10000000,Free,0,Teen,Books & Reference
+BN Más Cerca de Usted,FINANCE,3.9,8185,45M,500000,Free,0,Everyone,Finance
+Radio BN,FAMILY,4.2,53,4.2M,5000,Free,0,Everyone,Entertainment
+My College Bookstore,SHOPPING,3.2,661,7.6M,100000,Free,0,Everyone,Shopping
+NOOK Audiobooks,BOOKS_AND_REFERENCE,3.5,2539,8.6M,500000,Free,0,Everyone,Books & Reference
+BN PERKS™,LIFESTYLE,4.1,0,15M,100,Free,0,Everyone,Lifestyle
+BNCR Token Celular,FINANCE,3.7,913,70k,100000,Free,0,Everyone,Finance
+BN Mi Banco,BUSINESS,3.0,597,17M,100000,Free,0,Everyone,Business
+BN Pro BlueICS-b HD Text,LIBRARIES_AND_DEMO,4.2,78,812k,10000,Free,0,Everyone,Libraries & Demo
+BN Whitening Shoppe Ph,BEAUTY,4.0,2,13M,100,Free,0,Everyone,Beauty
+BN Pro ArialXL Legacy Text,LIBRARIES_AND_DEMO,4.1,142,442k,10000,Free,0,Everyone,Libraries & Demo
+Sam.BN Pro,TOOLS,4.0,11,2.0M,10,Paid,$0.99,Everyone,Tools
+NOOK App for NOOK Devices,BOOKS_AND_REFERENCE,4.7,19090,Varies with device,500000,Free,0,Everyone,Books & Reference
+BN Pro PercentXL-b Neon HD Txt,LIBRARIES_AND_DEMO,4.0,45,842k,5000,Free,0,Everyone,Libraries & Demo
+BN Bank Mobilbank,FINANCE,3.1,72,2.4M,10000,Free,0,Everyone,Finance
+BN Pro Play-b HD Text,LIBRARIES_AND_DEMO,4.4,34,417k,1000,Free,0,Everyone,Libraries & Demo
+[BN] Blitz,SPORTS,3.2,4,5.6M,100,Free,0,Everyone,Sports
+BN Pro LcdD Legacy Text,LIBRARIES_AND_DEMO,3.9,71,412k,10000,Free,0,Everyone,Libraries & Demo
+BN Pro RobotoXL-b HD Text,LIBRARIES_AND_DEMO,4.2,86,459k,10000,Free,0,Everyone,Libraries & Demo
+Browsery by Barnes & Noble,BOOKS_AND_REFERENCE,4.7,146,34M,5000,Free,0,Everyone,Books & Reference
+BN Pro ArialXL-b HD Text,LIBRARIES_AND_DEMO,4.0,24,478k,1000,Free,0,Everyone,Libraries & Demo
+2017 BN SM Sales Conference,BUSINESS,4.1,2,10M,100,Free,0,Teen,Business
+BN Inscript Improved Input keyboard,PRODUCTIVITY,4.2,0,6.2M,10,Free,0,Everyone,Productivity
+BN Pro Percent White HD Text,LIBRARIES_AND_DEMO,4.0,45,335k,5000,Free,0,Everyone,Libraries & Demo
+RTVBN,NEWS_AND_MAGAZINES,3.7,533,3.8M,50000,Free,0,Everyone,News & Magazines
+BN Pro White HD Text,LIBRARIES_AND_DEMO,4.1,120,782k,10000,Free,0,Everyone,Libraries & Demo
+BN Pro Roboto-b Neon HD Text,LIBRARIES_AND_DEMO,4.4,30,721k,5000,Free,0,Everyone,Libraries & Demo
+BN Pro LcdD HD Text,LIBRARIES_AND_DEMO,4.0,50,430k,5000,Free,0,Everyone,Libraries & Demo
+BN Pro LcdD-b HD Text,LIBRARIES_AND_DEMO,3.9,131,429k,10000,Free,0,Everyone,Libraries & Demo
+BN Pro Solid Battery-White,LIBRARIES_AND_DEMO,3.6,7,192k,1000,Free,0,Everyone,Libraries & Demo
+BN Pro Battery Level-White,LIBRARIES_AND_DEMO,4.2,21,200k,5000,Free,0,Everyone,Libraries & Demo
+BN MALLORCA Radio,COMMUNICATION,4.2,23,13M,1000,Free,0,Everyone,Communication
+"Calendars (En, Bn, Ar)",PRODUCTIVITY,4.6,27,2.5M,1000,Free,0,Everyone,Productivity
+BN Habitat - Property Experts - Buy | Sell | Rent,BUSINESS,4.1,0,8.9M,50,Free,0,Everyone,Business
+BN Pro Play HD Text,LIBRARIES_AND_DEMO,4.4,63,417k,5000,Free,0,Everyone,Libraries & Demo
+Yuzu eReader,FAMILY,1.9,250,Varies with device,50000,Free,0,Everyone,Education
+BN Pro RobotoXL HD Text,LIBRARIES_AND_DEMO,4.3,15,460k,1000,Free,0,Everyone,Libraries & Demo
+New York Mysteries (Full),GAME,4.5,514,5.9M,5000,Paid,$6.99,Teen,Adventure
+BN Pro ArialXL-b Neon HD Text,LIBRARIES_AND_DEMO,4.1,66,728k,10000,Free,0,Everyone,Libraries & Demo
+BN Pro Black Text,LIBRARIES_AND_DEMO,3.8,18,496k,1000,Free,0,Everyone,Libraries & Demo
+BN Pro BlueICS HD Text,LIBRARIES_AND_DEMO,4.1,174,816k,10000,Free,0,Everyone,Libraries & Demo
+The Legacy (Full),GAME,4.6,144,6.3M,1000,Paid,$6.99,Everyone,Adventure
+BN Pro Arial Legacy Text,LIBRARIES_AND_DEMO,3.7,83,414k,10000,Free,0,Everyone,Libraries & Demo
+BN Pro Black Text on White,LIBRARIES_AND_DEMO,3.9,53,334k,10000,Free,0,Everyone,Libraries & Demo
+BN Pro White Text,LIBRARIES_AND_DEMO,4.4,50,506k,5000,Free,0,Everyone,Libraries & Demo
+Sam.BN,TOOLS,4.0,83,2.0M,1000,Free,0,Everyone,Tools
+Bangla Calendar 1425: (EN-BN-AR) Holiday,LIFESTYLE,4.5,31,2.3M,1000,Free,0,Everyone,Lifestyle
+BN DB1 App,PRODUCTIVITY,4.2,2,34M,50,Free,0,Everyone,Productivity
+BN Inscript Improved Keyboard,PRODUCTIVITY,4.2,0,7.5M,10,Free,0,Everyone,Productivity
+Badoo - Free Chat & Dating App,SOCIAL,4.3,3781467,Varies with device,100000000,Free,0,Mature 17+,Social
+Skip-Bo™,GAME,4.4,33661,60M,100000,Paid,$2.99,Everyone,Card
+Skip-Bo™ Free,GAME,3.5,46801,60M,1000000,Free,0,Everyone,Card
+Beck & Bo: Toddler First Words,FAMILY,4.3,41,7.9M,1000,Paid,$2.99,Everyone,Education;Pretend Play
+Bubble Bo-Bo,FAMILY,4.5,65,24M,10000,Free,0,Everyone,Casual
+Boom Beach,FAMILY,4.5,5591653,95M,50000000,Free,0,Everyone 10+,Strategy
+Red Ball 4,GAME,4.4,1432447,59M,50000000,Free,0,Everyone,Arcade
+Bo's Bedtime Story,FAMILY,4.2,13,23M,1000,Paid,$2.49,Everyone,Education;Pretend Play
+Skater Boy,GAME,4.3,1167143,12M,100000000,Free,0,Everyone,Arcade
+Sic Bo,GAME,4.3,1,11M,100,Paid,$1.99,Teen,Card
+FX LITE BO,FINANCE,3.6,73,14M,10000,Free,0,Everyone,Finance
+Casual Sic Bo (骰寶),FAMILY,4.0,3,2.2M,500,Free,0,Teen,Casual
+Sic Bo Online! Free Casino,GAME,3.8,488,30M,100000,Free,0,Teen,Casino
+Dr.Dice - Sic bo analyzer,FAMILY,4.2,2,8.5M,10,Paid,$46.99,Everyone,Entertainment
+Bo's Matching Game,FAMILY,4.2,3,19M,1000,Paid,$0.99,Everyone,Education;Brain Games
+Hambo,GAME,4.4,125578,17M,5000000,Free,0,Everyone,Action
+HBO GO: Stream with TV Package,FAMILY,3.8,87734,32M,10000000,Free,0,Teen,Entertainment
+Sic Bo Rave,GAME,3.9,164,33M,10000,Free,0,Teen,Card
+Thai Sic Bo,GAME,4.1,14283,4.2M,1000000,Free,0,Teen,Casino
+Bo's Dinnertime Story,FAMILY,4.3,6,33M,1000,Paid,$2.49,Everyone,Education;Pretend Play
+BOO! - Next Generation Messenger,SOCIAL,3.5,20675,96M,1000000,Free,0,Teen,Social
+Socle Commun BO du 23-04-2015,LIBRARIES_AND_DEMO,4.2,4,4.7M,100,Paid,$0.99,Everyone,Libraries & Demo
+Wishbone - Compare Anything,SOCIAL,4.3,51569,26M,1000000,Free,0,Teen,Social
+Bee.Bo,LIFESTYLE,4.1,11,23M,1000,Free,0,Everyone,Lifestyle
+Bo's School Day,FAMILY,4.7,10,30M,1000,Paid,$2.99,Everyone,Education;Pretend Play
+Bounce Classic,GAME,4.5,38297,6.4M,10000000,Free,0,Everyone,Arcade
+Habbo - Virtual World,FAMILY,3.8,159398,28M,5000000,Free,0,Teen,Role Playing
+Bomber Friends,GAME,4.5,776730,49M,10000000,Free,0,Everyone 10+,Action
+Sic Bo (Tai Xiu) - Multiplayer Casino,GAME,4.2,152,16M,10000,Free,0,Teen,Casino
+Power Spheres by BoBoiBoy,FAMILY,4.3,70903,51M,5000000,Free,0,Everyone,Puzzle;Brain Games
+Bo Aung Din,EVENTS,4.1,110,2.6M,5000,Free,0,Teen,Events
+No Crop & Square for Instagram,PHOTOGRAPHY,4.6,819694,25M,10000000,Free,0,Everyone,Photography
+Township,FAMILY,4.6,4451317,Varies with device,50000000,Free,0,Everyone,Casual
+Hungry Shark World,GAME,4.5,1243017,27M,50000000,Free,0,Teen,Action
+Go-Go-Goat! Free Game,FAMILY,4.5,66740,23M,1000000,Free,0,Everyone,Arcade;Action & Adventure
+BPme - Mobile Fuel Payment & BP Driver Rewards app,TRAVEL_AND_LOCAL,3.0,69,31M,10000,Free,0,Everyone,Travel & Local
+My BP Lab,HEALTH_AND_FITNESS,2.6,186,25M,10000,Free,0,Everyone,Health & Fitness
+BP World Energy,BUSINESS,3.4,25,16M,10000,Free,0,Everyone,Business
+iBP Blood Pressure,MEDICAL,4.4,578,704k,10000,Paid,$0.99,Everyone,Medical
+Blood Pressure,MEDICAL,4.2,33033,7.4M,5000000,Free,0,Everyone,Medical
+BP and Sugar Test Prank,LIFESTYLE,4.0,7808,5.0M,1000000,Free,0,Everyone,Lifestyle
+Blood Pressure Log - MyDiary,MEDICAL,4.7,8347,2.6M,500000,Free,0,Everyone,Medical
+iFORA BP,MEDICAL,3.4,18,45M,1000,Free,0,Everyone,Medical
+MbH BP,MEDICAL,3.7,9,23M,1000,Free,0,Everyone,Medical
+Blood Pressure(BP) Diary,MEDICAL,3.7,3596,8.4M,1000000,Free,0,Everyone,Medical
+Cardio Journal — Blood Pressure Log,MEDICAL,4.5,3320,8.3M,100000,Free,0,Everyone,Medical
+Blood Pressure Info,FAMILY,3.9,174423,7.9M,10000000,Free,0,Everyone,Entertainment
+BP Journal - Blood Pressure Diary,MEDICAL,5.0,6,26M,1000,Free,0,Everyone,Medical
+Blood Pressure Monitor,MEDICAL,4.3,17,6.0M,10000,Free,0,Everyone,Medical
+Blood Pressure Companion,MEDICAL,4.2,178,4.8M,1000,Paid,$0.99,Everyone,Medical
+Monitor My BP,HEALTH_AND_FITNESS,4.3,0,4.6M,50,Paid,$5.99,Everyone,Health & Fitness
+MedM Blood Pressure,MEDICAL,4.0,255,16M,10000,Free,0,Everyone,Medical
+Free Blood Pressure,MEDICAL,4.2,7,5.7M,5000,Free,0,Everyone,Medical
+"Diabetes, Blood Pressure, Health Tracker App",MEDICAL,4.5,309,5.9M,10000,Free,0,Everyone,Medical
+Blood Pressure(BP) Report Lite,MEDICAL,4.0,91,335k,10000,Free,0,Everyone,Medical
+bp e-store,BOOKS_AND_REFERENCE,4.4,52,2.2M,1000,Free,0,Everyone,Books & Reference
+Wireless BP,MEDICAL,1.8,30,887k,500,Free,0,Everyone,Medical
+BP Tracker,HEALTH_AND_FITNESS,4.3,12,613k,1000,Free,0,Everyone,Health & Fitness
+BP Log lite,LIFESTYLE,5.0,3,1.5M,100,Free,0,Everyone,Lifestyle
+MI-BP,HEALTH_AND_FITNESS,5.0,1,12M,50,Free,0,Everyone,Health & Fitness
+BP Service,BUSINESS,4.1,0,26M,100,Free,0,Everyone,Business
+BP-Tech,FAMILY,3.2,12,13M,1000,Free,0,Everyone,Casual
+Blood Pressure Log - bpresso.com,MEDICAL,4.2,5661,Varies with device,500000,Free,0,Everyone,Medical
+Blood Pressure Diary,FAMILY,4.6,47,3.3M,5000,Free,0,Everyone,Simulation
+High Blood Pressure,MEDICAL,3.8,4,2.9M,1000,Free,0,Everyone,Medical
+Simple Blood Pressure log,MEDICAL,3.9,31,10M,1000,Free,0,Everyone,Medical
+BP Tracker-Symptoms & Solution,MEDICAL,4.2,34,3.2M,1000,Free,0,Everyone,Medical
+Compas BP Store,SHOPPING,4.3,0,2.5M,10,Free,0,Everyone,Shopping
+Blood Pressure Tracker,MEDICAL,4.0,11,1.8M,1000,Free,0,Everyone,Medical
+Hypertension Hi blood pressure,MEDICAL,3.8,292,2.7M,100000,Free,0,Everyone,Medical
+BP Scanner Prank,FAMILY,4.1,157,7.0M,50000,Free,0,Everyone,Entertainment
+Deep Breathe BP,HEALTH_AND_FITNESS,3.9,26,12M,1000,Free,0,Everyone,Health & Fitness
+bpresso PRO,MEDICAL,4.4,515,Varies with device,1000,Paid,$5.49,Everyone,Medical
+BP Toolbox,HEALTH_AND_FITNESS,2.1,32,9.6M,1000,Free,0,Everyone,Health & Fitness
+bp Magazine for Bipolar,LIFESTYLE,1.8,5,18M,1000,Free,0,Everyone 10+,Lifestyle
+Blood Pressure - Heartcare,MEDICAL,4.2,70,1.9M,10000,Free,0,Everyone,Medical
+UM BP Track,MEDICAL,2.0,1,29M,50,Free,0,Everyone,Medical
+BP Assist,TOOLS,4.0,0,9.4M,100,Free,0,Everyone,Tools
+BP Fitness Lead Scanner,EVENTS,4.4,0,6.7M,1,Paid,$109.99,Everyone,Events
+Blood pressure,HEALTH_AND_FITNESS,3.4,2256,1.6M,500000,Free,0,Everyone,Health & Fitness
+High Blood Pressure Symptoms,MEDICAL,4.3,46,2.0M,10000,Free,0,Everyone,Medical
+BQ Camera,PHOTOGRAPHY,3.6,2526,Varies with device,1000000,Free,0,Everyone,Photography
+BQ Services,TOOLS,3.7,5004,2.5M,1000000,Free,0,Everyone,Tools
+BQ-መጽሐፍ ቅዱሳዊ ጥያቄዎች,GAME,4.7,191,7.2M,5000,Free,0,Everyone,Trivia
+"Brilliant Quotes: Life, Love, Family & Motivation",BOOKS_AND_REFERENCE,4.5,67186,6.3M,1000000,Free,0,Everyone 10+,Books & Reference
+BQ Scan,TOOLS,4.6,18,4.0M,100,Free,0,Everyone,Tools
+Add-On: bq (a),PRODUCTIVITY,3.6,26,1.2M,5000,Free,0,Everyone,Productivity
+BQ Partners,COMMUNICATION,4.2,0,Varies with device,1000,Free,0,Everyone,Communication
+gardening ideas flower diy,HOUSE_AND_HOME,4.2,0,5.6M,100,Free,0,Everyone,House & Home
+Software Update,TOOLS,4.4,8259,3.5M,1000000,Free,0,Everyone,Tools
+RoboPad,FAMILY,4.6,41,9.2M,1000,Free,0,Everyone,Education
+Add-On: bq (c),PRODUCTIVITY,4.2,17,1.2M,1000,Free,0,Everyone,Productivity
+BQ Llicència,SPORTS,4.2,18,Varies with device,5000,Free,0,Everyone,Sports
+Wherever BQ,TRAVEL_AND_LOCAL,4.1,7,18M,50,Free,0,Teen,Travel & Local
+Bono’s Pit Bar-B-Q,FAMILY,2.3,3,36M,1000,Free,0,Everyone 10+,Entertainment
+Add-On: bq (b),PRODUCTIVITY,4.2,9,1.2M,1000,Free,0,Everyone,Productivity
+bq magazine,NEWS_AND_MAGAZINES,4.1,2,8.8M,50,Free,0,Everyone,News & Magazines
+QR Scanner & Barcode Scanner 2018,PRODUCTIVITY,3.8,8211,4.1M,5000000,Free,0,Everyone,Productivity
+Bill Miller Bar-B-Q Store Ops,BUSINESS,4.1,0,2.5M,100,Free,0,Everyone,Business
+BQ Scanner,TOOLS,3.0,2,2.7M,100,Free,0,Everyone,Tools
+Bar-B-Q Rib House,FOOD_AND_DRINK,5.0,2,33M,50,Free,0,Everyone,Food & Drink
+Gold Wallpapers,PERSONALIZATION,4.5,43,28M,10000,Free,0,Everyone,Personalization
+[Substratum] M5 Theme,PERSONALIZATION,4.4,16,6.7M,5000,Free,0,Everyone,Personalization
+Zowi App,FAMILY,4.5,516,21M,50000,Free,0,Everyone,Education;Education
+Bar-B-Q Recipes,FOOD_AND_DRINK,4.8,18,3.5M,5000,Free,0,Everyone,Food & Drink
+System Update Free,TOOLS,4.3,3068,6.0M,100000,Free,0,Everyone,Tools
+Camera FV-5,PHOTOGRAPHY,3.8,16317,Varies with device,100000,Paid,$3.95,Everyone,Photography
+Bar BQ Tonight Dublin,LIFESTYLE,4.1,0,22M,50,Free,0,Everyone,Lifestyle
+Camera MX - Free Photo & Video Camera,PHOTOGRAPHY,4.3,244302,Varies with device,10000000,Free,0,Everyone,Photography
+Woody's Bar-B-Q,FOOD_AND_DRINK,3.7,3,27M,1000,Free,0,Everyone,Food & Drink
+Launcher Oreo 8.1,PERSONALIZATION,4.5,13466,3.4M,500000,Free,0,Everyone,Personalization
+Theme for Android 7.0,PERSONALIZATION,4.3,0,Varies with device,5000,Free,0,Everyone,Personalization
+Free antivirus and VPN,TOOLS,4.3,27749,16M,1000000,Free,0,Everyone,Tools
+Jimbo's Pit Bar B-Q,FOOD_AND_DRINK,4.2,3,12M,100,Free,0,Everyone,Food & Drink
+RoboPad++,FAMILY,4.4,77,10M,10000,Free,0,Everyone,Education
+IKEA Store,SHOPPING,3.4,25515,Varies with device,10000000,Free,0,Everyone,Shopping
+Simple Gallery,TOOLS,4.5,28030,9.0M,1000000,Free,0,Everyone,Tools
+Pick-a-Paint,LIFESTYLE,1.6,242,36M,50000,Free,0,Everyone,Lifestyle
+Miller's Bar B-Q,FOOD_AND_DRINK,4.2,0,12M,50,Free,0,Everyone,Food & Drink
+BAR-B-Q Recipes,FOOD_AND_DRINK,4.2,0,3.6M,100,Free,0,Everyone,Food & Drink
+Left vs Right: Brain Training,FAMILY,4.5,75719,30M,5000000,Free,0,Everyone,Educational
+Bar BQ Night Middlesbrough,SHOPPING,4.3,0,19M,100,Free,0,Teen,Shopping
+BQ Wings,FOOD_AND_DRINK,4.2,1,13M,50,Free,0,Everyone,Food & Drink
+Bible Quizzer - The App for Bible Quizzers,FAMILY,4.2,0,33M,100,Free,0,Everyone,Education
+Texas Bar-B-Q Rewards,FOOD_AND_DRINK,4.2,0,14M,5,Free,0,Everyone,Food & Drink
+4-T's Bar-BQ & Catering,SHOPPING,4.3,0,243k,10,Free,0,Everyone,Shopping
+"Zetup, print in one click",TOOLS,4.0,40,24M,1000,Free,0,Everyone,Tools
+"Bleacher Report: sports news, scores, & highlights",SPORTS,4.4,122280,Varies with device,5000000,Free,0,Everyone 10+,Sports
+Baskin-Robbins,FOOD_AND_DRINK,3.8,1103,6.6M,100000,Free,0,Everyone,Food & Drink
+Infinity Dungeon VIP,FAMILY,4.3,21804,44M,1000000,Paid,$0.99,Everyone 10+,Role Playing
+Carros Rebaixados BR,GAME,4.3,20691,89M,1000000,Free,0,Everyone,Racing
+BR,LIFESTYLE,3.0,859,3.5M,100000,Free,0,Everyone,Lifestyle
+Bleacher Report Live,SPORTS,4.0,232,32M,50000,Free,0,Everyone,Sports
+Cardboard,LIBRARIES_AND_DEMO,4.2,130287,50M,10000000,Free,0,Everyone,Libraries & Demo
+QR Code Pro,PRODUCTIVITY,4.8,5865,15M,100000,Paid,$4.49,Everyone,Productivity
+BR Video Player,VIDEO_PLAYERS,4.0,46,3.1M,5000,Free,0,Everyone,Video Players & Editors
+Br. Parking - Busy road Parking 3D 2018,FAMILY,4.5,41,30M,5000,Free,0,Everyone,Simulation
+Br video editing,FAMILY,4.2,1,34M,100,Free,0,Everyone,Entertainment
+B R Telco FCU Mobile Banking,FINANCE,4.7,413,13M,10000,Free,0,Everyone,Finance
+BR Chat Bot,SOCIAL,1.9,16,2.6M,1000,Free,0,Everyone,Social
+Br Browser,SOCIAL,4.9,29,2.5M,500,Free,0,Everyone,Social
+TV Guide BR Gold,FAMILY,4.4,544,Varies with device,5000,Paid,$1.49,Everyone,Entertainment
+Dr B R Ambedkar (Jai Bhim),SOCIAL,4.7,2068,7.5M,100000,Free,0,Everyone,Social
+Tv Br News,FAMILY,4.2,4,569k,100,Free,0,Everyone,Entertainment
+Br Shafi,FAMILY,4.9,1288,26M,10000,Free,0,Everyone,Education
+Dr. B.R.Ambedkar,SOCIAL,4.8,1902,5.2M,100000,Free,0,Everyone,Social
+cronometra-br,PRODUCTIVITY,4.2,0,5.4M,0,Paid,$154.99,Everyone,Productivity
+Táxi Nacional BR,MAPS_AND_NAVIGATION,4.1,88,9.1M,5000,Free,0,Everyone,Maps & Navigation
+Texas HoldEm Poker Deluxe (BR),GAME,4.5,1418,26M,10000,Free,0,Teen,Casino
+BR Classified,BUSINESS,4.1,0,28M,50,Free,0,Everyone,Business
+Top BR Chaya Songs,FAMILY,4.2,0,3.8M,10,Free,0,Everyone,Entertainment
+Companion for Fortnite & Fortnite Battle Royale,FAMILY,4.6,2736,Varies with device,100000,Free,0,Everyone,Entertainment
+Mu Mobile BR,BUSINESS,4.5,43,92M,100,Free,0,Everyone,Business
+Cube BR LWP simple,PERSONALIZATION,4.3,19,206k,1000,Free,0,Everyone,Personalization
+Brick Breaker BR,GAME,5.0,7,19M,5,Free,0,Everyone,Arcade
+Mu Elite BR,BUSINESS,4.1,30,93M,100,Free,0,Everyone 10+,Business
+BR Series,VIDEO_PLAYERS,3.9,1016,13M,50000,Free,0,Teen,Video Players & Editors
+Loteria BR,FAMILY,4.2,0,1.8M,50,Free,0,Everyone,Entertainment
+Vidroid.com.br,NEWS_AND_MAGAZINES,4.1,49,10M,5000,Free,0,Everyone,News & Magazines
+CJ - BR MEMES,COMICS,4.3,109,3.5M,10000,Free,0,Everyone,Comics
+CINE BR,VIDEO_PLAYERS,4.1,23,7.5M,1000,Free,0,Everyone,Video Players & Editors
+Vlogger Go Viral - Tuber Game,FAMILY,4.8,1304467,68M,10000000,Free,0,Everyone,Strategy
+Next Portuguese(BR) Langpack,TOOLS,4.3,1320,778k,100000,Free,0,Everyone,Tools
+BR Ambedkar Biography & Quotes,BOOKS_AND_REFERENCE,4.6,156,2.1M,10000,Free,0,Everyone,Books & Reference
+B R COACHINGS,FAMILY,4.2,1,9.2M,10,Free,0,Everyone,Education
+B. R. Ambedkar Jayanti SMS,PERSONALIZATION,4.3,0,3.0M,500,Free,0,Everyone,Personalization
+Black Commando | Special Ops | FPS Shooting,GAME,4.1,1167,72M,100000,Free,0,Teen,Action
+GearBest Online Shopping,SHOPPING,4.5,245104,35M,5000000,Free,0,Everyone,Shopping
+iPlayIT for YouTube VR Player,VIDEO_PLAYERS,4.3,5879,Varies with device,1000000,Free,0,Teen,Video Players & Editors
+True Skateboarding Ride Skateboard Game Freestyle,GAME,3.8,8175,31M,1000000,Free,0,Everyone 10+,Arcade
+Bullshit! (Free),GAME,2.4,45,4.1M,10000,Free,0,Teen,Card
+BSPlayer FREE,VIDEO_PLAYERS,4.3,138337,Varies with device,10000000,Free,0,Everyone,Video Players & Editors
+Bullshite!,GAME,2.8,48,13M,10000,Free,0,Teen,Card
+Block Strike,GAME,4.5,947515,60M,10000000,Free,0,Teen,Action
+Loved by King Bs,FAMILY,4.6,5546,85M,100000,Free,0,Everyone,Simulation
+BombSquad Remote,GAME,4.1,13304,1.3M,1000000,Free,0,Everyone,Arcade
+BSPlayer,VIDEO_PLAYERS,4.2,4585,Varies with device,50000,Paid,$5.99,Everyone,Video Players & Editors
+BS CS IT & SE,FAMILY,4.6,9,6.9M,1000,Free,0,Everyone,Education
+BSPlayer ARMv7 VFP CPU support,VIDEO_PLAYERS,4.3,9966,5.5M,1000000,Free,0,Everyone,Video Players & Editors
+Marked by King Bs,FAMILY,4.6,70335,58M,500000,Free,0,Teen,Simulation
+COMSATS BOOK STORE FOR BS(CS),FAMILY,5.0,15,94M,50,Free,0,Everyone,Education
+BS-Mobile,COMMUNICATION,5.0,1,683k,50,Free,0,Everyone,Communication
+BS Meter (Ad Supported),FAMILY,3.9,14,592k,1000,Free,0,Teen,Entertainment
+BS Calendar / Patro / पात्रो,PRODUCTIVITY,4.2,218,Varies with device,50000,Free,0,Everyone,Productivity
+Simulator Brawl Box for BS,FAMILY,3.9,168,6.4M,5000,Free,0,Everyone,Simulation
+BS Generator,FAMILY,4.2,5,3.3M,100,Free,0,Everyone,Entertainment
+BS Match Maker Premium,TOOLS,4.0,3,319k,10,Paid,$0.99,Everyone,Tools
+BS Films,FAMILY,4.2,1,24M,100,Free,0,Everyone,Entertainment
+BS Tractor,GAME,4.3,3,36M,100,Free,0,Everyone,Racing
+BS player remote,VIDEO_PLAYERS,3.5,54,186k,10000,Free,0,Everyone,Video Players & Editors
+BibApp TU BS,FAMILY,4.2,16,3.5M,1000,Free,0,Everyone,Education
+King of B.S.,FAMILY,4.0,4,840k,100,Free,0,Everyone,Education
+BS Chopper,GAME,4.3,0,41M,100,Free,0,Everyone,Racing
+BS Play,FAMILY,3.7,56,1.5M,5000,Free,0,Everyone,Education
+B@dL!bs Lite,GAME,3.8,10,36M,1000,Free,0,Mature 17+,Word
+BS Battery+,TOOLS,4.3,269,647k,50000,Free,0,Everyone,Tools
+ATC Unico BS,COMMUNICATION,4.2,10,5.3M,500,Free,0,Everyone,Communication
+Revista BS,NEWS_AND_MAGAZINES,4.1,10,19M,100,Free,0,Everyone,News & Magazines
+BS MAPS,MAPS_AND_NAVIGATION,4.5,6,2.5M,50,Free,0,Everyone,Maps & Navigation
+Beauty Rental Shop,FAMILY,4.6,11480,93M,100000,Free,0,Everyone,Simulation
+BS Where Am I,TOOLS,4.0,9,2.8M,50,Free,0,Everyone,Tools
+Bsc Agri Notes,FAMILY,4.5,301,5.6M,10000,Free,0,Everyone,Education
+Love Signal: D-Mate,FAMILY,4.3,1895,72M,50000,Free,0,Everyone,Simulation
+BSC IT,FAMILY,4.4,847,21M,10000,Free,0,Everyone,Education
+BS TRACK CLIENT,TOOLS,4.0,0,191k,10,Free,0,Everyone,Tools
+Kiosko BS,NEWS_AND_MAGAZINES,4.1,55,22M,1000,Free,0,Everyone,News & Magazines
+Sleeping Delivery,FAMILY,4.6,19640,67M,100000,Free,0,Teen,Simulation
+BS Detector - Diss 'n' Gauges,FAMILY,4.2,0,842k,50,Paid,$1.49,Everyone,Entertainment
+CABLE SIZE CALCULATOR BS 7671,TOOLS,3.9,333,1.1M,100000,Free,0,Everyone,Tools
+Corporate B.S. Generator,BUSINESS,4.1,0,6.9M,10,Free,0,Everyone,Business
+Banco Sabadell App. Your mobile bank,FINANCE,3.9,25205,Varies with device,1000000,Free,0,Everyone,Finance
+Strætó.is,MAPS_AND_NAVIGATION,3.1,742,15M,100000,Free,0,Everyone,Maps & Navigation
+VOLT DROP CALCULATOR BS 7671,TOOLS,3.9,71,1.1M,10000,Free,0,Everyone,Tools
+BSc Ag Entrance Preparation,FAMILY,4.4,138,6.2M,10000,Free,0,Everyone,Education
+17th Edition Cable Sizer,BOOKS_AND_REFERENCE,4.4,47,1.4M,1000,Paid,$3.08,Everyone,Books & Reference
+Black Survival,FAMILY,4.4,48451,52M,1000000,Free,0,Teen,Strategy
+Black Social,SOCIAL,4.6,22,8.7M,1000,Free,0,Teen,Social
+BTNotification,TOOLS,3.9,15665,373k,5000000,Free,0,Everyone,Tools
+Little Magnet BT,TOOLS,4.6,3703,3.8M,100000,Free,0,Everyone,Tools
+BT Notifier,TOOLS,2.5,2794,3.8M,1000000,Free,0,Everyone,Tools
+Little Magnet BT Pro,TOOLS,4.6,251,3.8M,1000,Paid,$0.99,Everyone,Tools
+Bt Notifier -Smartwatch notice,TOOLS,2.8,632,8.2M,500000,Free,0,Everyone,Tools
+BT One Voice mobile access,COMMUNICATION,4.0,32,437k,5000,Free,0,Everyone,Communication
+BT One Mobile secure access,BUSINESS,3.4,54,5.7M,10000,Free,0,Everyone,Business
+BT Communicator,SOCIAL,3.8,32,1.6M,10000,Free,0,Teen,Social
+BT One Voice anywhere,BUSINESS,4.5,80,16M,10000,Free,0,Everyone,Business
+BT Find Address for Bluetooth,BUSINESS,4.8,8,2.6M,5000,Free,0,Everyone,Business
+BT Camera,PHOTOGRAPHY,3.3,1307,6.6M,500000,Free,0,Everyone,Photography
+BT Messenger,COMMUNICATION,3.9,97,598k,50000,Free,0,Everyone,Communication
+BT One Phone Mobile App,COMMUNICATION,3.5,33,2.7M,10000,Free,0,Everyone,Communication
+BitTorrent®- Torrent Downloads,VIDEO_PLAYERS,4.5,641219,Varies with device,10000000,Free,0,Everyone,Video Players & Editors
+SW-100.tch by Callstel,COMMUNICATION,4.0,1926,716k,1000000,Free,0,Everyone,Communication
+BT App,NEWS_AND_MAGAZINES,4.1,24,14M,1000,Free,0,Everyone,News & Magazines
+BT MeetMe with Dolby Voice,COMMUNICATION,3.6,437,12M,100000,Free,0,Everyone,Communication
+ProGrade BT,TOOLS,4.0,0,46M,500,Free,0,Everyone,Tools
+BT Share It,BUSINESS,4.7,12,13M,500,Free,0,Everyone,Business
+Bluetooth Auto Connect,COMMUNICATION,3.9,20829,1.9M,5000000,Free,0,Everyone,Communication
+Wifi BT Scanner,FAMILY,5.0,2,1.2M,500,Free,0,Everyone,Education
+Ultimate Control BT,BUSINESS,4.6,14,4.3M,500,Free,0,Everyone,Business
+BT Controller,TOOLS,3.9,4374,13M,1000000,Free,0,Everyone,Tools
+BT Church,LIFESTYLE,4.9,26,8.4M,1000,Free,0,Teen,Lifestyle
+Mediatek SmartDevice,TOOLS,3.6,11187,7.3M,1000000,Free,0,Everyone,Tools
+LG BT Reader Plus,TOOLS,3.7,2992,585k,500000,Free,0,Everyone,Tools
+BT Mobile,MAPS_AND_NAVIGATION,3.9,22,3.2M,1000,Free,0,Everyone,Maps & Navigation
+MagicLight BT,LIFESTYLE,2.7,135,6.5M,10000,Free,0,Everyone,Lifestyle
+Bluetooth Control BT->uC FREE,TOOLS,3.8,67,2.7M,10000,Free,0,Everyone,Tools
+B.T.,NEWS_AND_MAGAZINES,2.8,636,1.4M,100000,Free,0,Everyone,News & Magazines
+Autool BT-BOX,TOOLS,3.5,4,17M,500,Free,0,Everyone,Tools
+BT Remote (SPP) for Bluetooth,TOOLS,4.1,36,3.1M,10000,Free,0,Everyone,Tools
+BT Satmeter,TOOLS,4.0,0,2.4M,100,Free,0,Everyone,Tools
+Battery Notifier Pro BT,TOOLS,4.7,1363,1.6M,10000,Paid,$2.59,Everyone,Tools
+BT Panorama,FINANCE,4.3,34,Varies with device,5000,Free,0,Everyone,Finance
+Battery Notifier BT Free,TOOLS,4.5,21979,982k,1000000,Free,0,Everyone,Tools
+"BT Dating -Find your match, help cupid, be social",SOCIAL,4.1,158,26M,50000,Free,0,Mature 17+,Social
+BT (Usage Interne),LIBRARIES_AND_DEMO,4.2,3,19M,100,Free,0,Everyone,Libraries & Demo
+BT Position Sender - Bluetooth Position Sender,TOOLS,4.0,0,2.9M,10,Free,0,Everyone,Tools
+Aegis BT,BUSINESS,4.8,16,4.5M,500,Free,0,Everyone,Business
+BT Master,FAMILY,4.2,0,222k,100,Free,0,Everyone,Education
+OSRAM BT Control,TOOLS,4.0,2,42M,1000,Free,0,Everyone,Tools
+Vip视频免费看-BT磁力搜索,TOOLS,4.0,20,7.9M,1000,Free,0,Everyone,Tools
+AudioBT: BT audio GPS/SMS/Text,COMMUNICATION,3.4,198,219k,50000,Free,0,Everyone,Communication
+Jabbla BT,TOOLS,5.0,3,55k,100,Free,0,Everyone,Tools
+BT Speed,SPORTS,4.2,3,948k,10,Paid,$4.80,Everyone,Sports
+USB BT Wi-Fi Color Terminal Modem,TOOLS,4.0,0,7.3M,5,Paid,$8.99,Everyone,Tools
+SenseView BT Zephyr Sensor,TOOLS,4.3,37,323k,5000,Free,0,Everyone,Tools
+Bu the Baby Bunny - Cute pet care game,FAMILY,4.4,37122,89M,1000000,Free,0,Everyone,Educational
+Boston University Alumni,FAMILY,1.8,5,5.2M,1000,Free,0,Everyone,Education
+BU Bus Tracker,MAPS_AND_NAVIGATION,4.2,57,15M,10000,Free,0,Everyone,Maps & Navigation
+kick the buddy,GAME,3.3,294,19M,10000,Free,0,Everyone,Arcade
+BU Bookstore,SHOPPING,4.3,2,7.6M,1000,Free,0,Everyone,Shopping
+BU Study,FAMILY,5.0,7,5.6M,10,Free,0,Everyone,Education
+BU Dental GoGoldman,TRAVEL_AND_LOCAL,4.1,0,18M,100,Free,0,Everyone,Travel & Local
+Bu Hangi Uygulama ?,FAMILY,4.2,1,24M,10,Free,0,Everyone,Puzzle
+BU Questrom Launch,TRAVEL_AND_LOCAL,4.1,3,10M,100,Free,0,Everyone,Travel & Local
+sustainability@BU,LIFESTYLE,4.8,10,11M,1000,Free,0,Everyone,Lifestyle
+BU School of Public Health,TRAVEL_AND_LOCAL,4.1,0,29M,10,Free,0,Everyone,Travel & Local
+BU Mobile,FAMILY,4.5,472,4.3M,10000,Free,0,Everyone,Education
+Barisal University App-BU Face,FAMILY,5.0,100,10M,1000,Free,0,Everyone,Education
+"Pu - Cute giant panda bear, baby pet care game",FAMILY,4.5,22167,88M,1000000,Free,0,Everyone,Educational
+BU Students' Rep. Council,FAMILY,4.7,38,5.3M,500,Free,0,Everyone,Education
+On a Bu Pour Vous OBPV,LIFESTYLE,4.1,0,5.4M,10,Free,0,Teen,Lifestyle
+BU Calculator,FAMILY,4.6,69,3.1M,1000,Free,0,Everyone,Education
+BU Beauty Rooms,BEAUTY,4.3,1,6.0M,50,Free,0,Everyone,Beauty
+Bu Hangi Firma?,FAMILY,4.2,8,26M,100,Free,0,Everyone,Trivia;Education
+BU Syllabus,FAMILY,4.5,38,6.5M,1000,Free,0,Everyone,Education
+Bu Hangi Ünlü?,GAME,4.3,1,19M,10,Free,0,Everyone,Trivia
+Bu Nedir ?,GAME,4.3,0,33M,50,Free,0,Everyone,Trivia
+BU Bison Nation,SPORTS,3.5,4,40M,100,Free,0,Everyone,Sports
+Kim Bu Youtuber?,FAMILY,4.2,11,9.2M,1000,Free,0,Everyone,Puzzle
+BU HANGİ ŞARKI ? - 2018,GAME,4.3,4,28M,100,Free,0,Everyone,Trivia
+BU Library,FAMILY,3.5,4,21M,1000,Free,0,Everyone,Education
+SkyTest BU/GU Lite,BUSINESS,2.9,28,20M,500,Paid,$17.99,Everyone,Business
+BU Alsace,BOOKS_AND_REFERENCE,4.3,3,4.0M,100,Free,0,Everyone,Books & Reference
+Bu Hangi Oyun ?,GAME,4.3,2,26M,50,Free,0,Everyone,Word
+Catholic La Bu Zo Kam,BOOKS_AND_REFERENCE,5.0,23,Varies with device,500,Free,0,Everyone,Books & Reference
+Bu Hangi Youtuber ?,GAME,4.3,31,26M,1000,Free,0,Everyone,Trivia
+Nedir Bu ?,GAME,4.3,0,33M,10,Free,0,Everyone,Trivia
+Bu Hangi Film ?,FAMILY,4.2,3,25M,100,Free,0,Everyone,Puzzle
+Khrifa Hla Bu (Solfa),BOOKS_AND_REFERENCE,4.3,0,44M,10,Free,0,Everyone,Books & Reference
+Kick the Buddy,GAME,4.3,1004709,Varies with device,50000000,Free,0,Teen,Action
+Bu Hangi Dizi ?,GAME,4.3,14,19M,1000,Free,0,Everyone,Trivia
+Kristian Hla Bu,BOOKS_AND_REFERENCE,4.8,238,27M,10000,Free,0,Everyone,Books & Reference
+SA HLA BU,BOOKS_AND_REFERENCE,4.7,119,1.5M,1000,Free,0,Everyone,Books & Reference
+Bubble Witch 2 Saga,FAMILY,4.3,2838064,Varies with device,100000000,Free,0,Everyone,Casual
+Büfe BU,LIFESTYLE,4.1,14,13M,100,Free,0,Everyone,Lifestyle
+BV Mobile Apps,PRODUCTIVITY,5.0,3,4.8M,100,Free,0,Everyone,Productivity
+BV,COMMUNICATION,5.0,3,1.6M,100,Free,0,Everyone,Communication
+Bacterial Vaginosis,HEALTH_AND_FITNESS,4.3,1,4.9M,100,Free,0,Everyone,Health & Fitness
+Bacterial Vaginosis 🇺🇸,HEALTH_AND_FITNESS,4.3,1,3.5M,500,Free,0,Teen,Health & Fitness
+Bacterial Vaginosis Symptoms & Treatment,MEDICAL,4.2,0,8.7M,500,Free,0,Everyone,Medical
+Bacteria Vaginosis,HEALTH_AND_FITNESS,4.0,4015,7.7M,1000000,Free,0,Mature 17+,Health & Fitness
+Hilverda De Boer B.V. App,SHOPPING,4.3,5,19M,500,Free,0,Everyone,Shopping
+BV Smart,BUSINESS,4.3,28,3.4M,1000,Free,0,Everyone,Business
+BV Forest,BUSINESS,4.1,0,2.9M,100,Free,0,Everyone,Business
+Bacterial Vaginosis Symptoms,MEDICAL,4.1,698,2.4M,100000,Free,0,Everyone 10+,Medical
+BV Sridhara Maharaj,FAMILY,5.0,8,2.7M,100,Free,0,Everyone,Entertainment
+BV Aventure,TRAVEL_AND_LOCAL,4.1,0,5.0M,100,Free,0,Everyone,Travel & Local
+Bacterial vaginosis Treatment - Sexual disease,HEALTH_AND_FITNESS,5.0,2,5.9M,500,Free,0,Everyone,Health & Fitness
+BV Link,BUSINESS,4.1,10,2.8M,100,Free,0,Everyone,Business
+Bacterial Vaginosis Treatment,MEDICAL,4.2,0,3.4M,50,Free,0,Everyone,Medical
+BV Bombers,SPORTS,4.2,0,12M,100,Free,0,Everyone,Sports
+Schulman B.V.,SHOPPING,4.0,6,20M,100,Free,0,Everyone,Shopping
+BV MAAp,BUSINESS,4.1,9,4.2M,100,Free,0,Everyone,Business
+BV Taxi - Driver,MAPS_AND_NAVIGATION,4.1,1,10M,10,Free,0,Everyone,Maps & Navigation
+BV Taxi Sudan,MAPS_AND_NAVIGATION,3.5,8,26M,10,Free,0,Everyone,Maps & Navigation
+van Gennip Textiles BV,LIFESTYLE,4.1,1,4.0M,100,Free,0,Everyone,Lifestyle
+bacterial vaginosis,MEDICAL,4.2,0,3.6M,10,Free,0,Teen,Medical
+PIO bv App,BUSINESS,4.1,2,98M,10,Free,0,Everyone,Business
+Meu Cartão BV,FINANCE,4.1,15057,5.7M,500000,Free,0,Everyone,Finance
+BV Rando,TRAVEL_AND_LOCAL,4.1,0,3.6M,100,Free,0,Everyone,Travel & Local
+Kovax Europe B.V.,BUSINESS,4.1,17,96M,500,Free,0,Everyone,Business
+StartPage Private Search,LIFESTYLE,4.6,10198,2.2M,100000,Free,0,Everyone,Lifestyle
+DHV accountancy BV,BUSINESS,4.1,0,10M,10,Free,0,Everyone,Business
+BV Frankfurt inside,SPORTS,4.2,3,4.8M,50,Free,0,Everyone,Sports
+BV Teknisk App,BUSINESS,4.1,0,2.0M,50,Free,0,Everyone,Business
+TomTom GPS Navigation Traffic,MAPS_AND_NAVIGATION,4.1,132792,62M,10000000,Free,0,Everyone,Maps & Navigation
+Maps & GPS Navigation — OsmAnd,MAPS_AND_NAVIGATION,4.2,60820,Varies with device,5000000,Free,0,Everyone,Maps & Navigation
+OLX Uganda Sell Buy Cellphones,SHOPPING,4.2,4977,9.8M,100000,Free,0,Everyone,Shopping
+Feel Performer,COMMUNICATION,2.2,62,34M,10000,Free,0,Everyone,Communication
+Smashy Road: Arena,GAME,4.3,45558,53M,5000000,Free,0,Everyone 10+,Action
+My Budget Book,FINANCE,4.7,19784,7.3M,100000,Paid,$2.99,Everyone,Finance
+VictronConnect,TOOLS,3.8,400,Varies with device,50000,Free,0,Everyone,Tools
+BV Productions,BUSINESS,4.1,0,2.8M,1,Free,0,Everyone,Business
+Allsetra B.V.,BUSINESS,4.1,15,24M,1000,Free,0,Everyone,Business
+PIO bv Transport App,BUSINESS,4.1,0,73M,5,Free,0,Everyone,Business
+Philips Hue,LIFESTYLE,3.1,10006,53M,1000000,Free,0,Everyone,Lifestyle
+Evolution: Battle for Utopia,FAMILY,4.2,246705,27M,1000000,Free,0,Teen,Strategy
+Home Remedies for Bacterial Infections,HEALTH_AND_FITNESS,4.3,0,4.4M,50,Free,0,Everyone,Health & Fitness
+Best Western To Go,TRAVEL_AND_LOCAL,3.0,2719,17M,100000,Free,0,Teen,Travel & Local
+BW-Go,GAME,4.8,265,1.3M,1000,Paid,$3.49,Everyone,Board
+BW Smart,TOOLS,3.7,50,19M,5000,Free,0,Everyone,Tools
+Watch Face BW Inter,PERSONALIZATION,3.1,112,8.8M,1000,Paid,$0.99,Everyone,Personalization
+BW-Go Free,GAME,4.6,547,1.3M,10000,Free,0,Everyone,Board
+BlitzWolf Shutter - BW Shutter,PHOTOGRAPHY,2.9,333,1.8M,50000,Free,0,Everyone,Photography
+Black & White Camera - Lovely BW,PHOTOGRAPHY,4.2,329,4.8M,100000,Free,0,Everyone,Photography
+BW-Joseki,GAME,4.7,705,1.8M,10000,Free,0,Everyone,Board
+BW-DGS plugin,GAME,4.5,70,691k,1000,Free,0,Everyone,Board
+BW App,LIFESTYLE,2.8,48,12M,5000,Free,0,Everyone,Lifestyle
+Learn SAP BW,BOOKS_AND_REFERENCE,4.3,2,20M,500,Free,0,Everyone,Books & Reference
+Next Launcher 3D Theme Stun-BW,PERSONALIZATION,4.4,2839,5.1M,100000,Free,0,Everyone,Personalization
+Standard Chartered Mobile (BW),FINANCE,4.4,96,7.2M,10000,Free,0,Everyone,Finance
+BW Mobilbanking für Smartphone und Tablet,FINANCE,4.1,2048,24M,100000,Free,0,Everyone,Finance
+BW COMPANY FINDER,BUSINESS,4.6,48,7.4M,1000,Free,0,Everyone,Business
+BW Taxi,MAPS_AND_NAVIGATION,3.0,67,53M,5000,Free,0,Everyone,Maps & Navigation
+BW-GnuGo,GAME,4.1,64,1.3M,5000,Free,0,Everyone,Board
+Beautiful Widgets Pro,PERSONALIZATION,4.2,97890,14M,1000000,Paid,$2.49,Everyone,Personalization
+BW SmartLife,TOOLS,4.0,0,8.8M,100,Free,0,Everyone,Tools
+Bw Events,EVENTS,4.4,16,1.7M,100,Free,0,Everyone,Events
+Beautiful Widgets Free,PERSONALIZATION,3.9,25035,14M,1000000,Free,0,Everyone,Personalization
+Learn SAP BW on HANA,BOOKS_AND_REFERENCE,4.3,0,13M,500,Free,0,Everyone,Books & Reference
+Analog BW - Camera filter effect foto film retouch,PHOTOGRAPHY,4.2,2,17M,100,Free,0,Everyone,Photography
+BW Ultra,PRODUCTIVITY,4.2,0,24M,10,Free,0,Everyone,Productivity
+BW-IVMS,PRODUCTIVITY,4.2,0,17M,100,Free,0,Everyone,Productivity
+HD Widgets,PERSONALIZATION,4.3,58614,26M,1000000,Paid,$0.99,Everyone,Personalization
+BW Wallpaper,PERSONALIZATION,4.5,4,511k,50,Free,0,Everyone,Personalization
+Skull Widget BW,PERSONALIZATION,4.5,4,1.7M,10,Free,0,Everyone,Personalization
+BW Map mobile,TRAVEL_AND_LOCAL,3.6,57,32M,10000,Free,0,Everyone,Travel & Local
+Bell and Wyson Camera BW Pix +,LIFESTYLE,2.0,8,12M,1000,Free,0,Everyone,Lifestyle
+Best Western e-Concierge Hotel,TRAVEL_AND_LOCAL,4.0,41,23M,10000,Free,0,Everyone,Travel & Local
+BlackCam Pro - B&W Camera,PHOTOGRAPHY,4.5,1376,5.5M,100000,Paid,$1.49,Everyone,Photography
+SAP BW Tutorial,FAMILY,4.0,11,9.4M,1000,Free,0,Everyone,Education
+Kromium BW Theme for NEXT,PERSONALIZATION,4.3,1098,18M,50000,Free,0,Everyone,Personalization
+IP address BW,PRODUCTIVITY,4.2,7,1.8M,500,Free,0,Everyone,Productivity
+Color Changer Pro [root],PERSONALIZATION,4.5,69,951k,1000,Paid,$0.99,Everyone,Personalization
+Fantasy theme dark bw black building,ART_AND_DESIGN,4.8,41,1.9M,5000,Free,0,Everyone,Art & Design
+Keyboard Theme Gate Flat BW,PERSONALIZATION,4.5,75,2.6M,10000,Free,0,Mature 17+,Personalization
+BW Switch,GAME,4.3,1,13M,10,Free,0,Everyone,Arcade
+Tutorials for SAP BW Offline,FAMILY,4.2,1,16M,100,Free,0,Everyone,Education
+BL Essentials BW Icon Pack,PERSONALIZATION,4.2,17,963k,1000,Free,0,Everyone,Personalization
+Hypocam,PHOTOGRAPHY,4.5,12572,8.5M,1000000,Free,0,Everyone,Photography
+Hitman GO,FAMILY,4.6,84114,23M,500000,Paid,$0.99,Everyone 10+,Puzzle
+BW Fuhlenbrock,SPORTS,4.2,4,8.2M,100,Free,0,Everyone,Sports
+BW eServices,BUSINESS,4.1,1,3.8M,10,Free,0,Everyone,Business
+B&W Photo Filter Editor,PHOTOGRAPHY,3.9,205,2.4M,50000,Free,0,Everyone,Photography
+BW t&t,PRODUCTIVITY,4.2,2,1.7M,10,Free,0,Everyone,Productivity
+EBook For SAP BW ON HANA Learning Free,FAMILY,4.2,0,10M,50,Free,0,Everyone,Education
+BX Memo,FAMILY,4.3,131,2.0M,5000,Free,0,Everyone,Education
+Bixby Button Remapper - bxActions Pro / Coffee,TOOLS,3.9,319,25k,10000,Paid,$2.99,Everyone,Tools
+Bixby Button Remapper - bxActions,TOOLS,4.3,13064,4.6M,1000000,Free,0,Everyone,Tools
+Bitcoin BX Thailand,FINANCE,3.7,120,31M,10000,Free,0,Everyone,Finance
+Bx Thailand Alert (Bitcoin),FINANCE,4.7,3,8.2M,100,Free,0,Everyone,Finance
+bX Hot Articles by Ex Libris,FAMILY,4.3,42,554k,5000,Free,0,Everyone,Education
+Bitcoin BX Thailand PRO,FINANCE,1.7,21,21M,100,Paid,$4.99,Everyone,Finance
+Bitcoin Bx (Thailand),FINANCE,4.5,101,6.9M,10000,Free,0,Everyone,Finance
+Bx-WiFi-GI,VIDEO_PLAYERS,4.1,0,21M,100,Free,0,Everyone,Video Players & Editors
+BX Mobile TMC for SAP B1,BUSINESS,4.7,3,11M,100,Free,0,Everyone,Business
+BX Thailand - Crypto Tracking & Analyse Bitcoin,FINANCE,4.1,2,34M,100,Free,0,Everyone,Finance
+BxPort - Bitcoin Bx (Thailand),FINANCE,5.0,4,4.1M,50,Free,0,Everyone,Finance
+Bx Access 4d,TOOLS,4.0,1,1.9M,100,Free,0,Everyone,Tools
+bX Thailand Simple Market Price and Alert,FINANCE,4.1,8,3.5M,1000,Free,0,Everyone,Finance
+QR & Barcode Scanner BX PRO,TOOLS,4.0,4,3.0M,1000,Free,0,Everyone,Tools
+BX Diff - Crypto Coins Checker,FINANCE,4.6,83,4.0M,5000,Free,0,Everyone,Finance
+bitcoin exchange bx thailand,FINANCE,2.9,19,2.2M,5000,Free,0,Everyone,Finance
+CSHS BX,FAMILY,4.2,0,18M,100,Free,0,Everyone,Education
+Bitcoin & Cryptocurrency - Bx,FINANCE,4.8,11,3.7M,1000,Free,0,Everyone,Finance
+Benefit Extras Mobile App,HEALTH_AND_FITNESS,2.3,3,2.4M,1000,Free,0,Everyone,Health & Fitness
+Kick Axe Bx,HEALTH_AND_FITNESS,4.3,0,9.3M,1,Free,0,Everyone,Health & Fitness
+Car Driving Simulator Citroen,FAMILY,3.8,174,44M,10000,Free,0,Everyone,Simulation
+LEDSHOWTW,TOOLS,4.2,5,31M,500,Free,0,Everyone,Tools
+C3-C4-PİCASSO-ELYSEE RACİNG,GAME,4.3,12,48M,1000,Free,0,Everyone,Arcade
+Water Surfer Floating BMX Bicycle Rider Racing,FAMILY,4.4,551,38M,100000,Free,0,Everyone,Simulation
+Driving Cars Simulator Citroen,GAME,4.3,3,49M,100,Free,0,Everyone,Racing
+RC Monster Truck - Offroad Driving Simulator,GAME,4.0,38448,27M,5000000,Free,0,Everyone,Racing
+Tiny Call Confirm,COMMUNICATION,4.1,22782,351k,1000000,Free,0,Everyone,Communication
+Casa de Bolsa Bx+ Móvil,FINANCE,3.4,5,8.8M,500,Free,0,Everyone,Finance
+Super Jabber Jump,GAME,4.3,85882,23M,10000000,Free,0,Everyone,Arcade
+Commando Adventure Assassin,GAME,4.0,51067,48M,5000000,Free,0,Teen,Action
+Limbo PC Emulator QEMU ARM x86,TOOLS,4.2,13005,9.7M,1000000,Free,0,Everyone,Tools
+Lollipop Launcher Plus,PERSONALIZATION,4.1,131,27k,1000,Paid,$4.99,Everyone,Personalization
+Crypto Tracker by BitScreener,FINANCE,4.7,396,12M,10000,Free,0,Everyone,Finance
+City Builder 2016: County Mall,FAMILY,4.2,41693,74M,1000000,Free,0,Everyone,Simulation
+Fists For Fighting (Fx3),SPORTS,3.9,138739,44M,10000000,Free,0,Teen,Sports
+Train driving simulator,FAMILY,3.8,91645,36M,10000000,Free,0,Teen,Simulation
+Roulette Advisor LITE,GAME,4.1,41,1.4M,5000,Free,0,Everyone,Casino
+Mini Motor Racing WRT,GAME,4.2,107497,Varies with device,1000000,Free,0,Everyone,Racing
+BMX Boy Bike Stunt Rider Game,GAME,3.8,299,25M,10000,Free,0,Everyone,Racing
+"CoinMarketApp - CryptoCurrency Portfolio, News,ICO",FINANCE,4.7,20535,Varies with device,500000,Free,0,Everyone,Finance
+Best Friends Dress Up & Makeup,FAMILY,3.7,7664,44M,500000,Free,0,Everyone,Casual;Pretend Play
+World of Warriors: Duel,GAME,4.3,25952,36M,500000,Free,0,Everyone 10+,Action
+Trinomial Factoring Wizard,TOOLS,4.0,22,82k,1000,Paid,$0.99,Everyone,Tools
+Driving Zone,GAME,4.2,51791,57M,1000000,Free,0,Everyone,Racing
+Bitcoin Ticker Widget,FINANCE,4.6,25744,Varies with device,500000,Free,0,Everyone,Finance
+Quadratic Equation Solver with Steps and Graphs,FAMILY,4.7,513,9.8M,50000,Free,0,Everyone,Education
+Color by Number – New Coloring Book,GAME,4.7,142308,24M,5000000,Free,0,Everyone 10+,Board
+Car Race by Fun Games For Free,GAME,4.3,54221,47M,1000000,Free,0,Everyone,Racing
+Adult Color By Number Book: Number Coloring Pages,FAMILY,4.2,2231,37M,500000,Free,0,Everyone,Entertainment
+Glitter Color By Number - Glitter Number Coloring,FAMILY,3.5,1380,6.9M,500000,Free,0,Everyone,Entertainment
+Sandbox - Color by Number Coloring Pages,FAMILY,4.7,412744,10M,10000000,Free,0,Everyone,Entertainment;Creativity
+Sandbox Art-Sandbox Color by Number Coloring Pages,FAMILY,4.7,12784,15M,1000000,Free,0,Everyone,Entertainment
+One Today by Google,LIFESTYLE,4.5,2586,9.4M,100000,Free,0,Everyone,Lifestyle
+Art Pixel Coloring. Color by Number.,FAMILY,4.5,992,49M,100000,Free,0,Teen,Entertainment
+Color By Number - Sandbox Pixel Coloring Book,FAMILY,4.7,24557,24M,1000000,Free,0,Everyone,Casual;Creativity
+PixelDot - Color by Number Sandbox Pixel Art,FAMILY,4.6,16041,7.3M,1000000,Free,0,Everyone,Entertainment
+Slot Machines by IGG,GAME,4.6,267229,24M,10000000,Free,0,Teen,Casino
+PixPanda - Color by Number Pixel Art Coloring Book,FAMILY,4.9,55723,14M,1000000,Free,0,Everyone,Entertainment
+Sandbox Number Coloring Book Art - Color By Number,FAMILY,4.2,14356,Varies with device,1000000,Free,0,Everyone,Entertainment;Brain Games
+Adult Color by Number Book - Paint Mandala Pages,FAMILY,4.3,997,Varies with device,100000,Free,0,Everyone,Entertainment
+Photo Editor by Aviary,PHOTOGRAPHY,4.4,1490722,21M,50000000,Free,0,Everyone,Photography
+No.Color – Color by Number,FAMILY,4.4,23474,8.8M,5000000,Free,0,Everyone,Casual;Creativity
+PixBox Coloring - Color by number Sandbox,FAMILY,4.5,12293,4.0M,1000000,Free,0,Everyone,Entertainment
+"3D Color by Number: Voxel, Unicorn, Pixel Art 3D",FAMILY,4.3,2017,Varies with device,100000,Free,0,Everyone,Entertainment
+Pixelmania - Color by number & create pixel art,FAMILY,4.4,3588,18M,500000,Free,0,Everyone,Entertainment
+Valentines love color by number-Pixel art coloring,FAMILY,4.4,767,18M,100000,Free,0,Everyone,Entertainment
+Rized ‼️ Color By Number & Pixel Coloring Book,FAMILY,3.0,1279,13M,100000,Free,0,Everyone,Casual
+Pixyfy: coloring by number coloring book,FAMILY,4.8,22290,13M,500000,Free,0,Everyone,Puzzle
+Draw Color by Number - Sandbox Pixel Art,FAMILY,4.7,34279,24M,1000000,Free,0,Everyone,Casual;Creativity
+Project Fi by Google,TOOLS,4.6,7342,Varies with device,1000000,Free,0,Everyone,Tools
+Tattoo Color By Number Draw Book Page Pixel Art,FAMILY,4.0,309,25M,100000,Free,0,Everyone,Entertainment
+SegPlay Mobile Paint by Number,FAMILY,3.7,1478,43M,100000,Free,0,Everyone,Casual
+Paint By Number,FAMILY,3.5,807,4.6M,500000,Free,0,Everyone,Casual
+Color by Disney,FAMILY,2.7,5706,47M,500000,Free,0,Everyone,Entertainment
+Bingo by IGG: Top Bingo+Slots!,GAME,4.7,183343,20M,5000000,Free,0,Teen,Casino
+Painting By Numbers,FAMILY,4.1,213,26M,50000,Free,0,Everyone,Puzzle;Brain Games
+3D Color by Number with Voxels,FAMILY,4.5,5481,69M,500000,Free,0,Everyone,Entertainment
+Butterfly Pixel Art - coloring by number,FAMILY,4.6,769,13M,100000,Free,0,Everyone,Entertainment
+Best Hairstyles step by step,BEAUTY,4.5,45452,9.2M,5000000,Free,0,Everyone,Beauty
+Halloween Sandbox Number Coloring- Color By Number,FAMILY,4.4,289,19M,100000,Free,0,Everyone,Entertainment
+"Fiesta by Tango - Find, Meet and Make New Friends",SOCIAL,4.3,112223,34M,1000000,Free,0,Mature 17+,Social
+"Poly Art: Paint by Sticker, Color by Number Puzzle",FAMILY,4.4,2100,Varies with device,100000,Free,0,Everyone,Entertainment;Brain Games
+"Pixel art pro-Sand box,paint by number,number draw",FAMILY,4.5,2442,13M,100000,Free,0,Everyone,Casual;Brain Games
+Color by Number: Pixel Art,FAMILY,4.6,12034,34M,1000000,Free,0,Everyone,Entertainment
+UNICORN - Color By Number & Pixel Art Coloring,FAMILY,4.7,8264,24M,500000,Free,0,Everyone,Art & Design;Creativity
+FunnyPixels - Color by number Sandbox,FAMILY,4.6,1977,3.8M,100000,Free,0,Everyone,Entertainment
+Color By Numbers - Art Game for Kids and Adults,FAMILY,3.1,305,8.3M,100000,Free,0,Everyone,Educational;Brain Games
+Elmo Calls by Sesame Street,FAMILY,3.9,6903,25M,1000000,Free,0,Everyone,Educational;Pretend Play
+Voxel - 3D Color by Number & Pixel Coloring Book,GAME,4.7,62561,53M,1000000,Free,0,Everyone,Board
+No.Diamond – Colors by Number,FAMILY,4.6,9016,24M,1000000,Free,0,Everyone,Entertainment;Creativity
+BZ Reminder,BUSINESS,4.7,41625,5.4M,1000000,Free,0,Everyone,Business
+B.Z. Live-Ticker,NEWS_AND_MAGAZINES,4.1,114,7.7M,10000,Free,0,Everyone,News & Magazines
+420 BZ Budeze Delivery,MEDICAL,5.0,2,11M,100,Free,0,Mature 17+,Medical
+Weather BZ,WEATHER,4.4,8433,5.6M,100000,Free,0,Everyone,Weather
+BZ Reminder PRO,BUSINESS,4.8,726,5.4M,1000,Paid,$3.99,Everyone,Business
+BZ Bingo,FAMILY,4.2,1,17M,100,Free,0,Everyone,Entertainment
+Evasion.bz,SOCIAL,4.1,8,4.4M,100,Free,0,Teen,Social
+BZ Berner Zeitung E-Paper,NEWS_AND_MAGAZINES,4.1,4,Varies with device,1000,Free,0,Everyone,News & Magazines
+BZ-Smart,NEWS_AND_MAGAZINES,4.3,828,8.2M,10000,Free,0,Everyone,News & Magazines
+BZ Zombie VR,GAME,4.4,12,98M,1000,Free,0,Mature 17+,Action
+BZ Conferencing,TOOLS,4.7,7,29M,1000,Free,0,Everyone,Tools
+GITZ.bz,SHOPPING,4.0,4,2.4M,10,Free,0,Everyone,Shopping
+Berner Zeitung,NEWS_AND_MAGAZINES,3.4,736,8.5M,50000,Free,0,Teen,News & Magazines
+BZ Fingers,GAME,4.6,15,3.2M,50,Free,0,Everyone,Arcade
+Dragon B.Z Wallpapers,PERSONALIZATION,4.3,0,3.8M,10,Free,0,Everyone,Personalization
+bz Basellandschaftliche News,NEWS_AND_MAGAZINES,2.8,33,33M,1000,Free,0,Everyone,News & Magazines
+BZ Langenthaler Tagblatt E-Paper,NEWS_AND_MAGAZINES,4.1,0,Varies with device,10,Free,0,Everyone,News & Magazines
+24/7 BZ Reis,TRAVEL_AND_LOCAL,3.1,421,53M,100000,Free,0,Everyone,Travel & Local
+BZ Delivery,SHOPPING,4.3,1,6.2M,500,Free,0,Everyone,Shopping
+Badische Zeitung,NEWS_AND_MAGAZINES,3.9,262,22M,10000,Free,0,Everyone,News & Magazines
+Dragon BZ Wallpapers HD,PERSONALIZATION,4.3,5,17M,1000,Free,0,Everyone,Personalization
+bz Baselland E-Paper,NEWS_AND_MAGAZINES,4.2,69,25M,5000,Free,0,Everyone,News & Magazines
+BZWBK24 mobile,FINANCE,4.5,64983,39M,1000000,Free,0,Everyone,Finance
+BZ Dealer,PRODUCTIVITY,4.2,5,4.6M,500,Free,0,Everyone,Productivity
+BZ Vesper-App,TRAVEL_AND_LOCAL,4.1,60,13M,1000,Free,0,Everyone,Travel & Local
+BZ-Digital,NEWS_AND_MAGAZINES,4.1,4,36M,100,Free,0,Everyone,News & Magazines
+Dragon BZ Super Wallpapers,FAMILY,4.2,12,13M,1000,Free,0,Everyone,Entertainment
+BZ Berner Oberländer,NEWS_AND_MAGAZINES,4.1,64,8.5M,1000,Free,0,Everyone,News & Magazines
+bz Basel E-Paper,NEWS_AND_MAGAZINES,4.1,72,25M,5000,Free,0,Everyone,News & Magazines
+Südtirol2Go,MAPS_AND_NAVIGATION,3.3,555,31M,50000,Free,0,Everyone,Maps & Navigation
+TFO BZ Lessons,FAMILY,4.4,75,3.7M,500,Free,0,Everyone,Education
+BZ Langenthaler Tagblatt,VIDEO_PLAYERS,4.1,22,8.5M,1000,Free,0,Everyone,Video Players & Editors
+City Driving Jeep Mania: Parking Passion 2018,FAMILY,4.4,36,24M,10000,Free,0,Everyone,Simulation
+Sniper Gun Shot 3D: Impossible Missions,GAME,4.6,20,34M,100,Free,0,Mature 17+,Action
+ePN Cashback AliExpress,SHOPPING,4.4,19212,6.9M,500000,Free,0,Everyone,Shopping
+Elite Commando Shooting War,GAME,4.5,14,45M,100,Free,0,Teen,Action
+Restaurantführer Südbaden,TRAVEL_AND_LOCAL,4.1,46,12M,1000,Free,0,Everyone,Travel & Local
+bz Basel News,NEWS_AND_MAGAZINES,2.2,23,33M,1000,Free,0,Everyone,News & Magazines
+Contractor City Construction - Heavy Logistics,FAMILY,4.2,31,35M,5000,Free,0,Everyone,Simulation
+Park Limousine: Realistic Limo Parking Simulator,FAMILY,4.8,4,25M,1000,Free,0,Everyone,Simulation
+Animal Hunting: Sniper Shooting,GAME,4.3,0,48M,50,Free,0,Teen,Action
+WISE- MOBILE PORTAL,TOOLS,4.0,3,1.0M,500,Free,0,Everyone,Tools
+Inwestor mobile,FINANCE,3.2,124,7.2M,10000,Free,0,Everyone,Finance
+BZ Straußenführer,TRAVEL_AND_LOCAL,4.3,291,14M,10000,Free,0,Everyone,Travel & Local
+Zoosk Dating App: Meet Singles,DATING,4.0,516917,Varies with device,10000000,Free,0,Mature 17+,Dating
+Putzmeister Experts,TOOLS,4.6,21,8.9M,1000,Free,0,Everyone,Tools
+Filmi Gaane,FAMILY,4.4,572,Varies with device,100000,Free,0,Everyone,Entertainment
+Bubble,TOOLS,4.5,31621,208k,5000000,Free,0,Everyone,Tools
+iBiznes24 mobile,FINANCE,4.1,38,9.4M,5000,Free,0,Everyone,Finance
+CA Service Management,BUSINESS,3.4,91,8.3M,10000,Free,0,Everyone,Business
+CA Mobile Authenticator,BUSINESS,4.1,9,6.9M,1000,Free,0,Everyone,Business
+CA Latam Partners,BUSINESS,4.1,0,12M,10,Free,0,Everyone,Business
+CA Mobile OTP,TOOLS,3.3,688,5.5M,100000,Free,0,Everyone,Tools
+CA Lottery Official App,FAMILY,4.2,7000,26M,1000000,Free,0,Teen,Entertainment
+CA Technologies,FAMILY,4.2,1,98M,100,Free,0,Everyone,Puzzle
+CA Case Management,BUSINESS,2.4,16,5.2M,500,Free,0,Everyone,Business
+CA UIM Mobile,BUSINESS,3.2,54,7.7M,1000,Free,0,Everyone,Business
+CA Clarity Mobile Time Manager,BUSINESS,3.1,104,5.3M,10000,Free,0,Everyone,Business
+CA Auth ID,TOOLS,3.8,39,375k,10000,Free,0,Teen,Tools
+Patchcord.ca Inc. App Launcher,BUSINESS,4.1,0,3.7M,10,Free,0,Everyone,Business
+CA Speakers Free,LIFESTYLE,4.8,74,2.9M,5000,Free,0,Teen,Lifestyle
+CA World '17,PRODUCTIVITY,3.7,7,18M,1000,Free,0,Teen,Productivity
+CA DMV,TOOLS,4.2,5463,6.0M,1000000,Free,0,Everyone,Tools
+Save.ca,SHOPPING,3.7,2094,34M,100000,Free,0,Everyone,Shopping
+California Cop Assist CA Cop,PRODUCTIVITY,3.0,5,7.0M,100,Paid,$4.99,Everyone,Productivity
+CA Laws 2018 (California Laws and Codes),BOOKS_AND_REFERENCE,3.9,56,38M,5000,Free,0,Everyone,Books & Reference
+California Cameras - Traffic,TRAVEL_AND_LOCAL,4.0,305,5.4M,10000,Free,0,Everyone,Travel & Local
+CA Speakers,LIFESTYLE,5.0,12,1.2M,100,Paid,$0.99,Teen,Lifestyle
+Register.ca Mobile,PRODUCTIVITY,4.2,0,1.2M,100,Free,0,Everyone,Productivity
+CB Radio Chat - for friends!,COMMUNICATION,4.0,17998,7.9M,1000000,Free,0,Teen,Communication
+Truck Chat & CB for Truckers,MAPS_AND_NAVIGATION,2.7,89,2.3M,10000,Free,0,Mature 17+,Maps & Navigation
+CB Frequencies FREE!,TOOLS,3.1,364,2.3M,100000,Free,0,Everyone,Tools
+CB On Mobile,COMMUNICATION,4.1,901,323k,100000,Free,0,Teen,Communication
+Cricbuzz - Live Cricket Scores & News,SPORTS,4.5,838738,Varies with device,50000000,Free,0,Everyone,Sports
+CB Frequencies,TOOLS,4.0,5,1.4M,100,Paid,$0.99,Everyone,Tools
+Virtual Walkie Talkie,COMMUNICATION,3.8,21785,2.5M,1000000,Free,0,Everyone,Communication
+CB Outdoors,FAMILY,3.8,5,12M,1000,Free,0,Everyone,Education
+Viking CB Radios,BUSINESS,4.3,6,15M,1000,Free,0,Everyone,Business
+Frequencies Free,TOOLS,3.5,382,3.1M,100000,Free,0,Everyone,Tools
+CB-Mobile Banking,FINANCE,4.5,96,12M,10000,Free,0,Everyone,Finance
+CBRadioTab,TOOLS,3.9,127,1.5M,50000,Free,0,Everyone,Tools
+CB SMART LIFE,TOOLS,4.0,30,9.0M,500,Free,0,Everyone,Tools
+CB Bank Mobile Banking,FINANCE,4.5,1308,3.7M,100000,Free,0,Everyone,Finance
+CB Martial Arts,HEALTH_AND_FITNESS,4.3,0,8.7M,10,Free,0,Everyone,Health & Fitness
+C.B. Shop,SHOPPING,4.3,19,19M,100,Free,0,Everyone,Shopping
+CB Underground,LIFESTYLE,3.3,3,7.4M,500,Free,0,Everyone,Lifestyle
+CB Background - Free HD Wallpaper Images,PERSONALIZATION,4.1,4538,3.3M,1000000,Free,0,Everyone,Personalization
+CB NFC Pendant,HEALTH_AND_FITNESS,4.3,0,913k,50,Free,0,Everyone,Health & Fitness
+WRLP CB Repeater,FAMILY,4.2,14,4.9M,1000,Free,0,Teen,Entertainment
+CB Fit,HEALTH_AND_FITNESS,5.0,1,7.8M,10,Free,0,Everyone,Health & Fitness
+Minwa HA ( C.B ),HOUSE_AND_HOME,4.2,0,5.0M,50,Free,0,Everyone,House & Home
+Channel 19,COMMUNICATION,3.7,916,12M,100000,Free,0,Mature 17+,Communication
+Citizens Bank - CB Mobile,FINANCE,4.8,6,11M,1000,Free,0,Everyone,Finance
+CB Mobile Access,FINANCE,1.5,57,25M,1000,Free,0,Everyone,Finance
+CB VIDEO VISION,PHOTOGRAPHY,5.0,13,2.6M,100,Free,0,Everyone,Photography
+CB Hair Png - New Hair Png For CB Editing,PHOTOGRAPHY,4.6,26,7.2M,500,Free,0,Everyone,Photography
+CB STARS,FAMILY,4.2,1,1.8M,10,Free,0,Everyone,Education
+CB Mobile,BUSINESS,4.1,3,2.6M,100,Free,0,Everyone,Business
+C B Patel Health Club,HEALTH_AND_FITNESS,5.0,5,14M,100,Free,0,Everyone,Health & Fitness
+CB Trader,FINANCE,4.7,11,2.2M,1000,Free,0,Everyone,Finance
+CB TV,FAMILY,4.2,2,1.9M,100,Free,0,Teen,Strategy
+Football-CB GO Clock Theme,PERSONALIZATION,4.7,26,5.6M,1000,Free,0,Everyone,Personalization
+CB SmartCAR Monitor,TOOLS,4.0,1,514k,10,Free,0,Everyone,Tools
+CB News,FAMILY,5.0,7,20M,50,Free,0,Everyone,Education
+CB Pay,FINANCE,4.5,198,11M,10000,Free,0,Everyone,Finance
+CB Mobile GA,FINANCE,4.1,1,12M,100,Free,0,Everyone,Finance
+CB Register,FAMILY,5.0,1,5.6M,10,Free,0,Everyone,Entertainment
+Cádiz CB Gades,SPORTS,4.2,1,3.8M,10,Free,0,Everyone,Sports
+CB Land,BUSINESS,4.1,0,6.4M,100,Free,0,Everyone,Business
+Cb browser,COMMUNICATION,5.0,5,3.7M,50,Free,0,Everyone,Communication
+CB Edits PNG & CB Backgrounds,PHOTOGRAPHY,4.2,17,3.4M,5000,Free,0,Everyone,Photography
+CB Mobile Biz,FINANCE,1.0,3,8.4M,500,Free,0,Everyone,Finance
+Antenna Tool Premium,TOOLS,4.5,14,2.9M,500,Paid,$0.99,Everyone,Tools
+Antenna Tool,TOOLS,4.2,522,2.9M,50000,Free,0,Everyone,Tools
+CB Heroes,SOCIAL,5.0,5,1.8M,5,Free,0,Everyone,Social
+Frequencies,TOOLS,4.2,11,3.1M,500,Paid,$0.99,Everyone,Tools
+Creative Destruction,GAME,4.4,201426,80M,5000000,Free,0,Teen,Action
+CD Library,PRODUCTIVITY,3.9,44,3.3M,10000,Free,0,Everyone,Productivity
+Sonic CD Classic,GAME,4.6,26138,15M,1000000,Free,0,Everyone,Action
+ARK: Survival Evolved,GAME,3.8,51523,36M,500000,Free,0,Teen,Adventure
+APagri CD,PRODUCTIVITY,4.2,5,Varies with device,10,Free,0,Everyone,Productivity
+Design innovation CD Cassette,LIFESTYLE,4.1,5,8.3M,500,Free,0,Everyone,Lifestyle
+DIY Crafts Cds,LIFESTYLE,4.0,209,3.1M,50000,Free,0,Everyone,Lifestyle
+CD Events,BUSINESS,4.1,1,9.5M,100,Free,0,Everyone,Business
+PRIMATURE.CD,NEWS_AND_MAGAZINES,4.1,6,4.8M,100,Free,0,Everyone,News & Magazines
+CD Roma's,BUSINESS,4.1,2,6.7M,100,Free,0,Everyone,Business
+CD Ready,BUSINESS,4.6,52,Varies with device,1000,Free,0,Everyone,Business
+INTERKINOIS.CD,NEWS_AND_MAGAZINES,4.1,1,1.5M,5,Free,0,Everyone,News & Magazines
+CD Live - Club del Deportista,LIFESTYLE,4.1,8,9.2M,500,Free,0,Everyone,Lifestyle
+Bootable Methods(USB-CD-DVD),BOOKS_AND_REFERENCE,3.4,37,3.4M,10000,Free,0,Everyone,Books & Reference
+Creative CD Letter Holder,LIFESTYLE,4.1,0,13M,10,Free,0,Everyone,Lifestyle
+CD CHOICE TUBE,FAMILY,5.0,10,5.8M,500,Free,0,Everyone,Entertainment
+My Movies Pro - Movie & TV Collection Library,LIFESTYLE,4.6,6477,20M,10000,Paid,$7.99,Everyone,Lifestyle
+CD View Lite,TOOLS,4.0,2,20M,100,Free,0,Everyone,Tools
+CD - Teach me ABC English L1,FAMILY,4.2,2,63M,500,Free,0,Everyone,Education
+Best Design CD Ideas,LIFESTYLE,4.1,0,13M,10,Free,0,Everyone,Lifestyle
+CD Carpe Diem App,FAMILY,4.2,17,27M,100,Free,0,Everyone,Education
+Yazdani Cd Center EllahAbad Official App,FAMILY,5.0,8,3.8M,500,Free,0,Everyone,Entertainment
+CD JUANITO,SPORTS,4.2,6,16M,500,Free,0,Everyone,Sports
+CD Music,LIBRARIES_AND_DEMO,4.2,1,2.3M,100,Free,0,Everyone,Libraries & Demo
+DIY cd rom ideas,LIFESTYLE,4.1,5,12M,500,Free,0,Everyone,Lifestyle
+Easy DIY CD Craft Ideas,ART_AND_DESIGN,4.4,7,5.6M,5000,Free,0,Everyone,Art & Design
+Disc Label Print,TOOLS,3.0,262,37M,10000,Free,0,Everyone,Tools
+Kiosque CD,TRAVEL_AND_LOCAL,4.1,0,22M,5,Free,0,Everyone,Travel & Local
+CD-Zing,BUSINESS,3.8,70,Varies with device,1000,Free,0,Everyone,Business
+Nero AirBurn,VIDEO_PLAYERS,4.2,1008,1.7M,100000,Free,0,Everyone,Video Players & Editors
+CD COMET,MAPS_AND_NAVIGATION,4.3,12,2.6M,100,Free,0,Everyone,Maps & Navigation
+DIY Recycled CD Wall Art,LIFESTYLE,4.1,3,7.9M,1000,Free,0,Everyone,Lifestyle
+CD View,TOOLS,4.0,0,20M,500,Free,0,Everyone,Tools
+US 115th CD,TRAVEL_AND_LOCAL,4.1,0,5.7M,5,Free,0,Everyone,Travel & Local
+Билеты ПДД CD 2019 PRO,AUTO_AND_VEHICLES,4.2,21,16M,100,Paid,$1.49,Everyone,Auto & Vehicles
+STADE.CD,NEWS_AND_MAGAZINES,4.1,0,1.7M,5,Free,0,Everyone,News & Magazines
+OBJECTIFINFOS.CD,NEWS_AND_MAGAZINES,4.1,2,4.2M,50,Free,0,Everyone,News & Magazines
+DIY CD Craft Ideas,LIFESTYLE,4.4,5,4.6M,1000,Free,0,Everyone,Lifestyle
+РееI Smart Remote MP3 CD Player,TOOLS,3.2,27,2.7M,5000,Free,0,Everyone,Tools
+CD Padel Mora,SPORTS,4.2,1,7.2M,50,Free,0,Everyone,Sports
+Diligan CD VR,MEDICAL,4.2,1,46M,50,Free,0,Everyone,Medical
+CD Supply,BUSINESS,4.1,0,14M,5,Free,0,Mature 17+,Business
+Music Collector Inventory Organizer UPC Discogs,LIFESTYLE,3.5,155,12M,10000,Free,0,Everyone,Lifestyle
+CE on the go,TOOLS,4.4,79,3.7M,10000,Free,0,Everyone,Tools
+CE Map - Interactive Conan Exiles Map,MAPS_AND_NAVIGATION,4.5,62,1.6M,1000,Paid,$0.99,Everyone,Maps & Navigation
+CE Broker,FAMILY,3.7,190,12M,10000,Free,0,Everyone,Education
+CE Smart,TOOLS,5.0,3,29M,100,Free,0,Everyone,Tools
+PAC-MAN CE DX,GAME,4.5,1692,36M,10000,Paid,$4.99,Everyone,Arcade
+CEHQ - CE Credits for Nurses,FAMILY,4.5,12,4.0M,1000,Free,0,Everyone,Education
+Theatre of the Absurd CE(Full),FAMILY,4.1,1143,15M,10000,Paid,$2.99,Everyone 10+,Casual
+CE SmartApp.com,BUSINESS,4.1,0,42M,100,Free,0,Everyone,Business
+OE TRACKER CE Attendance App,MEDICAL,3.4,16,7.8M,5000,Free,0,Everyone,Medical
+Professor Online SEDUC-CE,FAMILY,4.1,188,4.6M,10000,Free,0,Everyone,Education
+ABAI CE Scanner,FAMILY,4.2,0,4.3M,1000,Free,0,Everyone,Education
+C-E Federal Credit Union,FINANCE,4.1,1,2.8M,500,Free,0,Everyone,Finance
+TI-84 CE Graphing Calculator Manual TI 84,FAMILY,5.0,1,27M,100,Paid,$4.99,Everyone,Education
+Ultra CE calculator,SPORTS,4.2,28,7.3M,1000,Free,0,Everyone,Sports
+Shiver: Moonlit Grove CE,FAMILY,4.1,3433,23M,50000,Free,0,Everyone 10+,Casual
+Beast of Lycan Isle CE,FAMILY,4.1,2683,20M,50000,Free,0,Everyone 10+,Casual
+QUI EST CE ?,FAMILY,4.2,7,5.4M,1000,Free,0,Everyone,Puzzle
+Volvo CE Insider,BUSINESS,4.2,45,24M,1000,Free,0,Everyone,Business
+Grim Tales: The Wishes CE,GAME,4.3,4923,20M,100000,Free,0,Everyone 10+,Adventure
+AC CE BJT Actorial,FAMILY,4.2,1,1.4M,50,Paid,$2.00,Everyone,Education
+MCQ CE IT,FAMILY,5.0,22,3.6M,1000,Free,0,Everyone,Education
+Placement Tips for BE (CE/IT),FAMILY,4.4,7,6.3M,500,Free,0,Everyone,Education
+NetApp CE,BUSINESS,4.1,0,21M,100,Free,0,Everyone,Business
+Depths of Betrayal CE (Full),FAMILY,4.3,363,14M,1000,Paid,$2.99,Everyone 10+,Casual
+Merck CE,BUSINESS,4.5,2,25M,100,Free,0,Everyone,Business
+CE-STRONG,FAMILY,4.2,0,16M,100,Free,0,Everyone,Education
+Magana Jari ce Littafi Na Uku : Part 3 of 3,FAMILY,4.8,65,55M,5000,Free,0,Everyone,Education
+CCleaner,TOOLS,4.4,885187,22M,50000000,Free,0,Everyone,Tools
+Qu'est ce qui est jaune et qui attend ?,FAMILY,4.2,10,3.0M,500,Free,0,Everyone,Entertainment
+CE-SETRAM l’Appli,LIBRARIES_AND_DEMO,4.2,0,2.6M,100,Free,0,Everyone,Libraries & Demo
+CE KISIO,LIFESTYLE,4.1,1,24M,100,Free,0,Everyone,Lifestyle
+Terminal Emulator for Android,TOOLS,4.4,113951,551k,10000000,Free,0,Everyone,Tools
+Ceasa CE,TOOLS,4.0,0,4.0M,50,Free,0,Everyone,Tools
+CE Genius Nurses Edition,MEDICAL,4.2,0,5.1M,1,Paid,$3.99,Everyone,Medical
+CE HPJM 69,NEWS_AND_MAGAZINES,4.1,2,22M,50,Free,0,Everyone,News & Magazines
+CE SODEXO PASS FRANCE,PRODUCTIVITY,4.2,0,21M,50,Free,0,Everyone,Productivity
+CE AH VLJ,TRAVEL_AND_LOCAL,4.1,1,18M,1000,Free,0,Everyone,Travel & Local
+Pregnancy Tracker & Countdown to Baby Due Date,PARENTING,4.7,658087,62M,10000000,Free,0,Everyone,Parenting
+ACCEPT CE MARKING,PRODUCTIVITY,4.2,0,30M,10,Free,0,Everyone,Productivity
+CE AR LOG,LIFESTYLE,4.1,0,23M,1,Free,0,Everyone,Lifestyle
+CE Airbus,LIFESTYLE,4.1,0,Varies with device,100,Free,0,Everyone,Lifestyle
+"Führerschein Klasse CE, LKW 2018",FAMILY,4.2,57,Varies with device,1000,Paid,$2.49,Everyone,Education
+CE Intelligence,BUSINESS,4.1,0,10M,5,Free,0,Everyone,Business
+CrossFire: Legends,GAME,4.3,144040,29M,5000000,Free,0,Teen,Action
+CF.lumen,TOOLS,4.4,4901,1.9M,100000,Free,0,Everyone,Tools
+CF-Bench Pro,TOOLS,4.6,159,29k,1000,Paid,$1.49,Everyone,Tools
+CF SHOP!,LIFESTYLE,2.8,88,43M,10000,Free,0,Everyone,Lifestyle
+CF Life,FAMILY,5.0,4,8.3M,100,Free,0,Everyone,Education
+Cheapflights – Flight Search,TRAVEL_AND_LOCAL,4.4,47777,19M,5000000,Free,0,Everyone,Travel & Local
+CF-Bench,TOOLS,4.4,2132,103k,100000,Free,0,Everyone,Tools
+CF Appreciation,LIFESTYLE,2.0,11,6.2M,1000,Free,0,Everyone,Lifestyle
+Unity CF,LIFESTYLE,5.0,5,8.3M,100,Free,0,Everyone,Lifestyle
+Next Launcher 3D Bold-CF Theme,PERSONALIZATION,4.4,175,5.5M,1000,Paid,$0.99,Everyone,Personalization
+Overcomers CF - GA,LIFESTYLE,5.0,7,11M,100,Free,0,Everyone,Lifestyle
+Themes DAF CF 85 Trucks,PERSONALIZATION,4.3,2,17M,100,Free,0,Teen,Personalization
+CF Chat: Connecting Friends,COMMUNICATION,3.4,5,2.4M,100,Free,0,Teen,Communication
+CF Invest,FINANCE,4.4,11,4.6M,500,Free,0,Everyone,Finance
+Team CF,LIFESTYLE,4.1,0,3.0M,100,Free,0,Everyone,Lifestyle
+iOBD2-CF,TOOLS,3.4,5,21M,500,Free,0,Everyone,Tools
+CF PD,FINANCE,4.1,4,2.7M,100,Free,0,Everyone,Finance
+Themes DAF CF Trucks,PERSONALIZATION,4.3,2,15M,100,Free,0,Teen,Personalization
+CF Calculator,LIFESTYLE,3.3,25,4.7M,1000,Free,0,Everyone,Lifestyle
+CF Climb,LIFESTYLE,1.5,2,3.0M,100,Free,0,Everyone,Lifestyle
+Squeezy CF,MEDICAL,4.2,0,1.4M,10,Paid,$2.99,Everyone,Medical
+Wallpapers DAF CF Trucks,PERSONALIZATION,4.3,1,13M,100,Free,0,Teen,Personalization
+Wallpapers DAF CF 85 Trucks,PERSONALIZATION,4.3,0,16M,10,Free,0,Teen,Personalization
+CF,FINANCE,5.0,2,2.0M,100,Free,0,Everyone,Finance
+Wallpapers Truck DAF CF,PERSONALIZATION,4.3,19,11M,1000,Free,0,Everyone,Personalization
+CF cal,TOOLS,4.3,123,2.9M,10000,Free,0,Everyone,Tools
+CF GeneE,MEDICAL,4.3,16,40M,1000,Free,0,Everyone,Medical
+Themes DAF CF 85,PERSONALIZATION,4.3,3,14M,100,Free,0,Teen,Personalization
+CF SPOT,HEALTH_AND_FITNESS,4.3,0,9.7M,100,Free,0,Everyone,Health & Fitness
+CF Talenti,HEALTH_AND_FITNESS,4.3,4,7.8M,100,Free,0,Everyone,Health & Fitness
+Villarreal CF Wallpapers 4 Fans,LIFESTYLE,4.1,2,3.2M,50,Free,0,Everyone,Lifestyle
+Thrive CF,HEALTH_AND_FITNESS,2.2,6,8.0M,100,Free,0,Everyone,Health & Fitness
+Special Forces Group 2,GAME,4.6,1432809,29M,10000000,Free,0,Mature 17+,Action
+Valencia CF Wallpapers 4 Fans,LIFESTYLE,4.1,4,3.1M,100,Free,0,Everyone,Lifestyle
+Cacique CF,SPORTS,4.2,19,3.5M,100,Free,0,Everyone,Sports
+CF Townsville,HEALTH_AND_FITNESS,5.0,4,14M,100,Free,0,Everyone,Health & Fitness
+CF Church,FAMILY,4.2,1,8.7M,50,Free,0,Teen,Education
+CF Etowah,HEALTH_AND_FITNESS,4.3,0,8.8M,100,Free,0,Everyone,Health & Fitness
+"Cystic Fibrosis Symptoms, Doctors & Treatments",HEALTH_AND_FITNESS,4.7,6,9.7M,100,Free,0,Teen,Health & Fitness
+Málaga CF Wallpapers 4 Fans,LIFESTYLE,4.1,2,3.1M,10,Free,0,Everyone,Lifestyle
+Cluster CF,SPORTS,4.2,10,3.2M,100,Free,0,Everyone,Sports
+CF Themis,HEALTH_AND_FITNESS,4.3,0,8.5M,100,Free,0,Everyone,Health & Fitness
+Imperium CF,SPORTS,4.2,9,3.5M,500,Free,0,Everyone,Sports
+Azulones Getafe CF Fans,SPORTS,4.2,4,7.8M,100,Free,0,Teen,Sports
+CF Riga,HEALTH_AND_FITNESS,4.3,12,11M,100,Free,0,Everyone,Health & Fitness
+Casa CF,HEALTH_AND_FITNESS,4.7,12,6.3M,500,Free,0,Everyone,Health & Fitness
+CampGladiator,HEALTH_AND_FITNESS,3.5,293,19M,50000,Free,0,Everyone,Health & Fitness
+CG Creative Sets: 2D/3D Artist,NEWS_AND_MAGAZINES,4.3,117,5.0M,10000,Free,0,Everyone,News & Magazines
+Motocross Motorbike Simulator Offroad,GAME,3.6,51366,16M,5000000,Free,0,Everyone,Racing
+CG Daily News,NEWS_AND_MAGAZINES,4.3,65,3.5M,10000,Free,0,Everyone,News & Magazines
+CG - Calendars Add-On,PRODUCTIVITY,3.6,49,2.3M,5000,Free,0,Everyone 10+,Productivity
+CG Fit Scale,HEALTH_AND_FITNESS,2.6,13,3.3M,1000,Free,0,Everyone,Health & Fitness
+All Info about Cg,FAMILY,4.7,15,4.1M,1000,Free,0,Teen,Education
+cg guruji,FAMILY,4.5,170,4.1M,10000,Free,0,Everyone,Education
+CG Yojna & Jansampark,FAMILY,4.0,54,4.1M,5000,Free,0,Teen,Education
+Offline Jízdní řády CG Transit,MAPS_AND_NAVIGATION,4.6,7314,7.0M,100000,Free,0,Everyone,Maps & Navigation
+CG Prints,PHOTOGRAPHY,5.0,1,2.3M,100,Free,0,Everyone,Photography
+CG Job Alerts,FAMILY,4.2,116,4.1M,10000,Free,0,Everyone,Education
+CG - Conference Call Add-On,PRODUCTIVITY,4.2,6,1.1M,1000,Free,0,Everyone,Productivity
+Somos CG,PRODUCTIVITY,4.2,2,18M,100,Free,0,Everyone,Productivity
+CG Samanya Gyan,FAMILY,4.2,145,4.1M,10000,Free,0,Teen,Education
+CG Smart,SPORTS,4.2,2,1.5M,100,Free,0,Everyone,Sports
+CG Freelancer,NEWS_AND_MAGAZINES,4.7,10,2.3M,1000,Free,0,Everyone,News & Magazines
+CG Wallpapers,FAMILY,4.5,11,3.5M,500,Free,0,Mature 17+,Entertainment
+Best CG Backgrounds,FAMILY,3.6,8,3.7M,500,Free,0,Everyone,Entertainment
+CG Districts,SOCIAL,3.8,14,Varies with device,1000,Free,0,Everyone,Social
+Amazing CG Backgrounds,FAMILY,4.2,34,4.0M,1000,Free,0,Everyone,Entertainment
+CG BILASPUR CARNIVAL,EVENTS,3.8,59,1.8M,5000,Free,0,Everyone,Events
+Chat Anónimo Gratis Español CG,DATING,3.5,69,4.0M,5000,Free,0,Everyone,Dating
+CG Shikshak Mitan,TOOLS,4.1,295,3.8M,50000,Free,0,Everyone,Tools
+CG 3D Model Viewer: view 3D models interactively,TOOLS,4.0,0,10M,100,Free,0,Everyone,Tools
+CG Wizard,TOOLS,4.0,6,1.3M,100,Free,0,Everyone,Tools
+CG FM,FAMILY,5.0,2,6.6M,500,Free,0,Everyone,Entertainment
+ASCP® CG Exam Flashcards 2018,FAMILY,4.2,0,4.1M,100,Free,0,Everyone,Education
+Best CG views,FAMILY,4.2,4,2.5M,100,Free,0,Teen,Entertainment
+Bhunaksha CG,TOOLS,4.1,67,4.1M,10000,Free,0,Everyone,Tools
+My CG,PRODUCTIVITY,4.2,0,Varies with device,10,Free,0,Teen,Productivity
+Best CG Photography,FAMILY,4.2,1,2.5M,500,Free,0,Unrated,Entertainment
+BF CG View Wallpapers,FAMILY,3.6,13,2.5M,1000,Free,0,Teen,Entertainment
+CG Sanyukt Bharti Pariksha 2018,FAMILY,4.3,14,4.3M,1000,Free,0,Teen,Education
+Betting Tips / Sports Tips by CG Tipster,SPORTS,4.1,315,7.7M,10000,Free,0,Everyone,Sports
+CG Shikshak,FAMILY,4.4,211,6.8M,10000,Free,0,Everyone,Education
+CG Vidhansabha Chunav 2018,NEWS_AND_MAGAZINES,4.1,0,3.4M,100,Free,0,Teen,News & Magazines
+gps tracker cg,TOOLS,4.0,0,1.4M,50,Free,0,Everyone,Tools
+CG Backgrounds,FAMILY,4.0,8,3.6M,500,Free,0,Everyone,Entertainment
+CG - Chemistry free,FAMILY,5.0,7,2.3M,1000,Free,0,Everyone,Education
+CG Jobs,FAMILY,5.0,8,14M,10,Free,0,Everyone,Education
+music (CG),FAMILY,4.2,0,99M,50,Free,0,Everyone,Entertainment
+CG Patwari Exam,FAMILY,3.8,28,4.1M,1000,Free,0,Teen,Education
+Naidunia: MP News & CG News,NEWS_AND_MAGAZINES,4.3,2746,8.7M,100000,Free,0,Everyone,News & Magazines
+BF CG Abstract Pictures,FAMILY,4.7,6,2.5M,1000,Free,0,Teen,Entertainment
+Bhuiyan Land Records Chhattisgarh (CG),NEWS_AND_MAGAZINES,4.5,12,2.9M,5000,Free,0,Everyone,News & Magazines
+CG JOKES - Copy & Share,FAMILY,4.4,31,4.3M,1000,Free,0,Everyone,Entertainment
+"Ultimate Public Campgrounds (Over 37,100 in US&CA)",TRAVEL_AND_LOCAL,4.7,213,6.1M,5000,Paid,$3.99,Everyone,Travel & Local
+Chrome Beta,PRODUCTIVITY,4.4,228755,Varies with device,10000000,Free,0,Everyone,Productivity
+20 minutes (CH),NEWS_AND_MAGAZINES,3.7,4379,Varies with device,1000000,Free,0,Teen,News & Magazines
+"OurHome – chores, rewards, groceries and calendar",FAMILY,4.3,3146,Varies with device,100000,Free,0,Everyone,Lifestyle;Education
+Weather Data CH,WEATHER,4.2,15,Varies with device,500,Paid,$2.99,Everyone,Weather
+Dots puzzle,FAMILY,4.0,179,14M,50000,Paid,$0.99,Everyone,Puzzle
+CH info,NEWS_AND_MAGAZINES,3.9,45,15M,5000,Free,0,Everyone,News & Magazines
+Dive-Store.ch,SPORTS,4.2,0,6.3M,5,Paid,$1.99,Everyone,Sports
+FAV KWGT,PERSONALIZATION,4.9,88,66M,1000,Paid,$0.99,Everyone,Personalization
+Flo's CH Boss Timer,FAMILY,3.5,163,3.4M,1000,Free,0,Everyone,Role Playing
+20 Minuten (CH),NEWS_AND_MAGAZINES,3.5,14153,Varies with device,1000000,Free,0,Everyone 10+,News & Magazines
+"Reading Race 1b: sh, ch words",FAMILY,4.2,2,76M,50,Paid,$3.99,Everyone,Educational;Education
+Calvary.ch App,LIFESTYLE,4.4,10,7.7M,500,Free,0,Teen,Lifestyle
+autolina.ch has over 120'000 cars on offer.,AUTO_AND_VEHICLES,4.2,25,6.5M,10000,Free,0,Everyone,Auto & Vehicles
+Speech Therapy: CH,FAMILY,4.2,0,14M,10,Paid,$1.99,Everyone,Education
+Digi-TV.ch,SOCIAL,4.3,62,25M,10000,Free,0,Teen,Social
+retteMi.ch,COMMUNICATION,4.2,31,Varies with device,5000,Free,0,Everyone,Communication
+Chrome Canary (Unstable),PRODUCTIVITY,4.3,21866,Varies with device,1000000,Free,0,Everyone,Productivity
+ch-mm Dict,BOOKS_AND_REFERENCE,4.3,0,1.4M,10,Paid,$1.96,Everyone,Books & Reference
+boattheory.ch Full 2018,FAMILY,4.7,54,50M,1000,Paid,$19.40,Everyone,Education
+waut.ch!,FAMILY,4.5,10,2.5M,100,Free,0,Everyone,Educational
+search.ch,TRAVEL_AND_LOCAL,4.4,11514,2.2M,500000,Free,0,Everyone,Travel & Local
+homegate.ch,HOUSE_AND_HOME,4.2,2543,4.6M,100000,Free,0,Everyone,House & Home
+tutti.ch - Free Classifieds,SHOPPING,4.4,9950,15M,500000,Free,0,Everyone,Shopping
+autoricardo.ch – vehicles,LIFESTYLE,3.3,1045,13M,100000,Free,0,Everyone,Lifestyle
+Chrome Dev,COMMUNICATION,4.4,63576,Varies with device,5000000,Free,0,Everyone,Communication
+Legit Check App by Ch Daniel,LIFESTYLE,4.9,66,8.1M,1000,Free,0,Everyone,Lifestyle
+Threema,COMMUNICATION,4.5,51110,Varies with device,1000000,Paid,$2.99,Everyone,Communication
+Battery HD Pro,TOOLS,4.7,17861,Varies with device,100000,Paid,$3.99,Everyone,Tools
+DRAGON QUEST IV,FAMILY,4.7,1647,16M,10000,Paid,$14.99,Everyone,Role Playing
+swissinfo.ch,NEWS_AND_MAGAZINES,3.9,271,9.6M,50000,Free,0,Everyone 10+,News & Magazines
+Automagic * Automation,TOOLS,4.7,1947,Varies with device,10000,Paid,$3.90,Everyone,Tools
+FlashLight HD LED Pro,TOOLS,4.7,4928,Varies with device,50000,Paid,$2.99,Everyone,Tools
+Students.ch,SOCIAL,4.3,5,Varies with device,1000,Free,0,Teen,Social
+CH Kadels,BUSINESS,4.4,36,10M,1000,Free,0,Everyone,Business
+Sermon on Proverbs CH Spurgeon,GAME,4.8,35,3.1M,10000,Free,0,Everyone,Trivia
+Pixxy KWGT,PERSONALIZATION,4.8,60,78M,1000,Paid,$0.99,Everyone,Personalization
+ricardo.ch,SHOPPING,4.0,13232,27M,500000,Free,0,Everyone,Shopping
+usgang.ch,LIFESTYLE,3.7,492,Varies with device,100000,Free,0,Everyone 10+,Lifestyle
+"Startupticker.ch News, Events",NEWS_AND_MAGAZINES,5.0,4,10M,100,Free,0,Everyone,News & Magazines
+ci,FAMILY,3.0,1691,5.8M,500000,Free,0,Everyone,Strategy
+Green Build - An unofficial Travis CI client,TOOLS,3.9,7,3.2M,100,Free,0,Everyone,Tools
+mySharpBranded CI Test,TOOLS,4.0,0,898k,1,Free,0,Everyone,Tools
+Valmet CI Tool,BUSINESS,4.1,1,3.7M,500,Free,0,Everyone,Business
+CI Remote for Go,PRODUCTIVITY,4.6,20,Varies with device,100,Free,0,Everyone,Productivity
+myNaida CI,MEDICAL,4.6,64,57M,5000,Free,0,Everyone,Medical
+CI MOBI,FAMILY,4.3,108,42M,5000,Free,0,Everyone,Education
+Paris ci la Sortie du Métro,MAPS_AND_NAVIGATION,4.2,453,36M,10000,Paid,$2.99,Everyone,Maps & Navigation
+Supply Travis-CI POC,LIBRARIES_AND_DEMO,4.2,0,1.2M,10,Free,0,Everyone,Libraries & Demo
+CI 174 Gray Icon Pack,PERSONALIZATION,5.0,1,46M,10,Paid,$0.99,Everyone,Personalization
+CI Crew,FAMILY,4.2,1,30M,100,Free,0,Everyone,Entertainment
+Pharmacy CI - Pharmacies de garde Côte d'Ivoire,HEALTH_AND_FITNESS,4.5,5509,3.2M,100000,Free,0,Everyone,Health & Fitness
+CI Staff App,LIFESTYLE,4.1,0,10M,10,Free,0,Everyone,Lifestyle
+IQ Test,PRODUCTIVITY,4.2,1623,1.8M,100000,Free,0,Everyone,Productivity
+1st Fed CI Mobile Banking,FINANCE,4.1,0,31M,500,Free,0,Everyone,Finance
+Thistletown CI,PRODUCTIVITY,1.0,1,6.6M,100,Free,0,Everyone,Productivity
+All-night drugstore CI & Price,HEALTH_AND_FITNESS,4.3,0,5.1M,10,Paid,$0.99,Everyone,Health & Fitness
+CI Dictionary,FAMILY,4.6,31,3.2M,1000,Free,0,Everyone,Education
+RGN CI-Control,BUSINESS,4.1,0,6.0M,50,Free,0,Everyone,Business
+CI Time,PRODUCTIVITY,4.2,4,2.5M,100,Free,0,Everyone,Productivity
+CI View,BUSINESS,4.1,2,9.9M,100,Free,0,Everyone,Business
+Ci - Logistics Group,BUSINESS,4.1,1,10M,50,Free,0,Everyone,Business
+CI Attendance,PRODUCTIVITY,4.2,0,172k,5,Paid,$0.99,Everyone,Productivity
+Annonces.ci,SHOPPING,4.3,14,5.2M,1000,Free,0,Everyone,Shopping
+C I Patel School,FAMILY,4.1,101,5.1M,1000,Free,0,Everyone,Education
+CI Screwed - Icon Pack,PERSONALIZATION,4.7,19,6.4M,1000,Free,0,Everyone,Personalization
+CI Stream,VIDEO_PLAYERS,4.1,0,14M,10,Free,0,Everyone,Video Players & Editors
+Majestic Cinema CI,BUSINESS,4.1,45,15M,5000,Free,0,Everyone,Business
+Bonjour 2017 Abidjan CI ❤❤❤❤❤,FAMILY,4.2,235,3.3M,10000,Free,0,Everyone,Entertainment
+Pharmacie de Garde CI et Prix,HEALTH_AND_FITNESS,4.4,2599,6.9M,100000,Free,0,Mature 17+,Health & Fitness
+CI Capital - Dynamic,FINANCE,4.8,4,5.1M,50,Free,0,Everyone,Finance
+Chicken Invaders 3,GAME,4.2,52390,20M,5000000,Free,0,Everyone,Arcade
+CI SA,BUSINESS,4.1,0,10.0M,10,Free,0,Everyone,Business
+Mesure CI,TOOLS,4.0,9,6.6M,500,Free,0,Everyone,Tools
+Trovami se ci riesci,GAME,5.0,11,6.1M,10,Free,0,Everyone,Arcade
+CircleCI Viewer,PRODUCTIVITY,4.6,16,3.2M,1000,Free,0,Everyone,Productivity
+SimCity BuildIt,FAMILY,4.5,4218587,100M,50000000,Free,0,Everyone 10+,Simulation
+Nur təfsiri 1-ci cild,LIBRARIES_AND_DEMO,5.0,15,1.4M,1000,Free,0,Everyone,Libraries & Demo
+Test de Inteligencia CI,FAMILY,2.9,21,2.1M,5000,Free,0,Everyone,Education
+Calculate My IQ,FAMILY,4.2,44,7.2M,10000,Free,0,Everyone,Entertainment
+South Park: Phone Destroyer™,FAMILY,4.4,288835,91M,5000000,Free,0,Mature 17+,Strategy
+CI CAFETERIAS UBER,PRODUCTIVITY,4.2,0,2.8M,100,Free,0,Everyone,Productivity
+Mizanul-Hikmət 2-ci cild,LIBRARIES_AND_DEMO,4.2,16,743k,1000,Free,0,Everyone,Libraries & Demo
+CI On The Go,NEWS_AND_MAGAZINES,3.0,2,14M,100,Free,0,Everyone,News & Magazines
+CJ SO COOL,FAMILY,4.5,145,14M,10000,Free,0,Everyone,Entertainment
+CJ Fitness,HEALTH_AND_FITNESS,2.4,221,43M,10000,Free,0,Everyone,Health & Fitness
+CJ: Strike Back,GAME,4.3,29330,6.9M,1000000,Free,0,Everyone,Action
+The Grand Wars: San Andreas,GAME,3.9,29990,96M,1000000,Free,0,Teen,Action
+CJ Fallon eBook Reader,FAMILY,1.9,76,14M,5000,Free,0,Everyone,Education
+Grand Theft Auto: San Andreas,GAME,4.4,348962,26M,1000000,Paid,$6.99,Mature 17+,Action
+CJ Gospel Hour,SOCIAL,5.0,7,18M,100,Free,0,Everyone,Social
+CJ's Tire & Automotive,AUTO_AND_VEHICLES,4.0,5,34M,1000,Free,0,Everyone,Auto & Vehicles
+CJ Camcorder,VIDEO_PLAYERS,4.7,3,2.8M,500,Free,0,Everyone,Video Players & Editors
+The Grand Way,GAME,3.9,1995,92M,500000,Free,0,Teen,Action
+CJ'S TIRE AND AUTO INC.,PRODUCTIVITY,5.0,5,11M,100,Free,0,Everyone,Productivity
+CJ Browser - Fast & Private,COMMUNICATION,4.2,5,15M,100,Free,0,Everyone,Communication
+CJ WOW SHOP,SHOPPING,4.2,2099,4.0M,100000,Free,0,Everyone,Shopping
+Gold Teeth Photo Editor,PHOTOGRAPHY,2.8,1022,3.8M,100000,Free,0,Everyone,Photography
+CJ VLC HD Remote (+ Stream),VIDEO_PLAYERS,4.2,4074,1.3M,500000,Free,0,Everyone,Video Players & Editors
+CJ DVD Rentals,COMMUNICATION,1.0,5,13M,100,Free,0,Everyone,Communication
+San Andreas City : Auto Theft Car gangster,GAME,3.9,923,67M,100000,Free,0,Teen,Action
+Miami Crime Vice Town,GAME,4.1,154519,99M,10000000,Free,0,Mature 17+,Action
+CJ Poker Odds Calculator,GAME,4.1,207,116k,50000,Free,0,Everyone,Card
+Commission Manager,PRODUCTIVITY,3.2,12,2.2M,1000,Free,0,Everyone,Productivity
+CJ Apps,BUSINESS,4.1,0,24M,10,Free,0,Everyone,Business
+The CJ Rubric,HEALTH_AND_FITNESS,5.0,5,43M,100,Free,0,Everyone,Health & Fitness
+Pekalongan CJ,SOCIAL,4.3,0,5.9M,0,Free,0,Teen,Social
+CJ's Coffee Cafe,TRAVEL_AND_LOCAL,5.0,6,2.4M,500,Free,0,Everyone,Travel & Local
+Gangster City Auto Theft,GAME,4.3,350,67M,50000,Free,0,Everyone,Action
+China Town Auto Theft 2,GAME,4.1,364,67M,50000,Free,0,Everyone 10+,Action
+Codes for GTA San Andreas,FAMILY,3.8,12414,13M,1000000,Free,0,Everyone,Entertainment
+CJ Wilson's ZoomZoomnation,PRODUCTIVITY,4.0,4,8.2M,500,Free,0,Everyone,Productivity
+C J Academy,FAMILY,4.2,0,5.2M,10,Free,0,Everyone,Education
+Grand Gangsters 3D,GAME,4.2,401643,Varies with device,10000000,Free,0,Teen,Action
+Sir C J New Primary School,FAMILY,5.0,3,9.2M,100,Free,0,Everyone,Education
+Gang Wars of San Andreas,GAME,4.1,9898,63M,1000000,Free,0,Mature 17+,Action
+CJ the REALTOR,BUSINESS,5.0,1,4.2M,10,Free,0,Everyone,Business
+CJ Infinity,FOOD_AND_DRINK,4.2,0,16M,10,Free,0,Everyone,Food & Drink
+CJmall,SHOPPING,3.7,18253,10M,10000000,Free,0,Everyone,Shopping
+CJ IT ApS,BUSINESS,4.1,0,18M,10,Free,0,Everyone,Business
+CJ Auto école,FAMILY,4.2,0,12M,50,Free,0,Everyone,Education
+Sin City Hero : Crime Simulator of Vegas,GAME,4.1,3371,78M,100000,Free,0,Teen,Action
+Courier Journal,NEWS_AND_MAGAZINES,3.5,254,38M,10000,Free,0,Everyone 10+,News & Magazines
+FANDOM for: GTA,FAMILY,3.9,39038,9.5M,5000000,Free,0,Mature 17+,Entertainment
+San Andreas Crime City Gangster 3D,FAMILY,4.2,9403,Varies with device,1000000,Free,0,Teen,Simulation
+Zombie Death Shooter,GAME,3.8,17372,45M,1000000,Free,0,Mature 17+,Arcade
+Project Grand Auto Town Sandbox Beta,GAME,3.7,7885,28M,500000,Free,0,Mature 17+,Racing
+Credit Karma,FINANCE,4.7,706618,Varies with device,10000000,Free,0,Everyone,Finance
+Company Kitchen,LIFESTYLE,2.8,81,7.7M,10000,Free,0,Everyone,Lifestyle
+Calvin Klein – US Store,SHOPPING,4.7,221,9.5M,50000,Free,0,Teen,Shopping
+CK FFXIV Companion,FAMILY,4.3,1364,5.2M,100000,Free,0,Everyone,Entertainment
+Can Knockdown,FAMILY,4.1,155649,38M,10000000,Free,0,Everyone,Casual
+Calvin Klein Petite Dresses,BEAUTY,4.3,0,3.7M,500,Free,0,Everyone,Beauty
+Louis CK,FAMILY,4.7,244,25M,10000,Free,0,Mature 17+,Entertainment
+CK-12: Practice Math & Science,FAMILY,4.2,562,20M,50000,Free,0,Everyone,Education;Education
+CK 初一 十五,LIFESTYLE,4.0,294,153k,10000,Free,0,Everyone,Lifestyle
+CK Eorzea Timepiece,PERSONALIZATION,3.2,8,5.3M,100,Free,0,Everyone,Personalization
+F*ck This Game,GAME,4.6,8,6.3M,100,Paid,$0.99,Teen,Action
+211:CK,GAME,5.0,8,38M,10,Paid,$0.99,Teen,Arcade
+CONTRACT KILLER: ZOMBIES (NR),GAME,4.4,206602,13M,5000000,Free,0,Mature 17+,Action
+ck-modelcars Shop,SHOPPING,4.5,118,6.4M,5000,Free,0,Everyone,Shopping
+Brainf*ck Interpreter,FAMILY,4.0,24,1.9M,1000,Free,0,Mature 17+,Entertainment
+ck-modelcars-UK Shop,SHOPPING,4.6,69,6.4M,5000,Free,0,Everyone,Shopping
+CK Multimedia - Gaming Accessories,SHOPPING,4.7,10,2.0M,500,Free,0,Everyone,Shopping
+CK SKILLZ,HEALTH_AND_FITNESS,4.3,0,8.6M,50,Free,0,Everyone,Health & Fitness
+CK-12 Physics Simulations,FAMILY,4.1,30,24M,5000,Free,0,Everyone,Education;Education
+CKZ ORIGINS,GAME,4.5,219821,10M,1000000,Free,0,Mature 17+,Action
+211:CK Lite,GAME,4.3,3,39M,10,Free,0,Mature 17+,Action
+CK Life,HEALTH_AND_FITNESS,4.3,3,60M,100,Free,0,Teen,Health & Fitness
+USMLE Step 2 CK Flashcards,FAMILY,5.0,1,40M,10,Paid,$19.99,Everyone,Education
+CK Employee Portal,BUSINESS,5.0,7,15M,1000,Free,0,Everyone,Business
+FML F*ck my life + widget,FAMILY,4.2,1415,209k,100000,Free,0,Everyone,Entertainment
+USMLE Step 2 CK Cards Lite,FAMILY,4.0,28,1.5M,5000,Free,0,Everyone,Education
+Company Kitchen Inventory,BUSINESS,4.1,3,2.3M,1000,Free,0,Everyone,Business
+Tic Tac CK,FAMILY,5.0,3,13M,10,Free,0,Everyone,Puzzle
+CK Pharmacies,HEALTH_AND_FITNESS,2.7,3,9.4M,100,Free,0,Everyone 10+,Health & Fitness
+INFAMY RO,FAMILY,4.1,2167,3.7M,50000,Free,0,Everyone,Role Playing
+CK Call NEW,COMMUNICATION,4.2,0,4.2M,10,Free,0,Everyone,Communication
+Ck Coif,LIFESTYLE,4.1,0,22M,10,Free,0,Everyone,Lifestyle
+CONTRACT KILLER: ZOMBIES,GAME,4.4,144545,13M,5000000,Free,0,Teen,Action
+CK Shop,TOOLS,4.0,13,8.1M,1000,Free,0,Everyone,Tools
+FlexBook,FAMILY,4.3,104,12M,10000,Free,0,Everyone,Education;Education
+Can Knockdown 3,GAME,4.1,349503,19M,10000000,Free,0,Everyone,Arcade
+Fu*** Weather (Funny Weather),WEATHER,4.7,20001,Varies with device,1000000,Free,0,Mature 17+,Weather
+OB-GYN USMLE Stp2 CK 300 Q & A,MEDICAL,4.4,34,4.9M,10000,Free,0,Everyone,Medical
+CK Active,HEALTH_AND_FITNESS,4.3,0,9.7M,10,Free,0,Everyone,Health & Fitness
+USMLE CK Clinical Knowledge Flashcards 2018 Ed,FAMILY,4.2,0,3.6M,5,Free,0,Everyone,Education
+Night Camera Blur Effect,PHOTOGRAPHY,3.6,100,2.5M,10000,Free,0,Everyone,Photography
+Camera V7 24 Megapixel,PHOTOGRAPHY,4.0,2480,2.5M,100000,Free,0,Everyone,Photography
+CL Mobile Pro - Classifieds for Craigslist,SHOPPING,4.1,1288,18M,100000,Free,0,Mature 17+,Shopping
+cloudLibrary,BOOKS_AND_REFERENCE,4.0,10774,35M,100000,Free,0,Everyone,Books & Reference
+"CL Reader for Craigslist(For sale, jobs, rental..)",TOOLS,4.1,61,6.3M,1000,Free,0,Everyone,Tools
+CL Pro App for Craigslist,SHOPPING,4.0,119,1.3M,10000,Free,0,Everyone,Shopping
+Castle Clash: Heroes of the Empire US,FAMILY,4.6,4578890,24M,50000000,Free,0,Everyone 10+,Strategy
+CL 2NE1 Wallpaper KPOP Fans HD,PERSONALIZATION,4.3,7,3.4M,100,Free,0,Everyone,Personalization
+CL 2ne1 Wallpaper KPOP HD Best,PERSONALIZATION,4.3,3,3.4M,10,Free,0,Everyone,Personalization
+FREE CHATS C.L.,COMMUNICATION,4.2,4,3.4M,10,Paid,$0.99,Mature 17+,Communication
+CL 2ne1 Wallpaper KPOP UHD Fans,PERSONALIZATION,4.3,1,3.4M,10,Free,0,Everyone,Personalization
+CL REPL,TOOLS,5.0,47,17M,1000,Free,0,Everyone,Tools
+CL Pro Client for Craigslist,SHOPPING,3.6,48,2.2M,5000,Free,0,Everyone,Shopping
+DAILY: Free Classifieds App for Android,LIFESTYLE,4.1,5025,Varies with device,500000,Free,0,Mature 17+,Lifestyle
+App for Craigslist Pro - Buy & Sell Postings,LIFESTYLE,4.3,707,5.0M,100000,Free,0,Everyone,Lifestyle
+Pro App for Craigslist,SHOPPING,4.1,5618,4.6M,500000,Free,0,Teen,Shopping
+Car Search For Craigslist CL Free,AUTO_AND_VEHICLES,2.6,5,9.0M,1000,Free,0,Everyone,Auto & Vehicles
+CL Clock,BUSINESS,2.7,7,1.3M,1000,Free,0,Everyone,Business
+Old: CL-150,FAMILY,3.8,120,24M,10000,Free,0,Everyone,Education
+CL Keyboard - Myanmar Keyboard (No Ads),TOOLS,5.0,24,3.2M,5000,Free,0,Everyone,Tools
+Clash of Kings : The King Of Fighters version,FAMILY,4.2,2233681,97M,50000000,Free,0,Teen,Strategy
+Cl-app!,SPORTS,4.2,41,353k,10000,Free,0,Everyone,Sports
+CL Notifier,TOOLS,5.0,36,3.2M,100,Free,0,Teen,Tools
+Leica CL,PHOTOGRAPHY,2.6,8,2.4M,1000,Free,0,Everyone,Photography
+cPro Marketplace: Buy. Sell. Rent. Date. Jobs.,SHOPPING,4.4,385764,8.4M,10000000,Free,0,Mature 17+,Shopping
+Postings (Craigslist Search App),SHOPPING,4.3,151095,12M,5000000,Free,0,Mature 17+,Shopping
+New CL 2ne1 Wallpaper KPOP live,PERSONALIZATION,4.3,0,3.4M,1,Free,0,Everyone,Personalization
+CL 2ne1 Wallpaper KPOP Fans All,PERSONALIZATION,4.3,0,3.4M,1,Free,0,Everyone,Personalization
+CL-Phlebotomist,MEDICAL,4.7,19,7.3M,100,Free,0,Everyone,Medical
+New: CL-150,FAMILY,2.8,4,4.2M,500,Free,0,Everyone,Education
+Battle of Zombies: Clans War,FAMILY,4.1,488039,58M,10000000,Free,0,Teen,Strategy
+CL-Customer Care,HEALTH_AND_FITNESS,4.3,2,6.8M,5,Free,0,Everyone,Health & Fitness
+CL Pebble Apps,LIFESTYLE,3.6,67,499k,5000,Free,0,Everyone,Lifestyle
+MPS CL,TOOLS,4.0,1,3.2M,10,Free,0,Everyone,Tools
+Turnotronik CL,TOOLS,4.0,1,3.3M,10,Free,0,Everyone,Tools
+CL e-bank,FINANCE,4.0,210,3.7M,10000,Free,0,Everyone,Finance
+E2CR CL,LIFESTYLE,4.1,0,25M,10,Free,0,Everyone,Lifestyle
+Wallpapers Mercedes Benz CL,PERSONALIZATION,4.3,2,12M,100,Free,0,Teen,Personalization
+Color CL,LIFESTYLE,5.0,2,1.3M,100,Free,0,Everyone,Lifestyle
+CL Strength,HEALTH_AND_FITNESS,5.0,3,40M,50,Free,0,Everyone,Health & Fitness
+CL-App,MEDICAL,4.7,6,5.2M,100,Free,0,Everyone,Medical
+"Security Master - Antivirus, VPN, AppLock, Booster",TOOLS,4.7,24900999,Varies with device,500000000,Free,0,Everyone,Tools
+"CM Launcher 3D - Theme, Wallpapers, Efficient",PERSONALIZATION,4.6,6700847,17M,100000000,Free,0,Teen,Personalization
+CM Launcher 3D Pro💎,PERSONALIZATION,4.7,23802,173k,100000,Paid,$4.99,Everyone,Personalization
+CM Locker - Security Lockscreen,TOOLS,4.6,3090680,Varies with device,100000000,Free,0,Everyone,Tools
+Clean Master Lite - For Low-End Phone,TOOLS,4.6,2246379,5.1M,50000000,Free,0,Everyone,Tools
+"CM Security Open VPN - Free, fast unlimited proxy",TOOLS,4.6,85496,5.8M,1000000,Free,0,Everyone,Tools
+CM Security Lite - Antivirus,TOOLS,4.6,262076,1.2M,10000000,Free,0,Everyone,Tools
+CM Transfer - Share any files with friends nearby,COMMUNICATION,4.6,71740,5.8M,5000000,Free,0,Everyone,Communication
+"CM Flashlight (Compass, SOS)",TOOLS,4.4,166363,1.8M,5000000,Free,0,Everyone,Tools
+CM Apps,TOOLS,3.8,3341,1.9M,100000,Free,0,Everyone,Tools
+CM AppLock,TOOLS,4.1,843,3.6M,100000,Free,0,Everyone,Tools
+"Ruler(cm, inch)",TOOLS,3.4,2889,2.5M,500000,Free,0,Everyone,Tools
+AppLock - Fingerprint Unlock,TOOLS,4.5,112482,2.1M,5000000,Free,0,Everyone,Tools
+CM Launcher Default Theme,PERSONALIZATION,4.5,3989,1.1M,100000,Free,0,Everyone,Personalization
+Battery Doctor-Battery Life Saver & Battery Cooler,TOOLS,4.5,8190074,17M,100000000,Free,0,Everyone,Tools
+Inch/cm/Foot Conversion,PRODUCTIVITY,4.0,319,2.1M,100000,Free,0,Everyone,Productivity
+"Speed Booster - Ram, Battery & Game Speed Booster",TOOLS,4.7,85079,2.8M,1000000,Free,0,Everyone,Tools
+CM FILE MANAGER,TOOLS,4.4,953790,Varies with device,50000000,Free,0,Everyone,Tools
+Technology CM Locker Theme,PERSONALIZATION,4.4,10093,5.5M,1000000,Free,0,Everyone,Personalization
+Swift Dark CM / CM13 Theme,PERSONALIZATION,4.7,1500,41M,10000,Paid,$1.99,Everyone,Personalization
+Melior NUI - Material CM Theme,PERSONALIZATION,4.7,1873,14M,100000,Free,0,Everyone,Personalization
+Height Converter feet-inch cm,TOOLS,4.2,498,597k,100000,Free,0,Everyone,Tools
+CM Secure Browser (Authorized),TOOLS,4.2,1147,2.7M,100000,Free,0,Everyone,Tools
+📏 Smart Ruler ↔️ cm/inch measuring for homework!,TOOLS,4.0,19,3.2M,10000,Free,0,Everyone,Tools
+Ruler cm,TOOLS,3.6,661,809k,100000,Free,0,Everyone,Tools
+"Length Converter: convert mm,cm,m, feet,yard,mile",TOOLS,4.7,76,2.2M,50000,Free,0,Everyone,Tools
+CM AppLock Fingerprint 2018,TOOLS,4.4,1264,8.2M,100000,Free,0,Everyone,Tools
+"m, cm, mm to yard, feet, inch converter tool",TOOLS,4.3,246,2.8M,100000,Free,0,Everyone,Tools
+Speed Car CM Locker Theme,PERSONALIZATION,4.4,7519,4.0M,500000,Free,0,Everyone,Personalization
+Calculator CM,TOOLS,4.4,8,1.8M,500,Free,0,Everyone,Tools
+Inches to cm conversion,TOOLS,4.4,29,70k,10000,Free,0,Everyone,Tools
+Vintage Flower CM Locker Theme,PERSONALIZATION,4.3,2910,2.3M,500000,Free,0,Everyone,Personalization
+Centimeter Ruler,TOOLS,3.3,16,1.3M,10000,Free,0,Everyone,Tools
+CM S Pen Add-on(ROOT),TOOLS,3.6,373,122k,10000,Free,0,Everyone,Tools
+Ruler,TOOLS,4.5,27180,4.1M,1000000,Free,0,Everyone,Tools
+My Style CM 13 Theme,PERSONALIZATION,4.5,314,11M,10000,Free,0,Everyone,Personalization
+QuickPic - Photo Gallery with Google Drive Support,PHOTOGRAPHY,4.6,847144,4.2M,10000000,Free,0,Everyone,Photography
+"Ruler & Area Measurement (cm, inch)",TOOLS,4.3,10,8.2M,10000,Free,0,Everyone,Tools
+Inches to Centimeters,TOOLS,3.6,949,411k,100000,Free,0,Everyone,Tools
+"cm, mm to inch, feet converter tool",PRODUCTIVITY,4.3,176,2.3M,100000,Free,0,Everyone,Productivity
+City light CM Locker Theme,PERSONALIZATION,4.4,6271,5.7M,500000,Free,0,Everyone,Personalization
+Speed Test - WiFi / Cellular speed test,TOOLS,4.1,24226,Varies with device,1000000,Free,0,Everyone,Tools
+CM FILE MANAGER Pro,BUSINESS,4.2,2359,2.7M,10000,Paid,$2.99,Everyone,Business
+cm to inches | centimeters to inches conversion,TOOLS,4.8,52,1.9M,5000,Free,0,Everyone,Tools
+OMEGA Black UI Theme - CM 12+,PERSONALIZATION,4.2,12,19M,100,Paid,$0.99,Everyone,Personalization
+In to cm,TOOLS,4.0,0,2.3M,10,Free,0,Everyone,Tools
+Cartoon Network App,FAMILY,4.0,119173,Varies with device,10000000,Free,0,Everyone 10+,Video Players & Editors;Music & Video
+CN Summer Challenge,FAMILY,3.7,985,49M,100000,Free,0,Everyone,Entertainment;Brain Games
+Teen Titans GO Figure!,FAMILY,4.5,1985,28M,10000,Paid,$3.99,Everyone 10+,Action;Action & Adventure
+CN Superstar Soccer: Goal!!!,FAMILY,4.1,3863,41M,100000,Paid,$2.99,Everyone,Sports;Action & Adventure
+Teeny Titans - Teen Titans Go!,FAMILY,4.6,20463,25M,100000,Paid,$3.99,Everyone 10+,Strategy;Action & Adventure
+CN Sayin' - Cartoon Network,FAMILY,4.5,85,25M,10000,Free,0,Everyone,Entertainment
+Cartoon Network Match Land,FAMILY,4.7,21979,38M,1000000,Free,0,Everyone,Puzzle
+Card Wars Kingdom,FAMILY,4.3,920571,28M,10000000,Free,0,Everyone 10+,Card;Action & Adventure
+Wrecker's Revenge - Gumball,FAMILY,4.3,2263,55M,100000,Free,0,Everyone,Puzzle;Action & Adventure
+Super Slime Blitz - Gumball,FAMILY,4.6,5395,58M,500000,Free,0,Everyone,Arcade;Action & Adventure
+Blamburger - Clarence,FAMILY,4.1,30444,27M,1000000,Free,0,Everyone 10+,Arcade;Action & Adventure
+Free Fur All – We Bare Bears,FAMILY,4.2,256916,25M,10000000,Free,0,Everyone,Arcade;Action & Adventure
+Sky Streaker - Gumball,GAME,4.3,37513,31M,5000000,Free,0,Everyone,Arcade
+Just A Regular Arcade,GAME,4.2,40847,94M,1000000,Free,0,Everyone,Action
+Soundtrack Attack,FAMILY,4.3,96045,25M,5000000,Free,0,Everyone,Action;Action & Adventure
+[adult swim],FAMILY,3.6,21433,21M,1000000,Free,0,Mature 17+,Entertainment
+Ben 10: Alien Experience,FAMILY,4.2,82005,45M,10000000,Free,0,Everyone 10+,Action;Action & Adventure
+MagiMobile – Mighty Magiswords,FAMILY,4.2,120035,45M,5000000,Free,0,Everyone,Entertainment;Action & Adventure
+Dreamland Arcade - Steven Universe,GAME,4.0,6386,24M,500000,Free,0,Everyone,Arcade
+Surely You Quest - Magiswords,FAMILY,4.6,43314,83M,1000000,Free,0,Everyone 10+,Role Playing;Action & Adventure
+Adventure Time Run,GAME,4.3,24628,88M,1000000,Free,0,Everyone,Action
+Glitch Fixers: Powerpuff Girls,GAME,4.4,39698,51M,5000000,Free,0,Everyone,Arcade
+StirFry Stunts - We Bare Bears,GAME,4.5,121533,63M,10000000,Free,0,Everyone,Arcade
+Burrito Bash – We Bare Bears,FAMILY,4.3,10776,21M,1000000,Free,0,Everyone,Arcade;Action & Adventure
+LEGO® TV,FAMILY,3.7,17250,7.2M,1000000,Free,0,Everyone 10+,Entertainment;Music & Video
+Boomerang,FAMILY,4.2,13519,51M,1000000,Free,0,Everyone,Entertainment;Music & Video
+We Bare Bears Match3 Repairs,FAMILY,4.7,39153,98M,1000000,Free,0,Everyone,Puzzle
+Champions and Challengers - Adventure Time,FAMILY,4.6,51973,27M,1000000,Free,0,Everyone,Role Playing
+Ski Safari: Adventure Time,FAMILY,4.5,48754,9.3M,100000,Paid,$0.99,Everyone,Arcade;Action & Adventure
+Block Survival Craft:The Story,FAMILY,4.1,7046,87M,500000,Free,0,Everyone 10+,Puzzle
+"What's Up, Snoopy? - Peanuts",FAMILY,4.5,773,55M,100000,Free,0,Everyone,Arcade;Action & Adventure
+DisneyNOW – TV Shows & Games,FAMILY,4.3,82499,Varies with device,5000000,Free,0,Everyone,Entertainment;Music & Video
+Rockstars of Ooo,FAMILY,3.4,642,26M,10000,Paid,$1.99,Everyone 10+,Arcade;Action & Adventure
+Pokémon TV,FAMILY,4.2,117461,Varies with device,5000000,Free,0,Everyone,Entertainment;Music & Video
+Angelo Rules - Crazy day,GAME,3.9,108336,62M,1000000,Free,0,Everyone,Adventure
+Flipped Out! - Powerpuff Girls,FAMILY,4.4,412,22M,10000,Paid,$2.99,Everyone 10+,Action;Action & Adventure
+Adventure Time Game Wizard,GAME,4.1,4107,40M,50000,Paid,$4.99,Everyone,Adventure
+Best Park in the Universe,GAME,4.3,3904,5.5M,10000,Paid,$2.99,Everyone 10+,Action
+Formula Cartoon All Stars,FAMILY,3.9,1213,18M,10000,Paid,$2.99,Everyone,Racing;Action & Adventure
+Multicraft Miner Exploration,GAME,4.0,14563,74M,1000000,Free,0,Everyone 10+,Adventure
+CN TV Canal 3 - Cable Netword,FAMILY,4.2,5,16M,1000,Free,0,Everyone,Entertainment
+CN Resident,FAMILY,5.0,1,64M,100,Free,0,Everyone,Entertainment
+Little Lovely Dentist,FAMILY,4.2,17786,16M,1000000,Free,0,Everyone,Casual
+Foods Co,SHOPPING,4.3,199,25M,10000,Free,0,Everyone,Shopping
+AND CO,FINANCE,4.5,175,12M,10000,Free,0,Everyone,Finance
+Tetrobot and Co.,FAMILY,4.5,709,18M,5000,Paid,$2.99,Everyone,Puzzle
+Brit + Co,LIFESTYLE,3.9,987,4.5M,10000,Free,0,Everyone,Lifestyle
+Wuwu & Co.,FAMILY,4.2,9,77M,100,Paid,$2.99,Everyone,Books & Reference;Creativity
+Dots & Co: A Puzzle Adventure,FAMILY,4.5,81001,85M,1000000,Free,0,Everyone,Puzzle
+AppClose - The #1 FREE Co-Parenting App,PARENTING,3.5,159,85M,10000,Free,0,Everyone,Parenting
+Co-op CRS,LIFESTYLE,3.6,581,26M,100000,Free,0,Everyone,Lifestyle
+Co Checker,TOOLS,1.9,12,2.0M,1000,Free,0,Everyone,Tools
+VCalendar - VenkatRama and Co,LIFESTYLE,4.3,87,3.9M,10000,Free,0,Everyone,Lifestyle
+Feeder.co,NEWS_AND_MAGAZINES,3.2,77,11M,5000,Free,0,Everyone,News & Magazines
+Co-op Connections,SHOPPING,1.6,8,18M,1000,Free,0,Everyone,Shopping
+mail.co.uk Mail,COMMUNICATION,4.2,21,8.7M,5000,Free,0,Everyone,Communication
+Aquarium Co-Op Podcast,LIFESTYLE,4.9,206,3.9M,1000,Free,0,Everyone,Lifestyle
+MobileBiz Co - Cloud Invoice,BUSINESS,4.4,373,4.0M,10000,Free,0,Everyone,Business
+Supermarket Cashier Kids Games,FAMILY,3.6,32416,Varies with device,1000000,Free,0,Everyone,Educational
+Co-op Taxi,MAPS_AND_NAVIGATION,3.4,168,53M,10000,Free,0,Everyone,Maps & Navigation
+Alex & Co Quiz,GAME,4.3,9,4.9M,1000,Free,0,Everyone,Trivia
+Them Bombs: co-op board game play with 2-4 friends,GAME,4.7,8038,52M,100000,Free,0,Teen,Board
+REI Co-op Mastercard,FINANCE,2.9,320,23M,10000,Free,0,Everyone,Finance
+Websites.co.in Instant Website,BUSINESS,4.3,327,13M,10000,Free,0,Everyone,Business
+Co-op Credit Union on the Go,FINANCE,4.4,5,30M,1000,Free,0,Everyone,Finance
+Hashtags For Likes.co,SOCIAL,4.3,420,18M,50000,Free,0,Everyone,Social
+Chinese Chess ( Xiangqi Free ),GAME,4.6,963,4.1M,50000,Free,0,Everyone,Board
+Krypton by krypt.co,PRODUCTIVITY,4.6,38,13M,1000,Free,0,Everyone,Productivity
+Chinese Chess / Co Tuong,GAME,4.2,6947,20M,500000,Free,0,Everyone,Board
+Fayr - Co-Parenting Simplified,PRODUCTIVITY,3.5,16,21M,1000,Free,0,Everyone,Productivity
+Co-Dependents Anonymous,LIFESTYLE,4.1,0,12M,500,Free,0,Everyone,Lifestyle
+Sprig by CO-OP,FINANCE,2.9,252,18M,10000,Free,0,Everyone,Finance
+Good&Co: Career match tests,BUSINESS,4.4,26572,41M,1000000,Free,0,Everyone,Business
+Central Bank and Trust Co.,FINANCE,4.7,65,12M,5000,Free,0,Everyone,Finance
+Soo Co-op Mobile Banking,FINANCE,4.5,159,14M,1000,Free,0,Everyone,Finance
+Co-Optima Mobile,FINANCE,4.4,218,Varies with device,10000,Free,0,Everyone,Finance
+SharedCare™ Co-parenting,PARENTING,2.0,23,Varies with device,100,Paid,$4.59,Everyone,Parenting
+Holl & Co Barbers,LIFESTYLE,4.7,12,6.0M,500,Free,0,Everyone,Lifestyle
+Call of Mini™ Zombies 2,GAME,4.4,248417,17M,5000000,Free,0,Teen,Arcade
+Grenada Co-operative Bank,FINANCE,4.4,137,400k,10000,Free,0,Everyone,Finance
+Dungeon Legends - PvP Action MMO RPG Co-op Games,FAMILY,4.4,102215,42M,1000000,Free,0,Teen,Role Playing
+CO CASE Events,FAMILY,4.2,0,54M,100,Free,0,Everyone,Education
+Permit Test CO Colorado DMV,FAMILY,4.5,41,11M,1000,Free,0,Everyone,Education
+"Chinese Chess 3D Online (Xiangqi, 象棋, co tuong)",GAME,3.5,23,37M,1000,Paid,$0.99,Everyone,Board
+2-Player Co-op Zombie Shoot,GAME,4.2,33,13M,1000,Free,0,Teen,Action
+Camping and Co - Camping in Europe,TRAVEL_AND_LOCAL,3.7,19,6.5M,1000,Free,0,Everyone,Travel & Local
+Remote | Fire TV | Android TV | KODI | CetusPlay,TOOLS,4.4,15911,16M,1000000,Free,0,Everyone,Tools
+Comboios de Portugal,MAPS_AND_NAVIGATION,3.4,1147,19M,100000,Free,0,Everyone,Maps & Navigation
+CP Dialer,SOCIAL,4.3,64,3.3M,50000,Free,0,Teen,Social
+CP Federal Mobile,FINANCE,3.6,180,35M,10000,Free,0,Everyone,Finance
+Cestovné poriadky CP,MAPS_AND_NAVIGATION,4.6,2681,6.3M,100000,Free,0,Everyone,Maps & Navigation
+CP Channel,FAMILY,4.6,7,12M,500,Free,0,Everyone 10+,Education
+CP Clicker,LIFESTYLE,4.2,251,5.0M,10000,Free,0,Everyone,Lifestyle
+Evolution CP & IV Calculator for pokemon,FAMILY,4.3,9465,43M,500000,Free,0,Everyone,Entertainment
+CP Creepypasta,FAMILY,3.8,128,2.9M,10000,Free,0,Teen,Entertainment
+Hercules CP Mobile,TOOLS,1.4,20,4.1M,1000,Free,0,Everyone,Tools
+Cerebral Palsy,MEDICAL,4.4,38,8.5M,1000,Free,0,Everyone,Medical
+"Speak quietly: Autism, CP",MEDICAL,4.2,6,7.0M,1000,Free,0,Everyone,Medical
+CP RACING 2 FREE,FAMILY,4.0,4607,19M,100000,Free,0,Everyone,Simulation
+CP-Care Mobile,FAMILY,4.2,1,16M,10,Free,0,Everyone,Education
+CP ToolBox,BUSINESS,4.6,70,14M,1000,Free,0,Everyone,Business
+"Talking Pictures: Autism, CP",MEDICAL,3.9,22,801k,5000,Free,0,Everyone,Medical
+CP HAPPS - Pittsburgh Events,LIFESTYLE,3.8,85,5.6M,5000,Free,0,Teen,Lifestyle
+Poke Genie - Safe IV Calculator,TOOLS,4.7,92958,36M,1000000,Free,0,Everyone,Tools
+IV Calc CP Calculator Toolkit,TOOLS,4.2,242,3.2M,10000,Free,0,Everyone,Tools
+CP Plus Showcase,BUSINESS,4.3,236,7.0M,50000,Free,0,Everyone,Business
+CP Calculator,FAMILY,4.1,187,2.9M,10000,Free,0,Everyone,Entertainment
+iTooch Mathématiques CP,FAMILY,4.3,1018,35M,100000,Free,0,Everyone,Education;Education
+gCMOB,TOOLS,4.2,7935,21M,1000000,Free,0,Everyone,Tools
+CP Connect 2.0,PRODUCTIVITY,4.2,0,5.8M,500,Free,0,Everyone,Productivity
+Evolution CP,FAMILY,3.6,13,4.7M,500,Free,0,Everyone,Entertainment
+IV Go（get IV for Pokemon）,GAME,4.6,132282,20M,1000000,Free,0,Everyone,Adventure
+CP Smart Check List,PERSONALIZATION,4.3,1,3.9M,10,Free,0,Everyone,Personalization
+Ditto CP Calculator GO,TOOLS,4.3,34,12M,1000,Free,0,Everyone,Tools
+Foothills CP,FAMILY,5.0,4,7.8M,100,Free,0,Teen,Education
+CP Installer App,BUSINESS,5.0,4,24M,100,Free,0,Everyone,Business
+CP Trivia,GAME,5.0,5,12M,100,Free,0,Everyone,Trivia
+CP Ready,BUSINESS,4.5,56,Varies with device,1000,Free,0,Everyone,Business
+CP Surprise,LIFESTYLE,3.8,2548,4.9M,100000,Free,0,Everyone,Lifestyle
+Evolve CP Calc. for PokemonGo,TOOLS,3.9,116,3.3M,10000,Free,0,Everyone,Tools
+CP Cloud,BUSINESS,4.1,3,5.4M,100,Free,0,Everyone,Business
+GO CP Evolution Calculator,FAMILY,4.2,5,2.4M,100,Free,0,Everyone,Entertainment
+ClanPlay: Community and Tools for Gamers,COMMUNICATION,4.8,34443,27M,1000000,Free,0,Teen,Communication
+CP Calculator - Poke Go Calc,FAMILY,4.1,7,22M,500,Free,0,Everyone,Entertainment
+Contents Provider(C.P.)Explorer,TOOLS,4.0,1,1.2M,100,Free,0,Everyone,Tools
+Cp Calculator for Evolution:GO,FAMILY,4.8,124,2.5M,500,Free,0,Everyone,Entertainment
+Calcy IV,TOOLS,4.8,36557,14M,1000000,Free,0,Everyone,Tools
+CP Brown English-Telugu Dictionary,FAMILY,4.4,8,6.8M,500,Free,0,Everyone,Education
+CP Parquet,LIFESTYLE,4.1,2,1.2M,100,Free,0,Everyone,Lifestyle
+CP evolution calculator Pokemo,FAMILY,4.1,78,787k,10000,Free,0,Everyone,Educational
+C.P. CERVANTES (TOBARRA),SOCIAL,4.3,0,4.9M,5,Free,0,Everyone,Social
+Sporting CP Keyboard Theme,SPORTS,4.2,45,5.3M,5000,Free,0,Everyone,Sports
+Meu Calendário CP,TOOLS,4.0,37,6.5M,100,Free,0,Everyone,Tools
+Crusaders Quest,FAMILY,4.4,475020,69M,5000000,Free,0,Everyone 10+,Role Playing
+CQ Hotels,TRAVEL_AND_LOCAL,4.3,15,14M,10000,Free,0,Everyone,Travel & Local
+CQ,NEWS_AND_MAGAZINES,3.7,7,3.4M,1000,Free,0,Everyone 10+,News & Magazines
+Curio Quest,FAMILY,4.3,59152,50M,1000000,Free,0,Everyone 10+,Role Playing
+CQ-Mobile,COMMUNICATION,4.2,10,8.1M,1000,Free,0,Everyone,Communication
+CQ Key,TOOLS,4.0,0,1.7M,100,Free,0,Everyone,Tools
+Sabbath School 4,FAMILY,4.3,2871,18M,100000,Free,0,Everyone,Education
+CQ Mobile,FINANCE,2.7,36,18M,1000,Free,0,Everyone,Finance
+Cardinal Quest 2,FAMILY,4.4,19207,36M,100000,Free,0,Everyone,Role Playing
+CQ-Alert,COMMUNICATION,4.2,3,8.1M,500,Free,0,Everyone,Communication
+SDA Collegiate Quarterly,BOOKS_AND_REFERENCE,4.5,8,5.1M,500,Free,0,Everyone,Books & Reference
+CQ SIGNAL PRO 5,FINANCE,4.1,0,1.6M,10,Free,0,Everyone,Finance
+CQ: Lost In Transmission,GAME,4.2,4,61M,10,Free,0,Everyone,Action
+HR Team CQ Region Ed Qld,BUSINESS,4.1,0,4.1M,500,Free,0,Everyone,Business
+Roll Call News,NEWS_AND_MAGAZINES,3.7,24,10M,5000,Free,0,Everyone,News & Magazines
+UFO-CQ,TOOLS,4.0,1,237k,10,Paid,$0.99,Everyone,Tools
+CQ ESPM,BUSINESS,5.0,2,3.4M,5,Free,0,Everyone,Business
+SHUTTLLS CQ - Connect Ride Go,TRAVEL_AND_LOCAL,4.1,0,18M,5,Free,0,Everyone,Travel & Local
+QRZ Assistant,COMMUNICATION,4.2,1044,3.5M,100000,Free,0,Everyone,Communication
+Palavras la cq,GAME,3.9,783,3.4M,100000,Free,0,Everyone,Trivia
+CQ Ukraine,PRODUCTIVITY,4.2,0,9.1M,10,Free,0,Everyone,Productivity
+Pocket Prefix Plus,COMMUNICATION,4.5,192,15M,10000,Free,0,Everyone,Communication
+CQ Electrical Group,PRODUCTIVITY,4.2,0,14M,1,Free,0,Everyone,Productivity
+10 WPM Amateur ham radio CW Morse code trainer,COMMUNICATION,3.5,10,3.8M,100,Paid,$1.49,Everyone,Communication
+Sabbath School,BOOKS_AND_REFERENCE,4.7,28237,10M,100000,Free,0,Everyone,Books & Reference
+Gunship Modern Combat 3D,GAME,4.2,3247,26M,500000,Free,0,Teen,Action
+Gun Simulator - Gun Games,FAMILY,4.4,134,Varies with device,10000,Free,0,Teen,Simulation
+ClanManagerTT2,FAMILY,4.7,55,3.3M,1000,Free,0,Everyone,Casual
+Christian Questions Podcast,FAMILY,4.6,222,15M,10000,Free,0,Everyone,Education
+Sniper Killer Shooter,GAME,4.0,119368,19M,10000000,Free,0,Teen,Action
+25WPM Amateur ham radio Koch CW Morse code trainer,TOOLS,4.0,0,3.7M,10,Paid,$1.49,Everyone,Tools
+QST,FAMILY,2.5,706,Varies with device,10000,Free,0,Everyone,Education
+Cypress College Library,BOOKS_AND_REFERENCE,4.3,0,2.1M,100,Free,0,Everyone,Books & Reference
+Create My App,BUSINESS,4.1,0,11M,10,Free,0,Everyone,Business
+Snowboard Racing Free Fun Game,GAME,3.8,4552,43M,100000,Free,0,Everyone,Racing
+theCut,LIFESTYLE,4.7,499,6.9M,50000,Free,0,Everyone,Lifestyle
+الفاتحون Conquerors,FAMILY,4.5,108130,40M,5000000,Free,0,Teen,Strategy
+Toughest Game Ever 2,GAME,4.6,293086,Varies with device,5000000,Free,0,Everyone,Action
+RIDE ZERO,GAME,4.6,8778,36M,100000,Free,0,Teen,Music
+CricQuick,SPORTS,5.0,17,1.5M,50,Free,0,Everyone,Sports
+Next Island: Dino Village,FAMILY,3.9,29,37M,1000,Free,0,Everyone 10+,Casual
+iReadMe,PRODUCTIVITY,5.0,8,22M,100,Free,0,Everyone,Productivity
+Global Shop,BUSINESS,4.1,0,3.3M,50,Free,0,Everyone,Business
+Webmail web mobile app,TOOLS,2.3,395,2.6M,100000,Free,0,Everyone,Tools
+QC,FAMILY,4.2,4,34M,100,Free,0,Everyone,Puzzle
+Traffic Info and Traffic Alert,MAPS_AND_NAVIGATION,3.6,695,2.9M,100000,Free,0,Everyone,Maps & Navigation
+Color Quartets,FAMILY,4.0,42,12M,1000,Free,0,Everyone,Casual
+Ham Radio Prefixes,COMMUNICATION,3.7,218,3.7M,10000,Free,0,Everyone,Communication
+Battle Result Predictor for CR,TOOLS,4.2,7063,17M,1000000,Free,0,Everyone,Tools
+Deck Advisor for CR,TOOLS,4.1,37975,23M,5000000,Free,0,Everyone,Tools
+Card Creator for CR,TOOLS,4.4,117850,17M,10000000,Free,0,Everyone,Tools
+CR & CoC Private Server - Clash Barbarians PRO,FAMILY,4.6,167974,5.0M,500000,Free,0,Everyone,Entertainment
+Deck Analyzer for CR,TOOLS,4.2,2630,18M,100000,Free,0,Everyone,Tools
+Chest Simulator for Clash Royale,FAMILY,4.4,4756,33M,100000,Free,0,Everyone,Simulation
+Clash Soundboard For CR & COC,FAMILY,4.3,13,26M,500,Free,0,Everyone,Entertainment
+Quiz for Clash Royale™,FAMILY,4.0,3788,32M,100000,Free,0,Everyone,Entertainment
+CR Blue Icon Pack,PERSONALIZATION,4.5,323,38M,10000,Free,0,Everyone,Personalization
+Chest Calculator for CR,FAMILY,3.9,14754,21M,1000000,Free,0,Everyone 10+,Entertainment
+Ultimate Calculator for CR,PRODUCTIVITY,3.7,7389,41M,500000,Free,0,Everyone,Productivity
+DCUO|CR Calculator Pro,TOOLS,4.6,82,1.7M,500,Paid,$0.99,Everyone,Tools
+Servidor Privado CR y CoC - Royale Servers PRO,TOOLS,4.0,55,4.3M,100,Paid,$1.99,Everyone,Tools
+Stats CR Clan for Clash Royale,FAMILY,3.8,16,9.9M,100,Free,0,Everyone,Entertainment
+Ultimate Clash Royale Tracker,FAMILY,4.7,92010,5.9M,1000000,Free,0,Everyone,Strategy
+Chest Opener for CR - The Circle Game,FAMILY,4.2,68,2.7M,5000,Free,0,Everyone,Entertainment
+Deck Simulator for CR,TOOLS,3.4,202,12M,10000,Free,0,Everyone,Tools
+Stats Royale for Clash Royale,BOOKS_AND_REFERENCE,4.5,68226,16M,1000000,Free,0,Everyone,Books & Reference
+Counter Deck Calculator for CR,TOOLS,4.1,3446,19M,500000,Free,0,Everyone,Tools
+CR Calculator,TOOLS,4.3,297,2.8M,50000,Free,0,Everyone,Tools
+Servidor Privado de CR y CoC - Light Royale,FAMILY,4.6,3106,3.6M,10000,Free,0,Everyone,Entertainment
+Helper for Clash Royale (All-in-1),FAMILY,4.3,6078,37M,500000,Free,0,Everyone,Entertainment
+"CR Fans: Mazos, Clanes y Grupos",FAMILY,4.3,219,4.3M,5000,Free,0,Everyone,Entertainment
+DCUO|CR Calculator Lite,TOOLS,4.0,182,1.7M,10000,Free,0,Everyone,Tools
+CR -Call Recorder,TOOLS,4.0,4,3.1M,100,Free,0,Everyone,Tools
+CR Best Decks,FAMILY,3.5,34,30M,1000,Free,0,Everyone,Strategy
+CR Family,FAMILY,2.3,10,5.2M,1000,Free,0,Everyone,Education
+CR Monitor,AUTO_AND_VEHICLES,4.2,1,2.8M,5,Free,0,Everyone,Auto & Vehicles
+JavaScript Editor CR,TOOLS,3.9,114,18M,5000,Free,0,Everyone,Tools
+Jetting for Honda CR dirt bike,SPORTS,4.1,7,3.4M,100,Paid,$3.49,Everyone,Sports
+CR-Red,PERSONALIZATION,4.5,561,41M,10000,Free,0,Everyone,Personalization
+Deck Shop for Clash Royale,FAMILY,4.6,2167,13M,100000,Free,0,Everyone,Entertainment
+Royale Tournaments,FAMILY,4.4,2420,6.7M,50000,Free,0,Teen,Entertainment
+Deck Builder & Analyzer for CR,FAMILY,3.1,52,9.8M,5000,Free,0,Everyone,Entertainment
+Chest Tracker for Clash Royale,TOOLS,4.3,77717,14M,5000000,Free,0,Everyone,Tools
+Jeppesen CR Flight Computer,MAPS_AND_NAVIGATION,3.3,3,26M,100,Paid,$9.99,Everyone,Maps & Navigation
+Cr Aviation Academy,FAMILY,5.0,7,22M,100,Free,0,Everyone,Education
+The ClubHouse CR,HEALTH_AND_FITNESS,4.3,5,8.7M,100,Free,0,Everyone,Health & Fitness
+CR-V Service Manual,AUTO_AND_VEHICLES,4.2,12,88M,500,Free,0,Everyone,Auto & Vehicles
+Java Editor CR,TOOLS,3.8,434,18M,50000,Free,0,Everyone,Tools
+XML Editor CR,TOOLS,3.3,47,18M,5000,Free,0,Everyone,Tools
+Evolution Marketing CR,HEALTH_AND_FITNESS,4.3,14,1.3M,1000,Free,0,Everyone,Health & Fitness
+CR Tracker for Chests,TOOLS,5.0,6,4.5M,50,Free,0,Everyone,Tools
+CR Magazine,BUSINESS,1.0,1,7.8M,100,Free,0,Everyone,Business
+Ultimate Chest Tracker,PRODUCTIVITY,4.5,40328,23M,1000000,Free,0,Everyone,Productivity
+CamScanner - Phone PDF Creator,PRODUCTIVITY,4.6,1502622,Varies with device,100000000,Free,0,Everyone,Productivity
+Critical Strike CS: Counter Terrorist Online FPS,GAME,4.3,22773,Varies with device,1000000,Free,0,Mature 17+,Action
+CamScanner (License),PRODUCTIVITY,4.4,26358,50k,500000,Paid,$1.99,Everyone,Productivity
+Assault Line CS Online Fps Go,GAME,4.1,52163,70M,1000000,Free,0,Mature 17+,Action
+Standoff 2,GAME,4.5,299046,47M,10000000,Free,0,Mature 17+,Action
+Counter Online FPS Game,GAME,4.2,41089,42M,5000000,Free,0,Teen,Action
+CS Customizer,COMMUNICATION,3.7,25,3.7M,1000,Free,0,Everyone,Communication
+Combat Strike CS 🔫 Counter Terrorist Attack FPS💣,GAME,4.1,1019,39M,100000,Free,0,Teen,Action
+CS-Touch,FAMILY,3.9,337,22M,10000,Free,0,Everyone,Education
+Ultimate Quiz for CS:GO - Skins | Cases | Players,GAME,4.5,2526,22M,100000,Free,0,Everyone,Trivia
+Аim Training for CS,GAME,3.6,2328,12M,100000,Free,0,Everyone,Action
+Sniper Traning for CS GO,GAME,3.2,655,14M,50000,Free,0,Teen,Action
+NetClient CS,BUSINESS,3.5,125,4.3M,10000,Free,0,Everyone,Business
+CS Guns Shoot,FAMILY,3.7,433,Varies with device,50000,Free,0,Teen,Entertainment
+Asiimov Skin - CS GO Icon Pack,PERSONALIZATION,4.6,26,8.5M,100,Paid,$2.49,Everyone,Personalization
+CS Interview Questions (TechQ),FAMILY,4.8,33,6.7M,5000,Free,0,Everyone,Education
+Your rank CS:GO,GAME,4.1,4946,7.5M,100000,Free,0,Teen,Trivia
+Guide for CS:GO,FAMILY,4.4,16459,88M,500000,Free,0,Everyone,Entertainment
+CS Interview FAQs,FAMILY,4.3,99,1.1M,10000,Free,0,Everyone,Education
+CS,BUSINESS,4.1,5,8.3M,100,Free,0,Everyone,Business
+Mobile CS,BUSINESS,4.0,13,5.7M,1000,Free,0,Everyone,Business
+Mobile CS:GO,GAME,3.1,1015,643k,100000,Free,0,Everyone,Action
+Counter Terrorist Gun Strike CS: Special Forces,GAME,4.2,211,44M,10000,Free,0,Teen,Action
+C.S. Lewis Daily Quotes,LIFESTYLE,4.1,75,11M,10000,Free,0,Everyone,Lifestyle
+CS go bomb simulator,FAMILY,4.2,7,28M,10,Paid,$0.99,Everyone,Casual
+Shooter Sniper CS - FPS Games,GAME,3.5,14823,40M,1000000,Free,0,Teen,Action
+CS16Client,GAME,4.3,8668,9.1M,500000,Free,0,Teen,Action
+CS Browser | #1 & BEST BROWSER,COMMUNICATION,3.8,52,2.1M,1000,Free,0,Everyone,Communication
+Counter Attack - Multiplayer FPS,GAME,4.3,112565,32M,1000000,Free,0,Teen,Action
+DU CS Lectures - Learn to Code for Free,FAMILY,4.8,16,7.8M,100,Free,0,Everyone,Education
+What's Your CS:GO rank?,GAME,2.3,278,2.4M,10000,Free,0,Teen,Trivia
+CS Browser Beta,COMMUNICATION,4.3,125,53M,5000,Free,0,Everyone,Communication
+Helper for CS:GO,TOOLS,4.4,208,6.0M,10000,Free,0,Everyone,Tools
+My Nexus for CS:S & CS:GO,FAMILY,3.6,783,25M,50000,Free,0,Teen,Entertainment
+CS & IT Interview Questions,FAMILY,5.0,43,3.3M,1000,Free,0,Everyone,Education
+GATE 21 years CS Papers(2011-2018 Solved),BOOKS_AND_REFERENCE,4.3,1,34M,50,Free,0,Everyone,Books & Reference
+Map Callouts for CS:GO,GAME,4.3,211,3.6M,50000,Free,0,Everyone,Action
+GATE CS Engineering 2019 Exam Prep App,FAMILY,4.2,162,6.2M,10000,Free,0,Everyone,Education
+Case Simulator Hero for CS:GO,FAMILY,4.3,14604,68M,500000,Free,0,Teen,Simulation
+CA CS Network,FAMILY,4.7,160,19M,5000,Free,0,Everyone,Education
+Smokes for CS:GO,FAMILY,3.9,3253,3.6M,100000,Free,0,Everyone,Entertainment
+Grenade Practice for CS:GO,FAMILY,4.4,431,17M,10000,Free,0,Everyone,Entertainment
+Quiz CS:GO players,GAME,4.4,460,31M,50000,Free,0,Everyone,Trivia
+Puzzle for CS:GO,GAME,4.3,247,18M,10000,Free,0,Everyone,Word
+Bomb and Nade Timer for CS:GO,PRODUCTIVITY,2.6,85,6.0M,5000,Free,0,Everyone,Productivity
+Smokes Guide for CS:GO,FAMILY,4.3,445,29M,50000,Free,0,Everyone,Entertainment
+Philips IQon Spectral CT Fundamentals.,MEDICAL,4.2,2,77M,100,Free,0,Everyone,Medical
+RadRevision: Anatomy on CT,MEDICAL,3.8,568,42M,50000,Free,0,Everyone,Medical
+Radiology CT Anatomy,MEDICAL,4.2,345,14M,50000,Free,0,Everyone,Medical
+CT Scan Viewer 3D,MEDICAL,4.2,6,29M,1000,Free,0,Everyone,Medical
+Learn CT Scan Of Head,BOOKS_AND_REFERENCE,4.1,10,5.7M,5000,Free,0,Everyone,Books & Reference
+CT Abdomen Pelvis,MEDICAL,4.0,36,36M,10000,Free,0,Everyone,Medical
+CT Neck,MEDICAL,4.4,7,8.9M,1000,Free,0,Everyone,Medical
+CT Scan Generations,FAMILY,4.7,6,5.1M,1000,Free,0,Everyone,Education
+Emergency Brain CT,MEDICAL,4.2,2,19M,10,Paid,$0.99,Everyone,Medical
+CT Prepares,NEWS_AND_MAGAZINES,2.6,13,4.3M,1000,Free,0,Everyone,News & Magazines
+CT Abdomen,FAMILY,4.3,7,62M,1000,Free,0,Everyone,Education
+CT Brain Interpretation,FAMILY,5.0,3,29M,500,Free,0,Everyone,Education
+CT-Guide & Positioning,FAMILY,3.7,6,7.8M,1000,Free,0,Everyone,Education
+CT Sessions,MEDICAL,4.3,62,20M,5000,Free,0,Everyone,Medical
+CT - DTC Lookup,TOOLS,4.1,41,986k,10000,Free,0,Everyone,Tools
+POCKET ATLAS OF CT HEAD,MEDICAL,4.3,22,18M,10000,Free,0,Everyone,Medical
+Interactive CT & MRI Anat.Lite,MEDICAL,3.8,534,14M,100000,Free,0,Everyone,Medical
+CT POSITIONING,MEDICAL,4.5,18,9.3M,5000,Free,0,Everyone,Medical
+CT Cervical Spine,MEDICAL,5.0,5,17M,1000,Free,0,Everyone,Medical
+Trauma CT Head Rules,MEDICAL,4.2,2,1.4M,100,Free,0,Everyone,Medical
+CT Head Basic Interpretation,FAMILY,4.2,1,16M,100,Free,0,Everyone,Education
+CT MyChiroTown Mobile,MEDICAL,3.9,40,4.0M,5000,Free,0,Everyone,Medical
+CT Lottery,FAMILY,3.8,271,8.3M,50000,Free,0,Teen,Entertainment
+Permit Test Connecticut CT DMV,FAMILY,4.6,186,9.6M,10000,Free,0,Everyone,Education
+POCKET BOOK CT ABDOMEN,MEDICAL,4.2,0,11M,100,Free,0,Everyone,Medical
+I AM C.T.,HEALTH_AND_FITNESS,4.6,28,20M,1000,Free,0,Mature 17+,Health & Fitness
+Solar CT PV System Power,PRODUCTIVITY,4.7,315,14M,10000,Free,0,Everyone,Productivity
+CARDIAC CT TECHNIQUE,MEDICAL,5.0,6,17M,1000,Free,0,Everyone,Medical
+TUTORIAL CT SCAN CARDIAC,MEDICAL,4.2,1,15M,1000,Free,0,Everyone,Medical
+HEAD TRAUMA CT EVALUATION,MEDICAL,4.5,18,13M,10000,Free,0,Everyone,Medical
+Simpli CT,TOOLS,4.0,4,11M,100,Free,0,Everyone,Tools
+CT Scan Cross Sectional Anatomy,MEDICAL,4.3,10,46M,100,Free,0,Everyone,Medical
+Remote CT - Smart Remote,TOOLS,3.5,3988,11M,1000000,Free,0,Everyone,Tools
+CT-REMOTE,GAME,3.3,19,1.6M,100,Paid,$4.49,Everyone,Action
+CT CONNECT,PRODUCTIVITY,4.2,2,28M,50,Free,0,Everyone,Productivity
+CT-ART 4.0 (Chess Tactics 1200-2400 ELO),GAME,4.8,8191,Varies with device,100000,Free,0,Everyone,Board
+CT-Stream Player,FAMILY,3.9,84,11M,10000,Free,0,Everyone,Entertainment
+CT Pulmonary Angiography,MEDICAL,4.2,0,4.9M,100,Free,0,Everyone,Medical
+Results for CT Lottery,FAMILY,4.5,86,8.6M,5000,Free,0,Teen,Entertainment
+Abdominal CT Sectional Walker,MEDICAL,4.2,2,23M,100,Paid,$9.99,Everyone,Medical
+Interactive CT and MRI Anatomy,MEDICAL,3.4,35,24M,1000,Paid,$15.46,Everyone,Medical
+Dine In CT - Food Delivery,SHOPPING,5.0,4,1.6M,1000,Free,0,Everyone,Shopping
+CT Checkout,FINANCE,5.0,1,8.4M,50,Free,0,Everyone,Finance
+CT and XR Dose Calculator,MEDICAL,4.2,3,97k,50,Paid,$0.99,Everyone,Medical
+Chest CT Sectional Walker,MEDICAL,4.2,2,20M,100,Paid,$9.99,Everyone,Medical
+Radiological Anatomy For FRCR1,MEDICAL,4.8,12,44M,100,Paid,$6.99,Everyone,Medical
+Radiology CT Viewer,MEDICAL,3.6,35,88M,10000,Free,0,Everyone,Medical
+POCKET ATLAS CARDIAC MRI AND CT,MEDICAL,4.2,0,4.8M,50,Free,0,Everyone,Medical
+"CU: UPI Payments, Chat & Call",FINANCE,4.3,693,32M,100000,Free,0,Teen,Finance
+CU of Colorado Mobile Banking,FINANCE,4.0,347,25M,10000,Free,0,Everyone,Finance
+Tech CU Mobile Banking,FINANCE,4.5,853,27M,10000,Free,0,Everyone,Finance
+My CU - Caucasus University,PRODUCTIVITY,4.6,48,7.3M,1000,Free,0,Everyone,Productivity
+Service CU Mobile Banking,FINANCE,4.7,6208,14M,100000,Free,0,Everyone,Finance
+Redwood CU v3.1.0,FINANCE,3.8,480,15M,50000,Free,0,Everyone,Finance
+Cyprus CU Mobile Banking,FINANCE,3.4,295,Varies with device,10000,Free,0,Everyone,Finance
+BayPort CU Mobile Banking,FINANCE,4.7,2374,16M,10000,Free,0,Everyone,Finance
+CU SoCal Mobile Banking,FINANCE,4.0,253,25M,10000,Free,0,Everyone,Finance
+Tropical Financial CU,FINANCE,4.6,1231,14M,10000,Free,0,Everyone,Finance
+Travis CU,FINANCE,2.0,207,2.9M,10000,Free,0,Everyone,Finance
+Commonwealth CU Go Mobile,FINANCE,4.3,231,18M,10000,Free,0,Everyone,Finance
+Public Service CU Mobile,FINANCE,2.0,314,35M,10000,Free,0,Everyone,Finance
+Freedom CU,FINANCE,3.6,117,25M,10000,Free,0,Everyone,Finance
+Meritrust CU Mobile Banking,FINANCE,4.7,3661,14M,50000,Free,0,Everyone,Finance
+Nusenda CU– Mobile Banking,FINANCE,3.5,805,6.5M,50000,Free,0,Everyone,Finance
+Lake Michigan CU Mobile,FINANCE,4.0,732,5.5M,50000,Free,0,Everyone,Finance
+Maps CU,FINANCE,3.5,256,28M,10000,Free,0,Everyone,Finance
+Family Savings CU Mobile,FINANCE,4.3,323,17M,10000,Free,0,Everyone,Finance
+FORUM Credit Union CU Online,FINANCE,4.1,196,7.3M,10000,Free,0,Everyone,Finance
+Educators CU Mobile Banking,FINANCE,4.6,1992,24M,50000,Free,0,Everyone,Finance
+Space Coast CU Mobile,FINANCE,3.8,922,2.1M,100000,Free,0,Everyone,Finance
+First Tech Federal CU,FINANCE,4.3,4290,24M,50000,Free,0,Everyone,Finance
+Southland CU,FINANCE,3.8,109,2.8M,10000,Free,0,Everyone,Finance
+Tech CU Card Manager,FINANCE,1.0,2,7.2M,1000,Free,0,Everyone,Finance
+Numerica CU,FINANCE,3.8,472,8.6M,50000,Free,0,Everyone,Finance
+Red River CU,FINANCE,3.3,343,2.3M,10000,Free,0,Everyone,Finance
+Firefighters First CU,FINANCE,4.8,495,12M,5000,Free,0,Everyone,Finance
+MYCU TX Mobile Banking,FINANCE,3.0,4,Varies with device,100,Free,0,Everyone,Finance
+Amazing Fart Sounds,FAMILY,4.0,28136,Varies with device,5000000,Free,0,Everyone,Casual
+Navigator PRO - GPS Navigation with Offline Maps,TRAVEL_AND_LOCAL,3.6,892,70M,50000,Paid,$2.49,Everyone,Travel & Local
+My Vodafone (GR),COMMUNICATION,3.8,12667,34M,1000000,Free,0,Everyone,Communication
+HTC Transfer Tool,TOOLS,4.3,40907,2.6M,5000000,Free,0,Everyone,Tools
+Planet of Cubes Survival Craft,FAMILY,3.9,475944,35M,10000000,Free,0,Everyone,Simulation
+Moto Rider,GAME,4.2,115176,24M,10000000,Free,0,Teen,Racing
+Shadow Fight 2,GAME,4.6,10981850,88M,100000000,Free,0,Everyone 10+,Action
+Crazy Wheels,GAME,4.0,121082,7.0M,10000000,Free,0,Teen,Adventure
+Curriculum vitae App CV Builder Free Resume Maker,BUSINESS,4.5,4571,3.9M,500000,Free,0,Everyone,Business
+Free Resume App,BUSINESS,4.6,15830,Varies with device,1000000,Free,0,Everyone,Business
+CV Engineer - Free Resume Maker & CV Templates,BUSINESS,4.6,213,3.8M,10000,Free,0,Everyone,Business
+CV Examples 2018,FAMILY,4.5,625,26M,100000,Free,0,Everyone,Education
+Curriculum Vitae,BUSINESS,3.7,3757,5.0M,1000000,Free,0,Everyone,Business
+Free resume builder CV maker templates PDF formats,BUSINESS,4.4,9555,4.7M,1000000,Free,0,Everyone,Business
+Resume Builder - Free CV Maker & Premium Templates,BUSINESS,4.6,770,5.6M,100000,Free,0,Everyone,Business
+Easy Cv maker 2018,BOOKS_AND_REFERENCE,3.9,88,5.3M,10000,Free,0,Everyone,Books & Reference
+Resume PDF Maker / CV Builder,BUSINESS,4.4,2147,2.2M,500000,Free,0,Everyone,Business
+Resume & CV Creator by Desygner,PRODUCTIVITY,4.5,48,26M,5000,Free,0,Everyone,Productivity
+CV S ( CV Editor - Resume ),BUSINESS,4.5,3972,5.6M,100000,Free,0,Teen,Business
+CV Formats 2018,FAMILY,4.3,374,26M,100000,Free,0,Everyone,Education
+CV Maker Pro,BUSINESS,3.7,113,8.6M,10000,Free,0,Everyone,Business
+Free CV Creator,TOOLS,3.9,37,21M,10000,Free,0,Everyone,Tools
+"Job CV Maker-Portfolio Maker , Resume Maker",FAMILY,3.9,139,4.8M,50000,Free,0,Everyone,Education
+Resume Builder and CV maker app,PRODUCTIVITY,4.3,2303,15M,100000,Free,0,Everyone,Productivity
+HOW TO WRITE A CV,BUSINESS,4.1,489,20M,100000,Free,0,Everyone,Business
+CV EXAMPLES,BUSINESS,4.1,423,20M,100000,Free,0,Everyone,Business
+Cv maker / Job cv maker,FAMILY,4.4,14,5.5M,1000,Free,0,Everyone,Education
+"Resume Builder Free, CV Maker & Resume Templates",BUSINESS,4.4,20921,5.7M,1000000,Free,0,Everyone,Business
+"Free Professional Resume Builder, CV, Cover Letter",BUSINESS,4.2,831,11M,50000,Free,0,Everyone,Business
+Resume Free,PRODUCTIVITY,4.5,27820,4.7M,1000000,Free,0,Everyone,Productivity
+How to Write CV,BOOKS_AND_REFERENCE,4.6,244,4.1M,100000,Free,0,Everyone,Books & Reference
+"Super Resume Builder Pro, CV",BUSINESS,4.4,244,6.9M,1000,Paid,$4.99,Everyone,Business
+Free Resume Builder – CV Maker,BUSINESS,4.4,25,12M,5000,Free,0,Everyone,Business
+Resume App,BUSINESS,4.4,11310,Varies with device,1000000,Free,0,Everyone,Business
+CV Builder,BUSINESS,3.8,203,5.9M,10000,Free,0,Everyone,Business
+Curriculum Vitae - Resume CV,PRODUCTIVITY,2.6,80,2.2M,10000,Free,0,Everyone,Productivity
+"Resume Maker:Free CV Maker,Templates Builder",BUSINESS,4.2,715,7.1M,100000,Free,0,Everyone,Business
+Resume Builder / CV Maker & Templates,BUSINESS,4.4,25,7.9M,5000,Free,0,Everyone,Business
+CV maker for Job Applications and Resume Maker,TOOLS,4.2,75,25M,10000,Free,0,Everyone,Tools
+CV Templates 2018,FAMILY,4.0,13,26M,5000,Free,0,Everyone,Education
+Job CV Maker & Portfolio Maker,FAMILY,4.2,593,4.9M,100000,Free,0,Everyone,Education
+CV Maker for Job Applications:Photo Resume Builder,TOOLS,4.0,114,25M,10000,Free,0,Everyone,Tools
+CV Creator,FAMILY,4.4,31,8.3M,10000,Free,0,Everyone,Education
+Resume ( CV Editor ),BUSINESS,4.5,416,6.0M,10000,Free,0,Everyone,Business
+CV Maker,PERSONALIZATION,3.2,114,3.0M,10000,Free,0,Everyone,Personalization
+Resume Maker - Creator,BUSINESS,4.3,740,19M,50000,Free,0,Everyone,Business
+CV Builder for Smart Resumes,BUSINESS,3.4,22,4.1M,1000,Free,0,Everyone,Business
+CV-RECORD Pro,COMMUNICATION,2.3,42,6.0M,1000,Paid,$0.99,Everyone,Communication
+CV-Library Job Search,BUSINESS,4.4,6997,4.6M,100000,Free,0,Everyone,Business
+CV Samples 2018,BUSINESS,4.3,34,26M,10000,Free,0,Everyone,Business
+CV (Curriculum Vitae / Resume) Maker,BUSINESS,4.1,4,4.4M,5000,Free,0,Everyone,Business
+"Easy Resume Builder, Resume help, Curriculum vitae",TOOLS,4.3,996,10M,50000,Free,0,Everyone,Tools
+Resume / CV,BUSINESS,3.6,125,5.0M,10000,Free,0,Everyone,Business
+VisualCV Resume Builder,BUSINESS,4.6,2555,16M,100000,Free,0,Everyone,Business
+Resume Maker / CV creator & Templates,TOOLS,4.2,54,22M,5000,Free,0,Everyone,Tools
+Resume Builder - Curriculum Vitae & Resume Maker,BUSINESS,4.0,12,8.1M,5000,Free,0,Everyone,Business
+The CW,FAMILY,4.4,288209,21M,5000000,Free,0,Teen,Entertainment
+CW Seed,FAMILY,4.5,16391,13M,500000,Free,0,Teen,Entertainment
+The CW TV app,FAMILY,3.2,24,4.8M,5000,Free,0,Everyone,Entertainment
+CW TV,NEWS_AND_MAGAZINES,1.7,367,6.1M,50000,Free,0,Everyone,News & Magazines
+The CW TN app 2018,FAMILY,2.2,54,4.3M,10000,Free,0,Everyone,Entertainment
+Archie Comics,COMICS,3.8,5084,6.2M,100000,Free,0,Everyone,Comics
+2 Amateur ham radio CW Morse code practice keys TX,COMMUNICATION,4.8,6,3.5M,100,Paid,$1.49,Everyone,Communication
+All Star Of CW,FAMILY,4.2,0,2.4M,10,Free,0,Everyone,Role Playing
+Cartoon Wars: Blade,GAME,4.4,165656,38M,5000000,Free,0,Teen,Arcade
+FANDOM: Arrow and The Flash,FAMILY,4.5,3935,9.5M,100000,Free,0,Mature 17+,Entertainment
+CW Beacon for Ham Radio,COMMUNICATION,4.8,10,516k,100,Paid,$1.49,Everyone,Communication
+IZ2UUF Morse Koch CW,COMMUNICATION,4.6,649,837k,50000,Free,0,Everyone,Communication
+Morse Decoder for Ham Radio,COMMUNICATION,3.7,166,2.0M,5000,Paid,$4.99,Everyone,Communication
+C W Browser,COMMUNICATION,4.4,14,17M,100,Free,0,Everyone,Communication
+Canon CameraWindow,PHOTOGRAPHY,3.5,12204,6.8M,1000000,Free,0,Everyone,Photography
+Saiyan Of CW,FAMILY,3.8,5,1.1M,500,Free,0,Everyone,Role Playing
+CW Studio ®,COMMUNICATION,3.8,9,780k,100,Paid,$0.99,Everyone,Communication
+20WPM Amateur ham radio Koch CW Morse code trainer,COMMUNICATION,4.3,12,3.7M,100,Paid,$1.49,Everyone,Communication
+CW Bluetooth SPP,COMMUNICATION,4.2,3,961k,100,Free,0,Everyone,Communication
+Morse Trainer for Ham Radio,COMMUNICATION,4.6,265,2.6M,10000,Paid,$2.99,Everyone,Communication
+Free CW TN Videos 2018,FAMILY,4.2,0,4.8M,10,Free,0,Everyone,Entertainment
+The Church at CW,LIFESTYLE,4.5,2,7.8M,100,Free,0,Teen,Lifestyle
+CW Mobile,FAMILY,4.2,3,22M,50,Free,0,Everyone,Education
+"Freeform – Stream Full Episodes, Movies, & Live TV",FAMILY,3.7,29229,Varies with device,1000000,Free,0,Teen,Entertainment
+CW BLE Peripheral Simulator,COMMUNICATION,4.2,2,1.5M,500,Free,0,Everyone,Communication
+Morse Machine for Ham Radio,COMMUNICATION,4.8,341,9.6M,5000,Paid,$0.99,Everyone,Communication
+Pocket RxTx Pro,PRODUCTIVITY,4.3,253,Varies with device,5000,Paid,$3.99,Everyone,Productivity
+Morse Player,FAMILY,5.0,12,2.4M,100,Paid,$1.99,Everyone,Education
+"FXNOW: Movies, Shows & Live TV",FAMILY,3.9,31552,Varies with device,1000000,Free,0,Teen,Entertainment
+My CW,TOOLS,3.0,1,55M,100,Free,0,Everyone,Tools
+CW Ringtone (Morse Code generator),COMMUNICATION,4.2,0,269k,10,Paid,$2.49,Everyone,Communication
+30WPM Amateur ham radio Koch CW Morse code trainer,FAMILY,5.0,1,3.7M,10,Paid,$1.49,Everyone,Education
+Learn CW,FAMILY,4.2,0,21M,1,Paid,$2.49,Everyone,Education
+DC All Access,FAMILY,4.4,12639,96M,500000,Free,0,Teen,Entertainment
+Koch Morse Trainer Pro,COMMUNICATION,4.6,94,1.1M,1000,Paid,$2.49,Everyone,Communication
+Morse Code Reader,COMMUNICATION,3.9,1436,20k,100000,Free,0,Everyone,Communication
+CW Nuclear,BOOKS_AND_REFERENCE,3.3,15,12M,1000,Free,0,Everyone,Books & Reference
+Pocket RxTx Free,PRODUCTIVITY,4.1,4513,Varies with device,100000,Free,0,Everyone,Productivity
+CW Deposit,BUSINESS,3.0,4,498k,1000,Free,0,Everyone,Business
+Hallmark Channel Everywhere,FAMILY,4.2,6784,13M,500000,Free,0,Everyone,Entertainment
+Morse Player Free,FAMILY,4.2,268,4.2M,50000,Free,0,Everyone,Education
+News 8 San Diego,NEWS_AND_MAGAZINES,4.2,1137,11M,50000,Free,0,Everyone,News & Magazines
+"Hulu: Stream TV, Movies & more",FAMILY,4.0,319777,Varies with device,10000000,Free,0,Teen,Entertainment
+Learn Morse Code - G0HYN Learn Morse,COMMUNICATION,4.0,27,600k,5000,Free,0,Everyone,Communication
+SYFY,FAMILY,3.2,3069,18M,500000,Free,0,Teen,Entertainment
+Morse Notifier Free,TOOLS,4.6,79,3.0M,1000,Free,0,Everyone,Tools
+AMC,FAMILY,3.2,20843,14M,1000000,Free,0,Teen,Entertainment
+Cartoon Wars 3,FAMILY,4.1,137674,72M,5000000,Free,0,Teen,Role Playing
+ABC – Live TV & Full Episodes,FAMILY,3.3,50428,Varies with device,5000000,Free,0,Teen,Entertainment
+Oracle CX Cloud Mobile,BUSINESS,4.4,48,54M,5000,Free,0,Everyone,Business
+CX-10WiFi,FAMILY,4.0,1419,12M,100000,Free,0,Everyone,Casual
+CX-OF,FAMILY,4.2,18,37M,1000,Free,0,Everyone,Entertainment
+cx-32wifi,FAMILY,4.1,62,6.5M,10000,Free,0,Everyone,Entertainment
+CX-17WIFI,FAMILY,4.3,49,6.6M,10000,Free,0,Everyone,Entertainment
+Cathay Pacific,TRAVEL_AND_LOCAL,3.3,4069,50M,1000000,Free,0,Everyone,Travel & Local
+Cx File Explorer,TOOLS,4.7,175,4.3M,10000,Free,0,Everyone,Tools
+cx-33wifi,FAMILY,4.4,63,7.6M,10000,Free,0,Everyone,Entertainment
+CX-WiFi720P,FAMILY,3.1,47,5.5M,10000,Free,0,Everyone,Entertainment
+CX-60,FAMILY,3.1,19,94M,1000,Free,0,Everyone,Casual
+ACTIVEON CX & CX GOLD,VIDEO_PLAYERS,3.3,439,35M,50000,Free,0,Everyone,Video Players & Editors
+CX North America,BUSINESS,3.9,10,55M,500,Free,0,Everyone,Business
+CX-10DS,FAMILY,3.4,12,11M,1000,Free,0,Everyone,Casual
+CX-37,FAMILY,3.9,13,12M,1000,Free,0,Everyone,Casual
+Avaya CX,BUSINESS,4.4,21,21M,1000,Free,0,Everyone,Business
+TI-Nspire CX Calculator Manual,FAMILY,3.9,11,27M,500,Paid,$4.99,Everyone,Education
+CX_WiFiUFO,SPORTS,3.7,818,5.3M,100000,Free,0,Everyone,Sports
+CX watcher,FAMILY,4.5,4,30M,500,Free,0,Everyone,Casual
+Theme For Techno Camon CX,PERSONALIZATION,4.7,42,10M,5000,Free,0,Everyone,Personalization
+CX-95WIFI,LIFESTYLE,4.1,6,11M,500,Free,0,Everyone,Lifestyle
+Theme for Tecno Camon CX / C8,LIFESTYLE,4.6,147,9.8M,10000,Free,0,Everyone,Lifestyle
+CX Carrier Lite,BUSINESS,4.1,0,68M,10,Free,0,Everyone,Business
+Oración CX,LIFESTYLE,5.0,103,3.8M,5000,Free,0,Everyone,Lifestyle
+CX-40,FAMILY,3.0,2,33M,100,Free,0,Everyone,Entertainment
+Cx Wize,PRODUCTIVITY,4.2,3,24M,100,Free,0,Everyone,Productivity
+Ring,COMMUNICATION,3.9,517,35M,10000,Free,0,Everyone,Communication
+Racing CX,GAME,4.3,4,20M,500,Free,0,Everyone,Racing
+cx advance call blocker,PERSONALIZATION,5.0,3,3.4M,50,Free,0,Everyone,Personalization
+CX Ram Booster,TOOLS,3.9,12,2.5M,500,Free,0,Everyone,Tools
+CX-42,FAMILY,4.2,0,32M,10,Free,0,Everyone,Casual
+CX Capture,BUSINESS,4.1,1,5.8M,100,Free,0,Everyone,Business
+CONNECT: The Mobile CX Summit,PRODUCTIVITY,4.2,0,18M,50,Free,0,Teen,Productivity
+Hyundai CX Conference,COMMUNICATION,4.2,0,20M,50,Free,0,Everyone,Communication
+CX-41,LIFESTYLE,4.1,1,32M,100,Free,0,Everyone,Lifestyle
+CX Monthly Tech News,VIDEO_PLAYERS,4.1,2,6.9M,500,Free,0,Everyone,Video Players & Editors
+CXmodel-ufo,FAMILY,3.8,19,12M,1000,Free,0,Everyone,Entertainment
+CX Summit,PRODUCTIVITY,4.2,1,17M,50,Free,0,Teen,Productivity
+Secret Codes For Android,TOOLS,3.6,6060,592k,500000,Free,0,Everyone,Tools
+Absolute RC Heli Simulator,SPORTS,3.9,654,50M,10000,Paid,$4.99,Everyone,Sports
+WiFi FPV,FAMILY,3.8,316,19M,100000,Free,0,Everyone,Entertainment
+CX Elevated,BUSINESS,4.1,0,55M,50,Free,0,Everyone,Business
+go41cx,FAMILY,4.8,171,1.0M,1000,Paid,$10.00,Everyone,Education
+FlexRelease CX,BUSINESS,4.1,4,2.0M,1000,Free,0,Everyone,Business
+Ambient CX,BUSINESS,4.1,0,7.5M,5,Free,0,Everyone,Business
+QuestionPro - CX,BUSINESS,4.1,1,16M,50,Free,0,Everyone,Business
+CX Network,BUSINESS,4.1,0,10M,0,Free,0,Everyone,Business
+"Cymera Camera- Photo Editor, Filter,Collage,Layout",PHOTOGRAPHY,4.4,2418165,Varies with device,100000000,Free,0,Everyone,Photography
+CY Security Antivirus Cleaner,PRODUCTIVITY,4.5,75140,Varies with device,1000000,Free,0,Everyone,Productivity
+Freecell CY,GAME,4.0,387,1.1M,50000,Free,0,Everyone,Card
+Cytus II,GAME,4.7,16851,81M,100000,Paid,$1.99,Everyone 10+,Music
+Cy-Reader,FAMILY,4.8,17,15M,100,Free,0,Everyone,Education
+Cy-Fair FCU Mobile Banking,FINANCE,4.7,439,13M,5000,Free,0,Everyone,Finance
+Cytus,GAME,4.7,541732,20M,5000000,Free,0,Everyone,Music
+Cy-Ranch,NEWS_AND_MAGAZINES,4.5,27,7.1M,500,Free,0,Everyone,News & Magazines
+Recycling Cy,LIFESTYLE,4.0,47,4.5M,1000,Free,0,Everyone,Lifestyle
+CY Konum,PERSONALIZATION,4.3,1,1.3M,100,Free,0,Everyone,Personalization
+CY.SEND Online Top Up,FINANCE,3.2,191,10M,10000,Free,0,Everyone,Finance
+ABTO CY-ET1,TOOLS,4.0,1,29M,100,Free,0,Everyone,Tools
+CY:ME - real time gps tracker,MAPS_AND_NAVIGATION,4.1,8,749k,1000,Free,0,Everyone,Maps & Navigation
+Alpha Bank CY,FINANCE,4.7,39,20M,1000,Free,0,Everyone,Finance
+Cy Messenger,COMMUNICATION,4.5,4,8.1M,100,Free,0,Everyone,Communication
+Amadeus GR & CY,COMMUNICATION,4.2,4,3.8M,100,Free,0,Everyone,Communication
+Igitabo cy'Indirimbo,FAMILY,4.5,93,1.6M,50000,Free,0,Everyone,Entertainment
+Doctor Finder CY,MEDICAL,4.9,57,6.1M,1000,Free,0,Everyone,Medical
+Eshopcy.com.cy,SHOPPING,4.2,182,4.9M,5000,Free,0,Everyone,Shopping
+NOMISMA.com.cy by FMW,NEWS_AND_MAGAZINES,5.0,3,Varies with device,100,Free,0,Everyone,News & Magazines
+Cy-Fair VFD EMS Protocols,MEDICAL,5.0,2,20M,100,Free,0,Everyone 10+,Medical
+EUROBANK CY,FINANCE,4.1,30,15M,100,Free,0,Everyone,Finance
+Cy-Fair Christian Church,LIFESTYLE,5.0,2,9.3M,100,Free,0,Everyone,Lifestyle
+Mediabox CY,FAMILY,4.2,0,12M,10,Free,0,Everyone,Entertainment
+Capitalnews.com.cy,NEWS_AND_MAGAZINES,4.1,0,3.9M,10,Free,0,Everyone,News & Magazines
+Shadowverse CCG,GAME,4.2,47340,61M,1000000,Free,0,Teen,Card
+CY Digital Net,SHOPPING,4.7,3,5.8M,500,Free,0,Everyone,Shopping
+Cy-Fair Houston Chamber,BUSINESS,4.1,0,5.0M,5,Free,0,Everyone,Business
+StudentLife.com.cy,NEWS_AND_MAGAZINES,4.1,17,4.4M,100,Free,0,Everyone,News & Magazines
+Phone Clean Best Speed Booster,PRODUCTIVITY,4.5,81502,Varies with device,1000000,Free,0,Everyone,Productivity
+VAT check CY,BUSINESS,4.1,0,642k,100,Free,0,Everyone,Business
+Cy's Elma Pharmacy,HEALTH_AND_FITNESS,4.3,0,9.4M,10,Free,0,Everyone 10+,Health & Fitness
+CY Spray nozzle,BOOKS_AND_REFERENCE,4.3,0,3.3M,10,Free,0,Everyone,Books & Reference
+LOCX Applock Lock Apps & Photo,PRODUCTIVITY,4.5,208543,Varies with device,10000000,Free,0,Everyone,Productivity
+Cymath - Math Problem Solver,FAMILY,4.5,10159,6.4M,1000000,Free,0,Everyone,Education
+Rewards,FINANCE,3.8,57,4.0M,5000,Free,0,Everyone,Finance
+Army of Heroes,FAMILY,4.5,85015,46M,1000000,Free,0,Everyone 10+,Strategy
+BibleRead En Cy Zh Yue,BOOKS_AND_REFERENCE,4.3,0,12M,5,Free,0,Everyone,Books & Reference
+Math Solver,FAMILY,4.3,2250,30M,100000,Free,0,Everyone,Education
+SuperBikers 2,GAME,3.9,6200,Varies with device,500000,Free,0,Everyone 10+,Racing
+Cyprus Bus Companion,MAPS_AND_NAVIGATION,3.9,112,1.4M,10000,Free,0,Everyone,Maps & Navigation
+Cyprus Police,SOCIAL,4.2,226,15M,10000,Free,0,Everyone 10+,Social
+foody Cyprus - online ordering,SHOPPING,4.5,214,1.8M,10000,Free,0,Everyone,Shopping
+Death Dragon Knights RPG,FAMILY,4.1,11179,19M,1000000,Free,0,Teen,Role Playing
+Camera360 Lite - Selfie Camera,PHOTOGRAPHY,4.4,221878,Varies with device,10000000,Free,0,Everyone,Photography
+Bank Of Cyprus,FINANCE,4.1,1514,12M,100000,Free,0,Everyone,Finance
+Map of Cyprus offline,TRAVEL_AND_LOCAL,4.6,470,21M,10000,Free,0,Everyone,Travel & Local
+McDelivery Cyprus,FOOD_AND_DRINK,3.3,60,25M,10000,Free,0,Everyone,Food & Drink
+CZ-USA,LIFESTYLE,4.5,11,3.4M,1000,Free,0,Everyone,Lifestyle
+CZ File Manager,TOOLS,2.2,876,8.7M,1000000,Free,0,Everyone,Tools
+Security Camera CZ,HOUSE_AND_HOME,4.4,137,19M,10000,Free,0,Everyone,House & Home
+Šmelina .cz inzeráty inzerce,SHOPPING,3.9,117,9.8M,10000,Free,0,Everyone,Shopping
+Alzashop.com,SHOPPING,4.5,32014,18M,500000,Free,0,Everyone,Shopping
+KFC CZ,LIFESTYLE,2.8,1189,18M,100000,Free,0,Everyone,Lifestyle
+Skylink Live TV CZ,FAMILY,3.3,2802,15M,100000,Free,0,Teen,Entertainment
+CZ-70 (CZ-50) pistol explained,BOOKS_AND_REFERENCE,4.3,2,17M,10,Paid,$5.99,Everyone,Books & Reference
+Mapy.cz - Cycling & Hiking offline maps,MAPS_AND_NAVIGATION,4.5,56409,43M,1000000,Free,0,Everyone,Maps & Navigation
+CZ-52 pistol explained,BOOKS_AND_REFERENCE,4.3,0,9.3M,10,Paid,$5.99,Everyone,Books & Reference
+CZ-27 pistol explained,BOOKS_AND_REFERENCE,4.3,1,11M,10,Paid,$5.99,Everyone,Books & Reference
+Online TV CZ/SK PRO,VIDEO_PLAYERS,3.1,167,2.0M,1000,Paid,$0.99,Everyone,Video Players & Editors
+Rande.cz,SOCIAL,3.2,398,2.2M,50000,Free,0,Mature 17+,Social
+Breweries (CZ/SK),LIFESTYLE,4.4,1740,4.4M,50000,Free,0,Teen,Lifestyle
+reality.cz,HOUSE_AND_HOME,4.1,1372,5.4M,50000,Free,0,Everyone,House & Home
+CZ-45 pistol explained,BOOKS_AND_REFERENCE,4.3,1,12M,10,Paid,$5.49,Everyone,Books & Reference
+CZ-Help,BOOKS_AND_REFERENCE,5.0,2,1.4M,5,Free,0,Everyone,Books & Reference
+Hlášenírozhlasu.cz,COMMUNICATION,4.2,0,17M,10,Free,0,Everyone,Communication
+signály.cz,SOCIAL,4.3,38,881k,1000,Free,0,Everyone,Social
+CZ-Cyberon Voice Commander,TOOLS,3.8,131,3.3M,1000,Paid,$5.99,Everyone,Tools
+Pistolet CZ-70 CZ-50 expliqué,BOOKS_AND_REFERENCE,4.3,0,17M,1,Paid,$5.99,Everyone,Books & Reference
+CZ-38 (vz 38) pistol explained,BOOKS_AND_REFERENCE,4.3,0,13M,5,Paid,$5.99,Everyone,Books & Reference
+HTC Sense Input - CZ,TOOLS,4.3,87,7.3M,10000,Free,0,Everyone,Tools
+WebCams,WEATHER,4.6,3963,23M,100000,Free,0,Everyone,Weather
+Wallpapers CZ 75 85,PERSONALIZATION,4.3,0,12M,10,Free,0,Teen,Personalization
+SMS Sender - sluzba.cz,COMMUNICATION,4.2,12,72k,1000,Free,0,Everyone,Communication
+Novinky.cz,NEWS_AND_MAGAZINES,3.7,2375,Varies with device,100000,Free,0,Everyone,News & Magazines
+Wallpaper.cz,PHOTOGRAPHY,4.9,7,2.2M,100,Free,0,Everyone,Photography
+Strava.cz,SHOPPING,4.3,2221,Varies with device,100000,Free,0,Everyone,Shopping
+CZ Kompas,TOOLS,5.0,2,3.5M,10,Free,0,Everyone,Tools
+Modlitební knížka CZ,BOOKS_AND_REFERENCE,4.3,4,18M,500,Free,0,Everyone,Books & Reference
+Reksio cz. 1,BOOKS_AND_REFERENCE,4.3,0,8.6M,10,Paid,$0.99,Everyone,Books & Reference
+MYTO CZ,MAPS_AND_NAVIGATION,2.9,30,4.8M,5000,Free,0,Everyone,Maps & Navigation
+PLAYzone.cz,FAMILY,4.4,14,7.3M,500,Free,0,Everyone,Entertainment
+Tools & Mi Band,HEALTH_AND_FITNESS,4.4,15753,13M,100000,Paid,$3.49,Everyone,Health & Fitness
+RoutePlan.cz,PRODUCTIVITY,4.2,6,5.3M,100,Free,0,Everyone,Productivity
+TeeTime.cz,SPORTS,4.6,1641,6.2M,10000,Free,0,Everyone,Sports
+What is my IP address,TOOLS,4.5,4228,656k,500000,Free,0,Everyone,Tools
+Windguru Lite,WEATHER,4.0,9307,5.0M,1000000,Free,0,Everyone,Weather
+Vira.cz Widget,LIFESTYLE,4.1,86,601k,1000,Free,0,Everyone,Lifestyle
+Da Fit,SPORTS,3.5,1151,8.3M,10000,Free,0,Everyone,Sports
+The House of Da Vinci,FAMILY,4.8,12400,Varies with device,100000,Paid,$4.99,Everyone,Puzzle
+Dan the Man: Action Platformer,GAME,4.8,528550,73M,10000000,Free,0,Teen,Arcade
+Ghost Detector,FAMILY,3.5,35337,7.4M,5000000,Free,0,Teen,Entertainment
+"Face Filter, Selfie Editor - Sweet Camera",PHOTOGRAPHY,4.7,142758,22M,10000000,Free,0,Everyone,Photography
+Master for Minecraft(Pocket Edition)-Mod Launcher,TOOLS,4.6,2674051,26M,50000000,Free,0,Everyone,Tools
+King of Math,FAMILY,4.4,766,14M,10000,Paid,$2.99,Everyone,Education;Education
+Translate: text & voice translator,TOOLS,4.3,122010,7.3M,5000000,Free,0,Everyone,Tools
+The Zueira's Voice,TOOLS,4.7,136540,3.1M,1000000,Free,0,Everyone,Tools
+Battery Calibration,TOOLS,4.4,134412,11M,5000000,Free,0,Everyone,Tools
+FVD - Free Video Downloader,TOOLS,4.0,327914,Varies with device,10000000,Free,0,Everyone,Tools
+Thuglife Video Maker,FAMILY,3.5,38824,12M,1000000,Free,0,Mature 17+,Entertainment
+MadLipz,FAMILY,4.6,171017,13M,10000000,Free,0,Teen,Entertainment
+Soccer FC,SPORTS,3.9,6289,33M,1000000,Free,0,Everyone,Sports
+Visage Lab – face retouch,PHOTOGRAPHY,3.5,49523,Varies with device,5000000,Free,0,Everyone,Photography
+Geometry Dash SubZero,GAME,4.6,260527,49M,10000000,Free,0,Everyone,Arcade
+Escaping the Prison,FAMILY,4.2,419375,31M,10000000,Free,0,Everyone 10+,Casual
+Metal Soldiers 2,GAME,4.4,153649,Varies with device,10000000,Free,0,Teen,Action
+Quiz TRUE or FALSE,GAME,4.6,2464,34M,50000,Free,0,Everyone,Trivia
+Glam Doll Salon - Chic Fashion,FAMILY,4.0,93898,44M,10000000,Free,0,Everyone,Casual
+Siren Ringtones,PERSONALIZATION,4.2,42190,11M,5000000,Free,0,Teen,Personalization
+Peppa Pig: Party Time,FAMILY,3.8,52,55M,10000,Paid,$2.99,Everyone,Educational;Pretend Play
+Download Manager for Android,TOOLS,4.1,420518,Varies with device,10000000,Free,0,Everyone,Tools
+COOKING MAMA Let's Cook!,FAMILY,4.3,528917,59M,10000000,Free,0,Everyone,Educational;Pretend Play
+Run Sausage Run!,GAME,4.4,276105,Varies with device,10000000,Free,0,Everyone 10+,Arcade
+Knife Hit,GAME,4.5,462614,60M,10000000,Free,0,Everyone,Arcade
+The Visitor,GAME,4.1,39895,25M,5000000,Free,0,Mature 17+,Adventure
+Just Dance Now,GAME,4.2,794058,56M,10000000,Free,0,Everyone,Music
+DB Navigator,MAPS_AND_NAVIGATION,4.0,119685,20M,10000000,Free,0,Everyone,Maps & Navigation
+SQLite DB Reader,TOOLS,3.6,301,2.3M,50000,Free,0,Everyone,Tools
+DB Browser,TOOLS,3.3,236,221k,50000,Free,0,Everyone,Tools
+Sound Meter,TOOLS,4.7,88993,1.5M,10000000,Free,0,Everyone,Tools
+DRAGON BALL LEGENDS,GAME,4.6,338742,48M,5000000,Free,0,Teen,Action
+db.Mobil App,LIBRARIES_AND_DEMO,4.5,23,31M,5000,Free,0,Everyone,Libraries & Demo
+DB Streckenagent,MAPS_AND_NAVIGATION,3.9,4569,7.5M,500000,Free,0,Everyone,Maps & Navigation
+dB: Sound Meter Pro,TOOLS,4.3,31,228k,5000,Free,0,Everyone,Tools
+Movie DB,FAMILY,4.2,10,2.6M,1000,Free,0,Teen,Entertainment
+dB Sound Level Meter,TOOLS,3.9,203,2.3M,10000,Free,0,Everyone,Tools
+DB Sound Meter: Measure Noise Level- Decibel Meter,TOOLS,4.3,824,2.8M,10000,Free,0,Everyone,Tools
+DB Welt - Die Zeitung der DB,NEWS_AND_MAGAZINES,4.1,145,16M,10000,Free,0,Everyone,News & Magazines
+Check DB Benchmark,TOOLS,4.0,0,2.2M,100,Free,0,Everyone,Tools
+ACCDB MDB DB Manager Pro - Editor for MS Access,PRODUCTIVITY,3.1,19,4.5M,500,Paid,$8.99,Everyone,Productivity
+Scale Models DB,TOOLS,4.4,9,33M,50,Paid,$2.99,Everyone,Tools
+DB Train Simulator,FAMILY,3.7,6514,72M,500000,Free,0,Everyone,Simulation
+DB Tools,FAMILY,4.6,37,3.3M,1000,Free,0,Everyone,Education
+dB Meter - measure sound & noise level in Decibel,TOOLS,4.6,154,6.6M,10000,Free,0,Everyone,Tools
+DB LINK RGB,TOOLS,2.7,7,5.2M,500,Free,0,Everyone,Tools
+DB BAHN,TRAVEL_AND_LOCAL,4.1,4,8.0M,500,Free,0,Everyone,Travel & Local
+DB Manager,PRODUCTIVITY,4.2,3,108k,1000,Free,0,Everyone,Productivity
+"10,000 Quotes DB (Premium)",BOOKS_AND_REFERENCE,4.1,70,3.5M,500,Paid,$0.99,Everyone,Books & Reference
+Guide for DB Xenoverse,BOOKS_AND_REFERENCE,4.2,459,11M,10000,Free,0,Everyone,Books & Reference
+DB Transport,MAPS_AND_NAVIGATION,1.9,179,10M,10000,Free,0,Everyone,Maps & Navigation
+DB Stay Connected,BUSINESS,4.6,17,9.4M,1000,Free,0,Everyone,Business
+DB FahrtProfi,TRAVEL_AND_LOCAL,4.1,1,10M,1000,Free,0,Everyone,Travel & Local
+DB TOS - Pocket Helper,TOOLS,4.2,265,Varies with device,10000,Free,0,Everyone,Tools
+ReDNAKET DB Normalization Tool,TOOLS,4.0,0,940k,10,Paid,$0.99,Everyone,Tools
+Guide for DB Xenoverse 2,BOOKS_AND_REFERENCE,4.4,121,8.7M,10000,Free,0,Everyone,Books & Reference
+DB Customer Connect,BUSINESS,4.2,100,6.3M,10000,Free,0,Everyone,Business
+Patron DB,TOOLS,3.9,64,4.1M,5000,Free,0,Everyone,Tools
+DB Event App,SOCIAL,2.4,37,37M,5000,Free,0,Teen,Social
+DB HOME,LIFESTYLE,5.0,5,3.2M,100,Free,0,Everyone,Lifestyle
+Bowers & Wilkins DB Subwoofers,TOOLS,3.9,21,11M,10000,Free,0,Everyone,Tools
+Guide for IMS DB,BOOKS_AND_REFERENCE,4.3,0,2.6M,10,Free,0,Everyone,Books & Reference
+DB Busradar NRW,MAPS_AND_NAVIGATION,3.7,78,3.0M,10000,Free,0,Everyone,Maps & Navigation
+DB Pickles,BUSINESS,5.0,5,14M,100,Free,0,Everyone,Business
+DB for Fallout Shelter,FAMILY,4.0,3323,47M,100000,Free,0,Everyone,Simulation
+LC-DB,PHOTOGRAPHY,3.0,1,2.5M,10,Paid,$3.49,Everyone,Photography
+dB Sound Meter,TOOLS,4.1,29,2.3M,5000,Free,0,Everyone,Tools
+DB for Hustle Castle,FAMILY,4.8,21,49M,1000,Free,0,Everyone,Role Playing
+DB Ultra Saiyan Battle,GAME,4.5,33,44M,1000,Free,0,Everyone 10+,Action
+Preferences Manager and SQLite DB Viewer,TOOLS,3.5,13,3.0M,1000,Free,0,Everyone,Tools
+LC-DB-LITE,PHOTOGRAPHY,4.2,0,2.3M,100,Free,0,Everyone,Photography
+db Meter - sound level meter with data logging,TOOLS,4.0,0,15M,1,Paid,$1.49,Everyone,Tools
+Hamburg Transit - Offline HVV DB times and plans,MAPS_AND_NAVIGATION,4.1,9,10M,1000,Free,0,Everyone,Maps & Navigation
+SW-DB,TOOLS,4.5,954,7.6M,10000,Free,0,Teen,Tools
+DC Legends: Battle for Justice,FAMILY,4.5,355613,59M,10000000,Free,0,Teen,Role Playing
+DC Comics,COMICS,4.2,25673,Varies with device,1000000,Free,0,Teen,Comics
+Injustice 2,GAME,4.3,504765,36M,5000000,Free,0,Teen,Action
+Injustice: Gods Among Us,GAME,4.4,2440877,32M,10000000,Free,0,Teen,Action
+FANDOM for: DC,FAMILY,4.4,6715,9.5M,500000,Free,0,Mature 17+,Entertainment
+DC Super Hero Girls™,FAMILY,4.3,43090,95M,5000000,Free,0,Everyone,Action;Action & Adventure
+LEGO Batman: DC Super Heroes,FAMILY,4.2,2557,5.8M,50000,Paid,$4.99,Everyone 10+,Adventure;Action & Adventure
+Ultimate DC Challenge,GAME,4.5,937,35M,10000,Free,0,Everyone,Trivia
+LEGO® DC Mighty Micros,FAMILY,4.3,139545,63M,10000000,Free,0,Everyone,Racing;Action & Adventure
+Justice League Action Run,GAME,4.3,22333,9.7M,1000000,Free,0,Everyone 10+,Action
+Marvel and DC Wallpapers,PERSONALIZATION,4.2,249,91M,10000,Free,0,Everyone,Personalization
+DC Comics Amino,SOCIAL,4.9,117,63M,1000,Free,0,Teen,Social
+Comics,COMICS,4.1,45651,Varies with device,5000000,Free,0,Teen,Comics
+Quiz DC,GAME,1.4,33,3.1M,1000,Free,0,Everyone,Trivia
+Batman: Gotham’s Most Wanted!,FAMILY,4.0,16190,88M,1000000,Free,0,Everyone,Action;Action & Adventure
+"Superheroes, Marvel, DC, Comics, TV, Movies News",COMICS,5.0,34,12M,5000,Free,0,Everyone,Comics
+MARVEL Contest of Champions,GAME,4.3,2468915,92M,50000000,Free,0,Teen,Action
+Choose SuperHero Quize Marvel | DC,FAMILY,4.2,3,4.1M,100,Free,0,Everyone,Entertainment
+MARVEL Avengers Academy,GAME,4.2,304106,Varies with device,10000000,Free,0,Teen,Adventure
+DC Universe Quiz,GAME,4.3,11,23M,500,Free,0,Everyone,Trivia
+DC HSEMA,BOOKS_AND_REFERENCE,3.8,38,7.2M,5000,Free,0,Everyone,Books & Reference
+DC Universe Online Map,TOOLS,4.1,1186,6.4M,50000,Free,0,Unrated,Tools
+DC Public Library,BOOKS_AND_REFERENCE,4.2,20,3.4M,1000,Free,0,Everyone,Books & Reference
+MARVEL Strike Force,FAMILY,4.3,166312,91M,5000000,Free,0,Teen,Role Playing
+Vote 4 DC,TOOLS,4.1,46,6.1M,1000,Free,0,Everyone,Tools
+Villains vs Superheroes,FAMILY,4.3,128,22M,10000,Free,0,Everyone,Puzzle
+DC Rider,MAPS_AND_NAVIGATION,3.6,258,6.9M,50000,Free,0,Everyone,Maps & Navigation
+Power Rangers: Legacy Wars,GAME,4.3,264755,91M,10000000,Free,0,Teen,Action
+MARVEL Future Fight,FAMILY,4.6,2354042,72M,50000000,Free,0,Everyone 10+,Role Playing
+DC Metro Transit - Free,TRAVEL_AND_LOCAL,4.4,6895,10M,500000,Free,0,Everyone,Travel & Local
+DC N COMPANY ENTERTAINMENT RADIO!,FAMILY,5.0,22,2.2M,100,Free,0,Mature 17+,Entertainment
+Results for DC Lottery,FAMILY,4.4,160,8.5M,5000,Free,0,Everyone,Entertainment
+FOX 5 DC,NEWS_AND_MAGAZINES,4.5,1440,12M,100000,Free,0,Everyone,News & Magazines
+Pepsi Cards DC,COMICS,4.2,1,21M,50,Free,0,Everyone 10+,Comics
+Driver Permit Test Prep DC DMV Driver's License Ed,FAMILY,4.7,78,11M,5000,Free,0,Everyone,Education
+Robin - DC Movie Collection,FAMILY,4.2,1,2.3M,500,Free,0,Everyone,Entertainment
+DC-014,PHOTOGRAPHY,5.0,3,16M,500,Free,0,Everyone,Photography
+D.C. Driving/Walking Tours,TRAVEL_AND_LOCAL,4.1,0,32M,50,Paid,$4.99,Everyone,Travel & Local
+Painting Lulu DC Super Friends,BOOKS_AND_REFERENCE,4.3,7,17M,1000,Free,0,Everyone,Books & Reference
+DC Metro,MAPS_AND_NAVIGATION,3.4,59,1.3M,10000,Free,0,Everyone,Maps & Navigation
+DC Trails-Hop On Hop Off Tours,TRAVEL_AND_LOCAL,3.1,16,18M,5000,Free,0,Everyone,Travel & Local
+DC Metro Transit,TRAVEL_AND_LOCAL,4.5,339,10M,5000,Paid,$2.99,Everyone,Travel & Local
+AC DC Power Monitor,LIFESTYLE,5.0,1,1.2M,10,Paid,$3.04,Everyone,Lifestyle
+McClatchy DC Bureau,NEWS_AND_MAGAZINES,4.3,80,8.7M,5000,Free,0,Everyone 10+,News & Magazines
+AutoScout24 - used car finder,AUTO_AND_VEHICLES,4.4,186648,42M,10000000,Free,0,Everyone,Auto & Vehicles
+WEB.DE Mail,COMMUNICATION,4.3,226541,Varies with device,10000000,Free,0,Everyone,Communication
+wetter.com - Weather and Radar,WEATHER,4.2,189310,38M,10000000,Free,0,Everyone,Weather
+Your Freedom VPN Client,COMMUNICATION,4.0,74497,5.3M,5000000,Free,0,Everyone,Communication
+Dictionary,BOOKS_AND_REFERENCE,4.5,264260,Varies with device,10000000,Free,0,Everyone,Books & Reference
+Bokeh (Background defocus),PHOTOGRAPHY,4.0,50109,Varies with device,10000000,Free,0,Everyone,Photography
+Speed Camera Radar,MAPS_AND_NAVIGATION,4.1,54034,5.8M,5000000,Free,0,Teen,Maps & Navigation
+WDAMAGE: Car Crash Engine,GAME,3.8,47386,96M,1000000,Free,0,Everyone,Racing
+Babbel – Learn Languages,FAMILY,4.3,267787,21M,10000000,Free,0,Everyone,Education
+Coloring Book for Me & Mandala,FAMILY,4.6,401211,Varies with device,10000000,Free,0,Everyone,Entertainment
+APUS File Manager (Explorer),TOOLS,4.1,498894,10M,50000000,Free,0,Everyone,Tools
+Offroad Police Car DE,FAMILY,4.3,9149,80M,1000000,Free,0,Everyone,Simulation
+Easy Language Translator,TOOLS,4.3,191621,6.1M,10000000,Free,0,Everyone,Tools
+Word Search multilingual,GAME,4.2,32849,1.5M,1000000,Free,0,Everyone,Word
+Love Collage - Photo Editor,PHOTOGRAPHY,4.3,251686,31M,10000000,Free,0,Everyone,Photography
+Heavy Bus Simulator,FAMILY,4.4,252006,26M,5000000,Free,0,Everyone,Simulation
+"CallApp: Caller ID, Blocker & Phone Call Recorder",COMMUNICATION,4.4,483782,20M,10000000,Free,0,Everyone,Communication
+Love Fonts for FlipFont,PERSONALIZATION,3.9,28694,2.9M,1000000,Free,0,Everyone,Personalization
+LINE Camera - Photo editor,PHOTOGRAPHY,4.3,1517395,Varies with device,100000000,Free,0,Everyone,Photography
+Piano Free - Keyboard with Magic Tiles Music Games,GAME,4.5,785622,Varies with device,50000000,Free,0,Everyone,Music
+Racing in Car 2,GAME,4.3,234589,38M,50000000,Free,0,Everyone,Racing
+Escape the Prison Room,FAMILY,3.5,113183,36M,5000000,Free,0,Everyone,Puzzle
+Bike Racing 3D,GAME,4.2,951435,14M,50000000,Free,0,Everyone,Racing
+Satellite Director,TOOLS,4.1,45610,176k,10000000,Free,0,Everyone,Tools
+Truck Driver Cargo,GAME,4.1,257531,44M,10000000,Free,0,Everyone 10+,Racing
+Anime Love Story Games: ✨Shadowtime✨,FAMILY,4.7,198480,82M,5000000,Free,0,Everyone,Simulation
+Checkers,GAME,4.5,375996,3.3M,10000000,Free,0,Everyone,Board
+Scratch Logo Quiz. Challenging brain puzzle,GAME,3.3,152102,18M,10000000,Free,0,Teen,Trivia
+Myth Defense 2: DF,FAMILY,4.2,17108,8.3M,100000,Free,0,Everyone,Strategy
+df,TOOLS,4.0,4,33k,1000,Free,0,Everyone,Tools
+DF Squid,GAME,4.3,1,14M,100,Free,0,Everyone,Board
+Google PDF Viewer,PRODUCTIVITY,4.2,226453,Varies with device,10000000,Free,0,Everyone,Productivity
+Myth Defense 2: DF Platinum,FAMILY,4.6,1764,8.3M,10000,Paid,$3.99,Everyone 10+,Strategy
+DF 司機,MAPS_AND_NAVIGATION,4.1,9,9.9M,500,Free,0,Everyone,Maps & Navigation
+DF@realtime,BUSINESS,4.3,24,8.0M,1000,Free,0,Everyone,Business
+DF Night Selfies,PHOTOGRAPHY,4.3,194,1.5M,10000,Free,0,Everyone,Photography
+DF Coaching,SPORTS,4.0,1,3.6M,100,Free,0,Everyone,Sports
+Digital Falak,TOOLS,4.7,3408,15M,50000,Free,0,Everyone,Tools
+The Divine Feminine App: the DF App,LIFESTYLE,5.0,8,6.7M,1000,Free,0,Everyone,Lifestyle
+Guide to Nikon Df,PHOTOGRAPHY,4.2,1,663k,10,Paid,$29.99,Everyone,Photography
+DF BugMeNot,SOCIAL,4.3,7,1.4M,500,Free,0,Teen,Social
+DF-CAM,TOOLS,4.0,2,20M,100,Free,0,Everyone,Tools
+DF Tracker,BUSINESS,4.1,2,6.0M,100,Free,0,Everyone,Business
+Guia Bike DF,SPORTS,4.2,29,14M,100,Free,0,Everyone,Sports
+Rádio DF FM,FAMILY,4.2,24,1.5M,1000,Free,0,Everyone,Entertainment
+Noticias DF,SOCIAL,4.3,2,2.3M,1000,Free,0,Everyone,Social
+DF Glue Board,PARENTING,5.0,1,27M,10,Free,0,Everyone,Parenting
+DF-Server Mobile,PRODUCTIVITY,4.9,17,76M,100,Free,0,Everyone,Productivity
+DF-View,BUSINESS,4.1,0,15M,100,Free,0,Everyone,Business
+"MexiRoomies - roomies, mexico, df, apt, house room",LIFESTYLE,4.1,2,32M,500,Free,0,Everyone,Lifestyle
+DF Wall Plus – Droid Firewall,TOOLS,4.0,9,6.3M,500,Free,0,Everyone,Tools
+Diario Financiero,FINANCE,4.1,30,24M,10000,Free,0,Everyone,Finance
+Digital FM Brasília DF,FAMILY,4.2,5,1.4M,100,Free,0,Everyone,Entertainment
+DF SmartPlus,TOOLS,4.0,0,36M,10,Free,0,Everyone,Tools
+Red Transporte DF,MAPS_AND_NAVIGATION,4.3,11100,15M,500000,Free,0,Everyone,Maps & Navigation
+ElejaOnline DF,BUSINESS,4.1,0,3.0M,50,Free,0,Everyone,Business
+ProconLegis-DF,TOOLS,4.0,2,14M,5,Free,0,Everyone,Tools
+Técnico Legislativo Câmara Legislativa DF,PRODUCTIVITY,4.2,1,10M,10,Paid,$2.99,Everyone,Productivity
+Periscope - Live Video,SOCIAL,4.0,479939,15M,10000000,Free,0,Mature 17+,Social
+Cargo de Praça PM DF,PRODUCTIVITY,4.2,0,5.2M,10,Paid,$2.99,Everyone,Productivity
+Consultar Infracciones de Transito DF y Mexico,TOOLS,4.0,0,2.9M,10,Free,0,Everyone,Tools
+Droidbug BusyBox Advance PRO,TOOLS,4.5,2,3.3M,100,Paid,$3.99,Everyone,Tools
+México City D.F News,NEWS_AND_MAGAZINES,4.1,2,5.7M,100,Free,0,Everyone,News & Magazines
+PDF Reader – PDF Editor 2018,TOOLS,4.1,1648,36M,500000,Free,0,Everyone,Tools
+Fix Error Google Playstore,BOOKS_AND_REFERENCE,4.3,18,5.7M,1000,Free,0,Everyone,Books & Reference
+df-Vegetable,BUSINESS,4.1,0,2.9M,5,Free,0,Everyone,Business
+Aproveita DF,LIFESTYLE,4.1,0,3.3M,1,Free,0,Everyone,Lifestyle
+EVENTOS DF,EVENTS,4.4,0,4.5M,10,Free,0,Everyone,Events
+Citymapper - Transit Navigation,MAPS_AND_NAVIGATION,4.5,65448,Varies with device,5000000,Free,0,Everyone,Maps & Navigation
+Rádio Sol Nascente DF,COMMUNICATION,4.2,12,1.6M,500,Free,0,Everyone,Communication
+Diseño de columnas NTC - RSEE 2017,PRODUCTIVITY,4.2,6,2.8M,100,Paid,$0.99,Everyone,Productivity
+"Dollar General - Digital Coupons, Ads And More",SHOPPING,3.9,16678,Varies with device,5000000,Free,0,Everyone,Shopping
+DG Coupon,SHOPPING,3.7,668,1.1M,100000,Free,0,Everyone,Shopping
+Penny Finder,SHOPPING,4.2,470,4.1M,10000,Paid,$2.99,Everyone,Shopping
+DG - Digital Coupons - Free Coupon and Discount,SHOPPING,3.6,38,1.1M,10000,Free,0,Everyone,Shopping
+DG Surveyor,BUSINESS,3.6,5,6.8M,50,Paid,$8.99,Everyone,Business
+DG Smart life,TOOLS,2.1,14,28M,1000,Free,0,Everyone,Tools
+Krazy Coupon Lady,SHOPPING,4.7,10318,32M,1000000,Free,0,Everyone,Shopping
+DG UPnP Player Free,VIDEO_PLAYERS,3.2,39,12M,10000,Free,0,Everyone,Video Players & Editors
+Penny Puss,TOOLS,3.0,19,22M,1000,Paid,$4.99,Everyone,Tools
+DG Mobile,GAME,4.3,59,1.4M,1000,Free,0,Everyone,Board
+Go Go Coupons - Free Coupon and Discount,SHOPPING,3.0,4,1.2M,1000,Free,0,Everyone,Shopping
+ZombieVital DG,FAMILY,4.3,10,20M,100,Paid,$12.99,Everyone,Simulation
+DJ Electro Mix Pad,FAMILY,3.9,53301,7.6M,10000000,Free,0,Everyone,Entertainment
+DG Screen Recorder,VIDEO_PLAYERS,3.3,12,2.9M,500,Free,0,Everyone,Video Players & Editors
+DG Report Reminder,PRODUCTIVITY,4.3,195,Varies with device,10000,Free,0,Everyone,Productivity
+DG Video Editor,VIDEO_PLAYERS,4.0,486,2.5M,10000,Free,0,Everyone,Video Players & Editors
+The DG Buddy,BUSINESS,3.7,3,11M,10,Paid,$2.49,Everyone,Business
+Roland DG Mobile Panel,TOOLS,2.8,27,34M,1000,Free,0,Everyone,Tools
+Destroy Gunners Σ,GAME,4.4,10786,21M,1000000,Free,0,Everyone,Arcade
+DG-App,TOOLS,5.0,1,4.5M,500,Free,0,Everyone,Tools
+Can I pack that? - DG App,TRAVEL_AND_LOCAL,3.9,58,22M,10000,Free,0,Everyone,Travel & Local
+DG Phone Call Task Switcher,PRODUCTIVITY,4.2,43,34k,1000,Free,0,Everyone,Productivity
+DG Fitness,HEALTH_AND_FITNESS,4.8,6,14M,100,Free,0,Everyone,Health & Fitness
+Sharaf DG,SHOPPING,4.0,7006,12M,500000,Free,0,Everyone,Shopping
+DG Card,COMMUNICATION,4.2,0,Varies with device,100,Free,0,Everyone,Communication
+Coupon Mob - Discount Coupons,SHOPPING,3.0,2,1.3M,100,Free,0,Everyone,Shopping
+DG Users,PRODUCTIVITY,4.5,8,3.1M,100,Free,0,Everyone,Productivity
+DG Cars,TRAVEL_AND_LOCAL,2.6,122,11M,10000,Free,0,Everyone,Travel & Local
+Free coupons and vouchers,FINANCE,5.0,4,5.9M,100,Free,0,Everyone,Finance
+DG Hair,LIFESTYLE,4.1,0,3.0M,10,Free,0,Everyone,Lifestyle
+DG Xplained,HEALTH_AND_FITNESS,4.3,1,12M,100,Free,0,Everyone,Health & Fitness
+DG OFF - 100% Free Coupons & Deals,SHOPPING,5.0,1,1.1M,10,Free,0,Everyone,Shopping
+Digoo·Cloud,TOOLS,4.1,543,26M,10000,Free,0,Everyone,Tools
+DG Monitor,BUSINESS,4.1,1,4.5M,100,Free,0,Everyone,Business
+DG ग्राम / Digital Gram Panchayat,NEWS_AND_MAGAZINES,4.5,53,5.9M,10000,Free,0,Teen,News & Magazines
+DG TV,NEWS_AND_MAGAZINES,5.0,3,5.7M,100,Free,0,Everyone,News & Magazines
+Daily Horoscope,LIFESTYLE,4.7,407589,Varies with device,10000000,Free,0,Everyone,Lifestyle
+DHgate-Shop Wholesale Prices,SHOPPING,4.5,104068,37M,5000000,Free,0,Teen,Shopping
+DH Texas Poker - Texas Hold'em,GAME,4.4,562345,Varies with device,10000000,Free,0,Teen,Casino
+DEER HUNTER CLASSIC,GAME,4.4,3941129,77M,50000000,Free,0,Teen,Action
+DEER HUNTER RELOADED,GAME,4.3,314774,43M,5000000,Free,0,Teen,Action
+DH Pineapple Poker OFC,GAME,4.2,1878,20M,100000,Free,0,Teen,Casino
+DH UFO,FAMILY,3.0,4,8.0M,1000,Free,0,Everyone,Entertainment
+Galaxy Defense,FAMILY,4.1,78142,17M,5000000,Free,0,Everyone,Strategy
+Call of Mini™ Dino Hunter,GAME,4.2,326042,10M,10000000,Free,0,Teen,Action
+Castle Defense 2,FAMILY,4.2,35172,34M,1000000,Free,0,Teen,Strategy
+Dungeon Rush,FAMILY,4.0,28633,81M,1000000,Free,0,Everyone 10+,Role Playing
+Bike Mayhem Free,GAME,4.3,331692,Varies with device,10000000,Free,0,Everyone,Racing
+Treasure Defense,FAMILY,4.1,3527,35M,100000,Free,0,Teen,Strategy
+Car Crash III Beam DH Real Damage Simulator 2018,GAME,3.6,151,100M,10000,Free,0,Everyone,Racing
+The Lost Lands:DH Lite,FAMILY,4.3,1130,48M,50000,Free,0,Teen,Simulation
+DH-UFO,FAMILY,5.0,1,59M,100,Free,0,Everyone,Entertainment
+Dungeon Hunter Champions: Epic Online Action RPG,FAMILY,4.2,26307,Varies with device,1000000,Free,0,Teen,Role Playing
+Daddyhunt: Gay Dating,SOCIAL,3.9,6450,14M,500000,Free,0,Mature 17+,Social
+DH Karaoke,FAMILY,4.2,8,10M,1000,Free,0,Everyone,Entertainment
+Tiny Defense,FAMILY,4.1,29387,16M,1000000,Free,0,Everyone,Strategy
+Toys Defense: Horror Land,FAMILY,3.8,168,24M,10000,Free,0,Everyone,Strategy
+D-H Pharmacy,LIFESTYLE,5.0,6,2.3M,1000,Free,0,Everyone,Lifestyle
+DEER HUNTER CHALLENGE,GAME,3.7,38767,4.1M,5000000,Free,0,Everyone 10+,Action
+Kingdom in Chaos,FAMILY,4.3,5623,28M,100000,Free,0,Everyone 10+,Role Playing
+Desperate Housewives: The Game,FAMILY,4.2,10440,27M,500000,Free,0,Teen,Role Playing
+Dinosaur War,FAMILY,4.3,157997,27M,10000000,Free,0,Everyone,Simulation
+DH News,NEWS_AND_MAGAZINES,2.5,81,6.7M,10000,Free,0,Mature 17+,News & Magazines
+Bike Unchained,SPORTS,4.3,83545,23M,5000000,Free,0,Everyone,Sports
+"Red Bull TV: Live Sports, Music & Entertainment",FAMILY,4.4,42069,Varies with device,1000000,Free,0,Teen,Entertainment
+DH Mariage,LIFESTYLE,4.1,0,4.9M,50,Free,0,Everyone,Lifestyle
+Bike 3D Configurator,SPORTS,4.3,34062,85M,1000000,Free,0,Everyone,Sports
+Castle Defense : Invasion,FAMILY,4.2,1484,41M,100000,Free,0,Everyone,Strategy
+Defender,GAME,4.6,152395,14M,10000000,Free,0,Everyone 10+,Action
+Avenger Legends,FAMILY,4.0,3715,94M,100000,Free,0,Everyone,Role Playing
+DrivingTest,FAMILY,2.9,975,45M,100000,Free,0,Everyone,Simulation
+D. H. Lawrence Poems FREE,BOOKS_AND_REFERENCE,4.3,13,942k,1000,Free,0,Everyone,Books & Reference
+Texas HoldEm Poker Deluxe,GAME,4.5,396090,26M,10000000,Free,0,Teen,Casino
+Idle Heroes,FAMILY,4.7,417197,99M,10000000,Free,0,Everyone 10+,Role Playing
+Wallpapers DH 4K,PERSONALIZATION,3.8,23,5.9M,1000,Free,0,Everyone,Personalization
+DH-Security Camera,BUSINESS,4.1,3,36M,100,Free,0,Everyone,Business
+Deck Heroes: Legacy,GAME,4.7,466495,52M,10000000,Free,0,Teen,Card
+Shred! Downhill Mountainbiking,GAME,3.9,41683,63M,1000000,Free,0,Everyone,Arcade
+Pocket Heroes,FAMILY,4.5,96658,26M,1000000,Free,0,Everyone 10+,Role Playing
+Duolingo: Learn Languages Free,FAMILY,4.7,6297590,Varies with device,100000000,Free,0,Everyone,Education;Education
+"Free phone calls, free texting SMS on free number",SOCIAL,4.5,412888,35M,10000000,Free,0,Everyone,Social
+DiskDigger photo recovery,TOOLS,4.2,227798,Varies with device,50000000,Free,0,Everyone,Tools
+Phone Tracker : Family Locator,SOCIAL,4.3,231446,5.4M,10000000,Free,0,Everyone,Social
+Meme Generator Free,FAMILY,4.4,303394,53M,10000000,Free,0,Mature 17+,Entertainment
+Stop Smoking - EasyQuit free,HEALTH_AND_FITNESS,4.8,39068,4.0M,500000,Free,0,Everyone,Health & Fitness
+FIFA Soccer,SPORTS,4.2,3909032,51M,100000000,Free,0,Everyone,Sports
+My Photo Keyboard,PHOTOGRAPHY,4.1,211620,20M,10000000,Free,0,Everyone,Photography
+Archery Physics Objects Destruction Apple shooter,GAME,4.5,6026,39M,100000,Free,0,Teen,Action
+Story Saver for Instagram,PHOTOGRAPHY,4.5,41331,5.0M,5000000,Free,0,Everyone,Photography
+Cameringo+ Filters Camera,PHOTOGRAPHY,4.6,28107,5.7M,500000,Paid,$2.99,Everyone,Photography
+Whoscall - Caller ID & Block,COMMUNICATION,4.4,552635,29M,10000000,Free,0,Everyone,Communication
+Cooking in the Kitchen,FAMILY,4.1,217736,87M,10000000,Free,0,Everyone,Casual;Pretend Play
+Automatic Call Recorder,TOOLS,4.3,1648515,7.1M,100000000,Free,0,Everyone,Tools
+Fancy Pants Adventures,GAME,4.7,55952,61M,1000000,Free,0,Everyone 10+,Arcade
+Boomerang from Instagram,PHOTOGRAPHY,4.4,928720,Varies with device,50000000,Free,0,Everyone,Photography
+Shopee: No.1 Belanja Online,SHOPPING,4.2,609186,30M,10000000,Free,0,Everyone,Shopping
+Lep's World 3 🍀🍀🍀,GAME,4.3,771001,52M,50000000,Free,0,Everyone 10+,Action
+Robbery Bob,GAME,4.5,617732,44M,10000000,Free,0,Everyone 10+,Action
+Google Sheets,PRODUCTIVITY,4.3,496397,Varies with device,100000000,Free,0,Everyone,Productivity
+Video Downloader - for Instagram Repost App,VIDEO_PLAYERS,4.8,332623,4.6M,10000000,Free,0,Everyone,Video Players & Editors
+Nyan Cat: Lost In Space,GAME,4.5,371318,90M,10000000,Free,0,Everyone 10+,Arcade
+HOLLA Live: Meet New People via Random Video Chat,SOCIAL,4.6,216513,Varies with device,5000000,Free,0,Mature 17+,Social
+"Quik – Free Video Editor for photos, clips, music",VIDEO_PLAYERS,4.7,696665,91M,10000000,Free,0,Everyone,Video Players & Editors
+Euro Truck Driver (Simulator),FAMILY,4.4,860078,30M,10000000,Free,0,Everyone,Simulation
+DJ Mix Effects Simulator,FAMILY,4.1,5997,20M,1000000,Free,0,Everyone,Simulation
+3D DJ – Music Mixer with Virtual DJ,FAMILY,4.3,796,28M,100000,Free,0,Everyone,Entertainment
+Virtual DJ Mixer,TOOLS,4.2,2013,16M,100000,Free,0,Everyone,Tools
+Mix Virtual DJ 2018,TOOLS,4.2,2925,16M,100000,Free,0,Everyone,Tools
+Resources For Virtual DJ,FAMILY,3.6,21095,7.9M,1000000,Free,0,Everyone,Entertainment
+DK 15 Minute Language Course,FAMILY,2.8,21,57M,1000,Free,0,Everyone,Education
+DK Readers,FAMILY,3.9,30,16M,1000,Free,0,Everyone,Education
+Eyewitness Travel Phrase Book,FAMILY,3.8,10,25M,1000,Free,0,Everyone,Education
+DK Quiz,GAME,4.4,1628,34M,50000,Free,0,Everyone,Trivia
+DK Virtual Reality,FAMILY,3.7,42,29M,1000,Free,0,Everyone,Books & Reference;Education
+Bilingual Dictionary Audio App,BOOKS_AND_REFERENCE,2.7,68,87M,5000,Free,0,Everyone,Books & Reference
+Super DK vs Kong Brother Advanced Free Classic,GAME,3.8,66,38M,10000,Free,0,Everyone,Arcade
+English for Everyone,FAMILY,3.2,429,18M,10000,Free,0,Everyone,Education
+DK Live - Sports Play by Play,SPORTS,3.9,255,19M,100000,Free,0,Everyone,Sports
+DK Eyewitness Audio Walks,TRAVEL_AND_LOCAL,2.3,9,70M,1000,Free,0,Everyone,Travel & Local
+DK Pittsburgh Sports,SPORTS,4.1,556,3.3M,10000,Free,0,Everyone,Sports
+LineStar For DK,SPORTS,4.3,1387,14M,50000,Free,0,Everyone,Sports
+Visuelles Wörterbuch Audio-App,FAMILY,3.1,192,66M,10000,Free,0,Everyone,Education
+Fodbold DK Pro,SPORTS,4.6,315,4.3M,1000,Paid,$2.99,Everyone,Sports
+10 Minutes a Day Times Tables,FAMILY,4.1,681,48M,100000,Free,0,Everyone,Education
+dk Verk,BUSINESS,4.4,9,31M,500,Free,0,Everyone,Business
+e-Boks.dk,PRODUCTIVITY,3.2,6752,3.3M,1000000,Free,0,Everyone,Productivity
+Account Class-11 Solutions (D K Goel),FAMILY,4.5,663,25M,50000,Free,0,Everyone,Education
+Dating.dk,SOCIAL,3.7,2111,11M,100000,Free,0,Mature 17+,Social
+S-Home DK,LIFESTYLE,4.1,4,17M,1000,Free,0,Everyone,Lifestyle
+DK Primrose for KLWP,PERSONALIZATION,4.3,0,16M,1,Paid,$0.99,Everyone,Personalization
+DK Online,FAMILY,4.2,21,3.5M,100,Free,0,Everyone,Entertainment
+Account Class-12 Solutions (D K Goel) Vol-1,FAMILY,4.4,708,33M,50000,Free,0,Everyone,Education
+Salah Widget (DK+Malmo),LIFESTYLE,4.5,532,6.4M,10000,Free,0,Everyone,Lifestyle
+PK and DK Audio App,FAMILY,5.0,2,3.9M,100,Free,0,Everyone,Entertainment
+dk,FAMILY,4.8,5,1.5M,10,Free,0,Everyone,Education
+HDWallpaper DK,PERSONALIZATION,4.3,0,6.6M,10,Free,0,Teen,Personalization
+Account Class-12 Solutions (D K Goel) Vol-2,FAMILY,4.6,124,23M,10000,Free,0,Everyone,Education
+DK Browser,COMMUNICATION,4.0,1,2.4M,10,Free,0,Everyone,Communication
+Discovery K!ds Play!,FAMILY,4.1,19388,35M,1000000,Free,0,Everyone,Entertainment;Music & Video
+cluster.dk,COMMUNICATION,4.2,49,1.1M,1000,Free,0,Everyone,Communication
+Transport DK,MAPS_AND_NAVIGATION,4.1,204,11M,10000,Free,0,Everyone,Maps & Navigation
+DK Childcare Centers,LIFESTYLE,4.1,0,13M,500,Free,0,Everyone,Lifestyle
+Gokarting.dk,FAMILY,4.2,13,34M,1000,Free,0,Everyone,Entertainment
+DK Murali,SOCIAL,4.8,65,7.1M,500,Free,0,Teen,Social
+DK TEL Dialer,COMMUNICATION,4.2,0,4.2M,50,Free,0,Everyone,Communication
+DK Studio Barbershop,BEAUTY,4.3,8,17M,100,Free,0,Everyone,Beauty
+Dr. D.K. Olukoya Sermons,LIFESTYLE,4.1,1,3.0M,100,Free,0,Everyone,Lifestyle
+GirlTalk.dk,SOCIAL,4.3,3,5.3M,100,Free,0,Teen,Social
+NY mobilbank DK - Danske Bank,FINANCE,2.8,851,30M,100000,Free,0,Everyone,Finance
+Dr D K Olukoya,LIFESTYLE,4.1,0,3.3M,1,Free,0,Teen,Lifestyle
+DK Hair Design,LIFESTYLE,4.1,0,2.5M,10,Free,0,Everyone,Lifestyle
+Advanced Download Manager Pro,TOOLS,4.7,6505,2.0M,50000,Paid,$2.99,Everyone,Tools
+Advanced Download Manager,TOOLS,4.5,569727,Varies with device,10000000,Free,0,Everyone,Tools
+GetThemAll Any File Downloader,TOOLS,4.2,91186,6.3M,5000000,Free,0,Everyone,Tools
+Downloader & Private Browser,TOOLS,4.3,1072565,Varies with device,50000000,Free,0,Everyone,Tools
+Download All Files,TOOLS,3.8,120494,2.3M,10000000,Free,0,Everyone,Tools
+Download Manager Pro FREE,PRODUCTIVITY,3.8,637,7.2M,100000,Free,0,Everyone,Productivity
+Download Accelerator Plus,TOOLS,4.2,43677,Varies with device,1000000,Free,0,Everyone,Tools
+Download Manager,TOOLS,3.8,79132,2.2M,10000000,Free,0,Everyone,Tools
+Download Video Free,FAMILY,4.0,39682,6.2M,1000000,Free,0,Everyone,Entertainment
+Fast Download Manager,TOOLS,4.0,18478,1.7M,1000000,Free,0,Everyone,Tools
+DL Hughley,FAMILY,4.6,12,10M,1000,Free,0,Mature 17+,Entertainment
+Turbo Download Manager (and Browser),TOOLS,4.0,32879,3.2M,5000000,Free,0,Everyone,Tools
+D.L. Evans Bank Mobile Banking,FINANCE,4.3,85,30M,10000,Free,0,Everyone,Finance
+The DL Hughley Show,FAMILY,4.3,23,11M,5000,Free,0,Everyone,Entertainment
+Download Blazer,TOOLS,3.9,34612,2.4M,5000000,Free,0,Everyone,Tools
+DL Image Manager,PRODUCTIVITY,5.0,2,1.7M,10,Paid,$0.99,Everyone,Productivity
+Download Manager For Android Free,TOOLS,4.0,593,3.3M,100000,Free,0,Everyone,Tools
+FrostWire: Torrent Downloader & Music Player,VIDEO_PLAYERS,4.1,253207,13M,10000000,Free,0,Everyone,Video Players & Editors
+Turbo Downloader,TOOLS,3.9,23348,3.2M,5000000,Free,0,Everyone,Tools
+Trimble DL,PRODUCTIVITY,4.2,133,7.9M,10000,Free,0,Everyone,Productivity
+Insave-Download for Instagram,PHOTOGRAPHY,4.3,46242,5.2M,1000000,Free,0,Everyone,Photography
++Download 4 Instagram Twitter,SOCIAL,4.5,40467,22M,1000000,Free,0,Everyone,Social
+Advanced Download Manager Holo,TOOLS,4.4,16192,1.6M,1000000,Free,0,Everyone,Tools
+G-Download Manager,TOOLS,4.1,802,9.4M,50000,Free,0,Everyone,Tools
+Video Downloader,VIDEO_PLAYERS,4.2,58981,5.4M,10000000,Free,0,Everyone,Video Players & Editors
+DL Calculator,SPORTS,4.5,177,1.1M,10000,Free,0,Everyone,Sports
+Inst Download - Video & Photo,VIDEO_PLAYERS,4.6,148715,3.3M,10000000,Free,0,Everyone,Video Players & Editors
+Vuze Torrent Downloader,VIDEO_PLAYERS,4.1,24565,5.5M,1000000,Free,0,Everyone,Video Players & Editors
+IDM Internet Download Manager,PRODUCTIVITY,3.9,1322,4.2M,100000,Free,0,Everyone,Productivity
+TorrDroid - Torrent Downloader,TOOLS,4.7,59632,10M,1000000,Free,0,Everyone,Tools
+Download Manager - File & Video,TOOLS,3.9,8780,5.0M,1000000,Free,0,Everyone,Tools
+AndStream - Streaming Download,VIDEO_PLAYERS,4.3,38607,2.9M,1000000,Free,0,Everyone,Video Players & Editors
+DM Me - Chat,SOCIAL,2.9,90,30M,10000,Free,0,Mature 17+,Social
+DM Screen,BOOKS_AND_REFERENCE,4.4,283,5.4M,10000,Free,0,Everyone 10+,Books & Reference
+DM for IG 😘 - Image & Video Saver for Instagram,SOCIAL,3.7,55,3.7M,5000,Free,0,Teen,Social
+DM for WhatsApp,COMMUNICATION,4.4,25,2.9M,5000,Free,0,Everyone,Communication
+Fifth Edition DM Tools,FAMILY,4.1,942,3.0M,100000,Free,0,Everyone,Role Playing
+DM Talk New,COMMUNICATION,4.2,3,4.2M,5000,Free,0,Everyone,Communication
+DM airdisk,TOOLS,2.8,11,11M,1000,Free,0,Everyone,Tools
+Diabetes mellitus (DM) from zero to hero,MEDICAL,4.9,18,3.0M,1000,Free,0,Everyone,Medical
+Auto DM for Twitter 🔥,SOCIAL,3.4,44,6.3M,1000,Free,0,Teen,Social
+DM HiDisk,TOOLS,2.8,54,20M,5000,Free,0,Everyone,Tools
+DM EVOLUTION,GAME,2.5,450,97M,10000,Free,0,Everyone,Card
+Daily DM,PERSONALIZATION,4.7,51,259k,1000,Free,0,Everyone,Personalization
+Dungeons and Dragons DM Tools,BOOKS_AND_REFERENCE,3.1,50,4.9M,1000,Paid,$1.99,Everyone,Books & Reference
+DM - The Offical Messaging App,COMMUNICATION,4.2,0,11M,10,Free,0,Teen,Communication
+DM airdisk Pro,TOOLS,3.2,11,36M,1000,Free,0,Everyone,Tools
+Convert Coordinates DM to DMS,MAPS_AND_NAVIGATION,4.3,15,164k,5000,Free,0,Everyone,Maps & Navigation
+DM security - Dragon Mobile,TOOLS,3.9,27,3.0M,1000,Free,0,Everyone,Tools
+DM 24/7,TOOLS,3.6,7,16M,1000,Free,0,Everyone,Tools
+DM Storage (for twitter),SOCIAL,3.2,6,458k,100,Free,0,Everyone,Social
+DM Transfers Dalaman Transfers,TRAVEL_AND_LOCAL,4.1,51,245k,10000,Free,0,Everyone,Travel & Local
+DM Tracker,COMMUNICATION,3.5,11,5.2M,1000,Free,0,Everyone,Communication
+DM Tuning,SPORTS,3.3,64,5.7M,5000,Free,0,Everyone,Sports
+DM Die Roller 9000,TOOLS,4.0,0,3.3M,5,Paid,$0.99,Everyone,Tools
+DM Magazine,NEWS_AND_MAGAZINES,4.1,0,27M,10,Free,0,Everyone,News & Magazines
+DM הפקות,PHOTOGRAPHY,4.2,2,10M,100,Free,0,Everyone,Photography
+DM TrackMan,MAPS_AND_NAVIGATION,4.1,10,7.8M,100,Free,0,Everyone,Maps & Navigation
+Aster DM Healthcare,MEDICAL,2.4,32,8.5M,5000,Free,0,Everyone,Medical
+Fake Chat (Direct Message),SOCIAL,4.4,5985,5.9M,500000,Free,0,Everyone,Social
+Interactive NPC DM Tool,FAMILY,2.8,5,629k,50,Paid,$0.99,Everyone,Role Playing
+DM Buddy » Learn Digital Marketing,FAMILY,5.0,3,1.7M,500,Free,0,Everyone,Education
+DM Accounting and Payroll,FINANCE,4.1,0,92M,100,Free,0,Everyone,Finance
+Basketball Dynasty Manager 16,SPORTS,4.4,426,21M,5000,Paid,$1.99,Everyone,Sports
+DM Collection,SHOPPING,4.3,3,1.2M,100,Free,0,Everyone,Shopping
+DM AirDisk HDD,TOOLS,4.0,4,33M,100,Free,0,Everyone,Tools
+DM AirDisk NAS,TOOLS,4.0,0,35M,50,Free,0,Everyone,Tools
+Shaggy's DM Assistant,PRODUCTIVITY,4.2,0,Varies with device,5,Free,0,Everyone,Productivity
+Otto DM,SOCIAL,4.3,0,2.4M,10,Free,0,Teen,Social
+DM Adventure,GAME,4.3,0,11M,10,Free,0,Everyone,Adventure
+Ramdor DM Mobile,BUSINESS,4.1,1,23M,100,Free,0,Everyone,Business
+Disciple Maker’s (DM) Lab,FAMILY,5.0,3,4.0M,100,Free,0,Everyone,Education
+Ultimate DM,FAMILY,4.2,0,Varies with device,10,Free,0,Everyone,Role Playing
+DN,NEWS_AND_MAGAZINES,3.3,78,17M,10000,Free,0,Everyone,News & Magazines
+DN eAvis,NEWS_AND_MAGAZINES,2.9,61,4.1M,10000,Free,0,Everyone,News & Magazines
+DN Sync,NEWS_AND_MAGAZINES,4.1,56,28k,1000,Free,0,Everyone 10+,News & Magazines
+DN Reader,NEWS_AND_MAGAZINES,4.6,18,1.8M,100,Free,0,Everyone,News & Magazines
+DN Managed Mobility App,BUSINESS,4.1,0,3.4M,50,Free,0,Everyone,Business
+e-DN - den digitala tidningen från Dagens Nyheter,NEWS_AND_MAGAZINES,2.2,160,32M,50000,Free,0,Everyone 10+,News & Magazines
+MultiPicture Live Wallpaper dn,PERSONALIZATION,4.3,505,288k,10000,Paid,$1.99,Everyone,Personalization
+DN Blog,SOCIAL,5.0,20,4.2M,10,Free,0,Teen,Social
+Dagens Nyheter,NEWS_AND_MAGAZINES,2.5,2055,17M,100000,Free,0,Everyone,News & Magazines
+DN Events,PRODUCTIVITY,4.2,4,18M,500,Free,0,Teen,Productivity
+DN.VR,NEWS_AND_MAGAZINES,3.0,29,37M,5000,Free,0,Everyone 10+,News & Magazines
+DN - Diário de Notícias,NEWS_AND_MAGAZINES,3.7,794,15M,100000,Free,0,Everyone,News & Magazines
+DN Employee,FAMILY,5.0,1,3.8M,10,Free,0,Everyone,Education
+DN Advanced Service Coder,BUSINESS,4.1,0,21M,10,Free,0,Everyone,Business
+DN Premium Hookah Lounge,BUSINESS,4.1,1,4.2M,50,Free,0,Everyone,Business
+PlayMotiv dn edition,BUSINESS,4.1,0,28M,500,Free,0,Everyone,Business
+Cossack Dictionary (DN),BOOKS_AND_REFERENCE,4.3,7,2.3M,10,Paid,$2.99,Teen,Books & Reference
+DN Calculators,FINANCE,5.0,12,775k,100,Free,0,Everyone,Finance
+DN Diamonds,BUSINESS,4.1,4,10M,100,Free,0,Everyone,Business
+DN Prasad,FINANCE,4.1,0,5.9M,100,Free,0,Everyone,Finance
+Writing Wizard Premium - Handwriting,FAMILY,4.1,89,33M,5000,Paid,$4.49,Everyone,Education;Education
+DN Driver,FAMILY,4.2,0,7.5M,5,Free,0,Everyone,Education
+D.N. College Meerut,FAMILY,4.2,0,19M,10,Free,0,Everyone,Education
+DN Radio FM,NEWS_AND_MAGAZINES,4.1,0,3.8M,10,Free,0,Teen,News & Magazines
+Sverige Tidningar,NEWS_AND_MAGAZINES,4.1,905,4.0M,50000,Free,0,Everyone,News & Magazines
+Svenska Dagbladet,NEWS_AND_MAGAZINES,2.6,820,Varies with device,100000,Free,0,Everyone,News & Magazines
+Dragon Nest M,FAMILY,4.6,11872,62M,100000,Free,0,Teen,Role Playing
+Downtown Mafia: Gang Wars (Mobster Game) Free,FAMILY,4.5,69013,Varies with device,1000000,Free,0,Teen,Role Playing
+DN Snacks,BUSINESS,4.1,0,7.6M,1,Free,0,Everyone,Business
+Guardian Hunter: SuperBrawlRPG,FAMILY,4.5,364013,27M,1000000,Free,0,Everyone 10+,Role Playing
+Sweden Newspapers,NEWS_AND_MAGAZINES,4.1,0,2.1M,0,Free,0,Everyone,News & Magazines
+ES Remote,FAMILY,3.3,707,15M,100000,Free,0,Everyone,Entertainment
+MC.Fitting,PRODUCTIVITY,4.2,130,3.4M,1000,Paid,$8.49,Everyone,Productivity
+Destiny Ninja Shall we date otome games love story,GAME,4.4,13079,30M,500000,Free,0,Everyone 10+,Adventure
+Day Night Live Wallpaper (All),PERSONALIZATION,4.7,4856,18M,50000,Paid,$2.49,Everyone,Personalization
+CritDice - Dice Roller,FAMILY,4.7,2910,5.3M,50000,Free,0,Everyone,Entertainment
+Cursive Writing Wizard - Handwriting,FAMILY,4.0,3745,31M,1000000,Free,0,Everyone,Education;Education
+Free Poker Games : Downtown Casino - Texas Holdem,GAME,4.5,2032,50M,50000,Free,0,Teen,Card
+WFVS 2018 | WhatApp Full Video Status & Downloader,PRODUCTIVITY,4.3,596,22M,50000,Free,0,Everyone,Productivity
+Maher EL Mouaikly - Offline,FAMILY,4.6,166,2.6M,10000,Free,0,Everyone,Entertainment
+Darkness Rises,FAMILY,4.7,456474,86M,5000000,Free,0,Teen,Role Playing
+NARUTO X BORUTO NINJA VOLTAGE,GAME,4.4,267395,71M,5000000,Free,0,Everyone 10+,Action
+Sword Art Online: Integral Factor,FAMILY,4.0,45359,32M,1000000,Free,0,Everyone 10+,Role Playing
+Mahalaxmi Dindarshika 2018,PRODUCTIVITY,4.2,25427,9.2M,1000000,Free,0,Everyone,Productivity
+Google Docs,PRODUCTIVITY,4.3,815974,Varies with device,100000000,Free,0,Everyone,Productivity
+"Microsoft To-Do: List, Task & Reminder",PRODUCTIVITY,4.1,14432,16M,1000000,Free,0,Everyone,Productivity
+"Any.do: To-do list, Calendar, Reminders & Planner",PRODUCTIVITY,4.5,298854,Varies with device,10000000,Free,0,Everyone,Productivity
+PDF Reader - Scan、Edit & Share,BUSINESS,4.3,54520,Varies with device,10000000,Free,0,Everyone,Business
+Notepad & To do list,PRODUCTIVITY,4.3,226295,4.2M,10000000,Free,0,Everyone,Productivity
+To Do List,PRODUCTIVITY,4.7,253155,3.5M,5000000,Free,0,Everyone,Productivity
+File Viewer for Android,TOOLS,4.1,7063,Varies with device,1000000,Free,0,Everyone,Tools
+"Polaris Office - Word, Docs, Sheets, Slide, PDF",PRODUCTIVITY,4.3,549900,60M,10000000,Free,0,Everyone,Productivity
+Google Keep,PRODUCTIVITY,4.4,691474,Varies with device,100000000,Free,0,Everyone,Productivity
+do,FAMILY,3.1,1073,5.9M,100000,Free,0,Everyone,Strategy
+Does not Commute,GAME,4.0,154108,78M,5000000,Free,0,Everyone,Racing
+Do It Later: Tasks & To-Dos,PRODUCTIVITY,4.5,123412,Varies with device,50000000,Free,0,Everyone,Productivity
+Todoist: To-do lists for task management & errands,PRODUCTIVITY,4.5,155998,12M,10000000,Free,0,Everyone,Productivity
+To Do Reminder with Alarm,PRODUCTIVITY,4.4,72161,4.9M,1000000,Free,0,Everyone,Productivity
+To-Do Calendar Planner,PRODUCTIVITY,4.2,30291,Varies with device,1000000,Free,0,Everyone,Productivity
+Wunderlist: To-Do List & Tasks,PRODUCTIVITY,4.6,404610,Varies with device,10000000,Free,0,Everyone,Productivity
+wikiHow: how to do anything,BOOKS_AND_REFERENCE,4.4,43088,3.0M,1000000,Free,0,Teen,Books & Reference
+"Ike - To-Do List, Task List",PRODUCTIVITY,4.6,6320,6.3M,100000,Free,0,Everyone,Productivity
+Kung Fu Do Fighting,GAME,4.0,271214,Varies with device,10000000,Free,0,Teen,Arcade
+"My Effectiveness: To do, Tasks",PRODUCTIVITY,4.6,14089,8.4M,500000,Free,0,Everyone,Productivity
+Do it (Tomorrow),PRODUCTIVITY,4.3,26452,4.0M,1000000,Free,0,Everyone,Productivity
+Do Not Disturb,PRODUCTIVITY,4.3,6120,1.9M,100000,Free,0,Everyone,Productivity
+To-Do List Widget,PRODUCTIVITY,3.9,7801,201k,1000000,Free,0,Everyone,Productivity
+NoteToDo. Notes. To do list,PRODUCTIVITY,4.5,57449,5.0M,1000000,Free,0,Everyone,Productivity
+"Memory Helper - To do list, Notepad, Notes, Memo",PRODUCTIVITY,4.7,7566,4.0M,500000,Free,0,Everyone,Productivity
+"2Do - Reminders, To-do List & Notes",PRODUCTIVITY,4.3,4649,30M,100000,Free,0,Everyone,Productivity
+"TickTick: To Do List with Reminder, Day Planner",PRODUCTIVITY,4.6,25370,Varies with device,1000000,Free,0,Everyone,Productivity
+"Notes : Colorful Notepad Note,To Do,Reminder,Memo",LIFESTYLE,4.6,10484,9.0M,1000000,Free,0,Everyone,Lifestyle
+"Time Planner - Schedule, To-Do List, Time Tracker",PRODUCTIVITY,4.2,2537,8.5M,500000,Free,0,Everyone,Productivity
+MyLifeOrganized: To-Do List,PRODUCTIVITY,4.3,4441,Varies with device,100000,Free,0,Everyone,Productivity
+ColorNote Notepad Notes,PRODUCTIVITY,4.6,2401017,Varies with device,100000000,Free,0,Everyone,Productivity
+Cal - Google Calendar + Widget,PRODUCTIVITY,4.2,86172,13M,1000000,Free,0,Everyone,Productivity
+"Clean My House – Chore To Do List, Task Scheduler",PRODUCTIVITY,4.1,661,3.4M,100000,Free,0,Everyone,Productivity
+"Goal Meter: Goal Tracker, Habit Changer,To-Do List",PRODUCTIVITY,4.6,7969,20M,100000,Free,0,Everyone,Productivity
+To-do list,PRODUCTIVITY,4.4,688,4.4M,50000,Free,0,Everyone,Productivity
+Do Not Crash,FAMILY,3.7,56664,8.3M,1000000,Free,0,Everyone,Casual
+Do I Snore or Grind,MEDICAL,4.4,2295,19M,100000,Free,0,Everyone,Medical
+How well do you know me?,GAME,3.9,1290,6.4M,100000,Free,0,Everyone,Word
+EasyNote Notepad | To Do List,TOOLS,4.3,15618,2.4M,1000000,Free,0,Everyone,Tools
+Apex Launcher,PERSONALIZATION,4.3,266434,Varies with device,10000000,Free,0,Everyone,Personalization
+Adobe Fill & Sign: Easy PDF Form Filler,PRODUCTIVITY,4.3,11402,5.3M,1000000,Free,0,Everyone,Productivity
+DO YOU KNOW THE WAY Soundboard,FAMILY,4.5,1007,5.2M,100000,Free,0,Everyone,Entertainment
+Dude Perfect 2,GAME,4.5,401648,70M,10000000,Free,0,Everyone,Action
+Endless Ducker,GAME,4.5,8193,41M,500000,Free,0,Everyone,Arcade
+Dude Perfect,SPORTS,4.5,97,1.9M,10000,Free,0,Everyone,Sports
+that's lit,GAME,4.7,1115,39M,100000,Free,0,Everyone,Arcade
+All Type DP,FAMILY,4.3,1853,5.8M,500000,Free,0,Everyone,Entertainment
+Dp For WhatsApp,PERSONALIZATION,4.4,1623,11M,1000000,Free,0,Mature 17+,Personalization
+DP and Status for WhatsApp 2018,SOCIAL,4.5,787,6.9M,100000,Free,0,Everyone,Social
+DP Editor,PHOTOGRAPHY,4.3,18,15M,5000,Free,0,Teen,Photography
+DP & Status,FAMILY,4.3,1922,4.7M,500000,Free,0,Everyone,Entertainment
+Dp for girls,ART_AND_DESIGN,4.2,175,8.2M,50000,Free,0,Everyone,Art & Design
+DP Maker,PHOTOGRAPHY,4.2,784,18M,100000,Free,0,Everyone,Photography
+Download Instant DP (Full HD),TOOLS,4.3,1283,4.4M,100000,Free,0,Everyone,Tools
+Square DP For Whatsapp,PHOTOGRAPHY,4.2,67,15M,10000,Free,0,Everyone,Photography
+Profile pictures for WhatsApp,PERSONALIZATION,4.7,10786,9.4M,500000,Free,0,Mature 17+,Personalization
+DP and Status,FAMILY,4.1,623,3.0M,100000,Free,0,Everyone,Entertainment
+Dp For Whatsapp,SOCIAL,4.3,39,12M,5000,Free,0,Everyone,Social
+DP & Status for Whatsapp 2018,PERSONALIZATION,4.1,293,3.4M,100000,Free,0,Everyone,Personalization
+DP Creator for WhatsApp,PHOTOGRAPHY,3.8,4813,5.1M,100000,Free,0,Everyone,Photography
+Dp For FB,PHOTOGRAPHY,4.5,12,2.0M,1000,Free,0,Teen,Photography
+Best DP and Status (Daily Updates Photos),FAMILY,4.1,3003,3.2M,1000000,Free,0,Everyone,Entertainment
+Magical Insta DP,PHOTOGRAPHY,4.2,2,5.2M,1000,Free,0,Everyone,Photography
+Profile Pictures and DP for Whatsapp,SOCIAL,4.3,48,11M,5000,Free,0,Everyone,Social
+All Types DP & Status Maker,PHOTOGRAPHY,4.5,16,14M,1000,Free,0,Teen,Photography
+DP Photo Editor,PHOTOGRAPHY,4.1,88,7.7M,10000,Free,0,Everyone,Photography
+Status For WhatsApp DP - pro,PERSONALIZATION,4.4,49,12M,10000,Free,0,Teen,Personalization
+"Marathi DP - status and message,jokes,Video app",FAMILY,4.3,694,3.8M,100000,Free,0,Everyone,Entertainment
+Cute Images for Whatsapp,FAMILY,4.4,634,8.1M,100000,Free,0,Teen,Entertainment
+Profile Pictures - Best DP Status,FAMILY,4.3,131,5.4M,50000,Free,0,Everyone,Entertainment
+Best DP and Status - All Type DP & Status,FAMILY,4.2,1,5.7M,100,Free,0,Everyone,Entertainment
+Dp for Facebook,SOCIAL,4.1,56,10M,5000,Free,0,Everyone,Social
+Fifa World Cup 2018: Photo Frame Editor & DP Maker,PHOTOGRAPHY,4.6,666,8.7M,100000,Free,0,Everyone,Photography
+DP and Status Images | All Latest Status 2018,LIFESTYLE,4.7,25,3.8M,10000,Free,0,Teen,Lifestyle
+Best DP and Status,SOCIAL,4.2,93,5.6M,10000,Free,0,Teen,Social
+"100000+ Messages - DP, Status, Jokes & GIF 2018",LIFESTYLE,3.7,121,3.8M,10000,Free,0,Mature 17+,Lifestyle
+Instant DP Downloader for Instagram,SOCIAL,4.7,38,4.1M,5000,Free,0,Everyone,Social
+DP Display Pictures Life Quotes Motivational GM,SOCIAL,4.4,39,11M,5000,Free,0,Everyone,Social
+Latest DP and Status Pro 2018,FAMILY,4.7,19,5.7M,1000,Free,0,Everyone,Entertainment
+Best DP And Video Status 2018 For Whatsapp,FAMILY,4.2,91,3.8M,10000,Free,0,Everyone,Entertainment
+Qeek for Instagram - Zoom profile insta DP,SOCIAL,4.6,12111,9.1M,500000,Free,0,Everyone,Social
+DP Battle,FAMILY,4.5,132,2.5M,5000,Free,0,Everyone,Entertainment
+Faceoff DP Battle App,FAMILY,4.8,38,6.7M,1000,Free,0,Everyone,Entertainment
+Insta Square Profile DP,PHOTOGRAPHY,3.7,42,11M,5000,Free,0,Everyone,Photography
+Name Art DP - Focus n Filter Text 2018,ART_AND_DESIGN,4.3,132,7.7M,10000,Free,0,Everyone,Art & Design
+DP Status 2017,PHOTOGRAPHY,4.2,302,7.0M,50000,Free,0,Everyone,Photography
+Dairy Queen,FOOD_AND_DRINK,3.6,742,43M,100000,Free,0,Everyone,Food & Drink
+DQ Texas,FOOD_AND_DRINK,4.1,336,13M,100000,Free,0,Everyone,Food & Drink
+DQ Events,BUSINESS,2.3,41,20M,10000,Free,0,Everyone,Business
+Dash Quest Heroes,GAME,4.3,8432,59M,500000,Free,0,Everyone 10+,Adventure
+Coupons for Dairy Queen,FOOD_AND_DRINK,4.6,42,3.9M,100,Free,0,Teen,Food & Drink
+DRAGON QUEST VIII,FAMILY,4.5,7812,27M,50000,Paid,$19.99,Everyone 10+,Role Playing
+ODTMobile v4,BUSINESS,4.0,3,16M,1000,Free,0,Everyone,Business
+DRAGON QUEST III,FAMILY,4.2,1661,63M,10000,Paid,$9.99,Everyone,Role Playing
+LightMeter (noAds),PHOTOGRAPHY,4.6,617,12M,10000,Paid,$1.99,Everyone,Photography
+DRAGON QUEST,FAMILY,4.2,9659,30M,100000,Paid,$2.99,Everyone,Role Playing
+DRAGON QUEST II,FAMILY,4.5,2576,44M,10000,Paid,$4.99,Everyone,Role Playing
+SONIC Drive-In,FOOD_AND_DRINK,4.3,19373,43M,1000000,Free,0,Everyone,Food & Drink
+DRAGON QUEST VI,FAMILY,4.4,3358,17M,100000,Paid,$14.99,Everyone,Role Playing
+McDonald's,FOOD_AND_DRINK,3.6,145646,42M,10000000,Free,0,Everyone,Food & Drink
+DQT GPS,BUSINESS,4.0,3,6.3M,500,Free,0,Everyone,Business
+DQ Akses,TOOLS,4.0,0,2.6M,1,Free,0,Everyone,Tools
+Discovery Insure,MAPS_AND_NAVIGATION,2.8,1911,20M,100000,Free,0,Everyone,Maps & Navigation
+Taco Bell,LIFESTYLE,3.8,28140,16M,1000000,Free,0,Everyone,Lifestyle
+LightMeter Free,PHOTOGRAPHY,4.1,5485,13M,1000000,Free,0,Everyone,Photography
+CHRONO TRIGGER (Upgrade Ver.),FAMILY,3.8,11250,6.3M,100000,Paid,$9.99,Everyone 10+,Role Playing
+ODTMobile,BUSINESS,3.4,15,2.7M,10000,Free,0,Everyone,Business
+Whataburger,FOOD_AND_DRINK,4.5,5093,56M,500000,Free,0,Everyone,Food & Drink
+FINAL FANTASY DIMENSIONS,FAMILY,4.3,8450,1.1M,100000,Paid,$13.99,Everyone,Role Playing
+Arby's,FOOD_AND_DRINK,3.1,194,26M,100000,Free,0,Everyone,Food & Drink
+RPG Dragon Lapis,FAMILY,4.6,13492,56M,100000,Free,0,Teen,Role Playing
+Find Fast Food,SHOPPING,3.3,272,785k,100000,Free,0,Everyone,Shopping
+Jungle book-The Great Escape,GAME,3.9,2362,25M,100000,Free,0,Everyone,Action
+Bunny Skater,GAME,4.2,139432,4.7M,10000000,Free,0,Everyone,Adventure
+DQSalmaan - A fan made App,FAMILY,4.9,707,6.0M,10000,Free,0,Everyone,Entertainment
+Culver's,LIFESTYLE,3.9,1638,4.9M,100000,Free,0,Everyone,Lifestyle
+Wendy’s – Food and Offers,FOOD_AND_DRINK,3.4,6512,18M,1000000,Free,0,Everyone,Food & Drink
+World Webcams,WEATHER,3.7,7896,Varies with device,1000000,Free,0,Everyone,Weather
+Dunkin' Donuts,FOOD_AND_DRINK,4.2,68270,66M,1000000,Free,0,Everyone,Food & Drink
+SUBWAY®,FOOD_AND_DRINK,3.8,21381,41M,1000000,Free,0,Everyone,Food & Drink
+The Walking Zombie: Dead City,GAME,4.6,58575,96M,1000000,Free,0,Teen,Action
+Monster Fishing 2018,SPORTS,4.4,32881,76M,1000000,Free,0,Everyone,Sports
+Call Blocker & Blacklist,COMMUNICATION,4.0,6,4.2M,1000,Free,0,Everyone,Communication
+Panera Bread,FOOD_AND_DRINK,4.2,10225,36M,1000000,Free,0,Everyone,Food & Drink
+Dulquer Salmaan HD Wallpapers,PERSONALIZATION,4.3,1,3.9M,100,Free,0,Everyone,Personalization
+IHOP®,FOOD_AND_DRINK,4.2,441,24M,100000,Free,0,Everyone,Food & Drink
+Starbucks,FOOD_AND_DRINK,4.5,455496,35M,10000000,Free,0,Everyone,Food & Drink
+myGrow,PRODUCTIVITY,4.6,84,23M,1000,Paid,$4.29,Mature 17+,Productivity
+Dr. Parking 4,GAME,4.4,475369,13M,50000000,Free,0,Everyone,Racing
+Dr. Driving 2,GAME,4.6,358633,19M,10000000,Free,0,Everyone,Racing
+Anti-virus Dr.Web Light,TOOLS,4.5,1094094,Varies with device,100000000,Free,0,Everyone,Tools
+dr.fone - Recovery & Transfer wirelessly & Backup,TOOLS,3.7,23347,7.6M,5000000,Free,0,Everyone,Tools
+Dr. Truck Driver : Real Truck Simulator 3D,FAMILY,4.1,1626,96M,100000,Free,0,Everyone 10+,Simulation
+Dr. Cares - Pet Rescue 911 🐶,FAMILY,4.2,14432,35M,500000,Free,0,Everyone,Casual
+Dr. Panda Town,FAMILY,4.0,36578,Varies with device,1000000,Free,0,Everyone,Education;Pretend Play
+Dr. Parker : Parking Simulator,GAME,4.5,14253,81M,1000000,Free,0,Everyone,Racing
+Dr. Parker : Real car parking simulation,GAME,4.6,15829,95M,1000000,Free,0,Everyone,Racing
+Dr. Battery - Fast Charger - Super Cleaner 2018,TOOLS,4.5,101738,10M,1000000,Free,0,Everyone,Tools
+"Dr. Safety - Antivirus, Booster, Cleaner, AppLock",TOOLS,4.4,372553,21M,10000000,Free,0,Everyone,Tools
+DR TV,VIDEO_PLAYERS,3.3,6716,4.7M,500000,Free,0,Mature 17+,Video Players & Editors
+Real Car Dr Parking Master: Parking Games 2018,FAMILY,4.2,3345,27M,1000000,Free,0,Everyone,Simulation
+Doctor Kids,FAMILY,4.2,200450,25M,10000000,Free,0,Everyone,Casual;Pretend Play
+Dr. Rocket,GAME,4.0,42182,3.4M,1000000,Free,0,Everyone,Arcade
+Dr. Muscle,HEALTH_AND_FITNESS,4.0,87,33M,10000,Free,0,Everyone,Health & Fitness
+Dr. Dominoes,GAME,4.0,2700,5.7M,500000,Free,0,Everyone,Board
+Dr. Sudoku,FAMILY,3.5,2310,3.1M,500000,Free,0,Everyone,Puzzle
+Dr.Web Security Space,TOOLS,4.5,594406,Varies with device,10000000,Free,0,Everyone,Tools
+Dr. Unblock,FAMILY,3.9,3847,4.3M,1000000,Free,0,Everyone,Puzzle
+Dr. Gomoku,GAME,3.9,85317,4.5M,5000000,Free,0,Everyone,Board
+Dr. Panda Farm,FAMILY,4.1,265,46M,10000,Paid,$2.99,Everyone,Education;Pretend Play
+DR.MEEP,FAMILY,4.4,54,33M,500,Paid,$2.99,Everyone,Puzzle
+Dr. Panda Art Class,FAMILY,4.2,1013,58M,50000,Paid,$2.99,Everyone,Education;Creativity
+Dr. Panda's Swimming Pool,FAMILY,4.4,2311,9.3M,100000,Paid,$1.99,Everyone,Casual;Pretend Play
+Dr. Pixel: Pill mania Classic,FAMILY,4.3,2419,6.2M,100000,Free,0,Everyone,Puzzle
+Dr. Chess,GAME,4.1,97209,6.7M,1000000,Free,0,Everyone,Board
+Super Dr. Parking 3D,FAMILY,4.0,4518,41M,1000000,Free,0,Everyone,Simulation
+Dr Dre - Beatmaker,GAME,4.3,146,6.0M,10000,Free,0,Mature 17+,Music
+Dr. Panda & Toto's Treehouse,FAMILY,4.4,3397,9.5M,50000,Paid,$3.99,Everyone,Casual;Pretend Play
+Dr. Cares - Amy's Pet Clinic 🐈 🐕,FAMILY,4.5,3580,60M,100000,Free,0,Everyone,Casual
+Dr. Splorchy Presents Space Heroes,GAME,4.6,18,31M,100,Paid,$4.99,Mature 17+,Adventure
+Pet Vet Dr - Animals Hospital,FAMILY,3.7,11748,36M,1000000,Free,0,Teen,Casual
+Dr.Android Repair Master 2017,PRODUCTIVITY,3.8,1205,4.3M,100000,Free,0,Everyone,Productivity
+DR CONTROL,FAMILY,3.4,267,1.5M,10000,Free,0,Everyone,Entertainment
+Dr Driving Racer,GAME,4.3,183,68M,10000,Free,0,Everyone,Racing
+Dr. McDougall Mobile Cookbook,HEALTH_AND_FITNESS,3.8,76,1.2M,1000,Paid,$4.99,Everyone,Health & Fitness
+Dr. Seuss's ABC,FAMILY,4.7,429,12M,10000,Paid,$3.99,Everyone,Books & Reference;Education
+Dr. Booster - Boost Game Speed,TOOLS,4.4,138872,22M,10000000,Free,0,Everyone,Tools
+Dr. Panda Hospital,FAMILY,4.4,1091,45M,50000,Paid,$2.99,Everyone,Education;Pretend Play
+Dr. Panda Café Freemium,FAMILY,4.1,11788,62M,1000000,Free,0,Everyone,Educational;Pretend Play
+Dr. Panda Ice Cream Truck Free,FAMILY,4.4,23022,80M,1000000,Free,0,Everyone,Role Playing;Pretend Play
+Dr. Doug's Tips,BOOKS_AND_REFERENCE,4.0,22,34M,1000,Free,0,Everyone,Books & Reference
+Dr. 2048,FAMILY,3.9,1985,3.5M,500000,Free,0,Everyone,Puzzle
+Dr. Panda Restaurant 2,FAMILY,4.3,3725,67M,100000,Paid,$2.99,Everyone,Educational;Pretend Play
+Dr. Panda Supermarket,FAMILY,4.2,1357,58M,50000,Paid,$2.99,Everyone,Educational;Pretend Play
+Dr. Shogi,GAME,3.3,19291,5.1M,1000000,Free,0,Everyone,Board
+DR Sebi's Alkaline List,FAMILY,4.0,68,5.5M,5000,Free,0,Everyone,Education
+DraStic DS Emulator,GAME,4.6,87766,12M,1000000,Paid,$4.99,Everyone,Action
+NDS Emulator - For Android 6,GAME,4.1,14002,19M,1000000,Free,0,Everyone,Arcade
+Free DS Emulator,GAME,4.1,22896,19M,1000000,Free,0,Everyone,Arcade
+nds4droid,GAME,3.4,107778,8.8M,10000000,Free,0,Everyone,Arcade
+MegaNDS (NDS Emulator),GAME,3.4,2218,11M,500000,Free,0,Everyone,Arcade
+DS file,PRODUCTIVITY,4.1,10676,12M,1000000,Free,0,Everyone,Productivity
+DS finder,TOOLS,4.0,2596,32M,500000,Free,0,Everyone,Tools
+DS get,TOOLS,3.4,71852,22M,5000000,Free,0,Everyone,Tools
+DS cloud,TOOLS,3.2,4908,38M,500000,Free,0,Everyone,Tools
+DS photo,VIDEO_PLAYERS,3.8,7335,Varies with device,1000000,Free,0,Everyone,Video Players & Editors
+DS video,VIDEO_PLAYERS,3.8,12443,Varies with device,1000000,Free,0,Everyone,Video Players & Editors
+DS note,PRODUCTIVITY,3.9,2046,60M,100000,Free,0,Everyone,Productivity
+DS cam,PRODUCTIVITY,3.6,3227,35M,500000,Free,0,Everyone,Productivity
+DS router,TOOLS,3.8,253,15M,50000,Free,0,Everyone,Tools
+EmuBox - Fast Retro Emulator,GAME,3.9,1576,43M,50000,Free,0,Everyone,Arcade
+Synology Drive,PRODUCTIVITY,3.2,368,Varies with device,100000,Free,0,Everyone,Productivity
+DS Creator 2.0,TOOLS,1.0,2,4.4M,500,Free,0,Everyone,Tools
+DS App Manager,TOOLS,4.6,14,2.1M,1000,Free,0,Everyone,Tools
+Simple x3DS Emulator - BETA,GAME,4.3,0,Varies with device,50000,Free,0,Everyone,Arcade
+DS Helpdesk Plus,BUSINESS,3.6,21,Varies with device,100,Paid,$12.99,Everyone,Business
+DS,FAMILY,4.9,15,23M,100,Free,0,Everyone,Casual
+Ability DS UNO,PRODUCTIVITY,4.2,3,2.3M,50,Paid,$2.60,Everyone,Productivity
+DS Connector 2.0,TOOLS,2.6,5,636k,500,Free,0,Everyone,Tools
+DS Barometer - Altimeter and Weather Information,WEATHER,3.9,2962,4.2M,100000,Free,0,Everyone,Weather
+DS Companion,HEALTH_AND_FITNESS,4.3,0,4.6M,50,Free,0,Everyone,Health & Fitness
+DS-L4 Viewer,PHOTOGRAPHY,3.5,13,7.9M,1000,Free,0,Everyone,Photography
+DS Tower Defence,GAME,3.2,768,1.4M,100000,Free,0,Everyone,Arcade
+DS-Admin,FAMILY,4.2,1,21M,10,Free,0,Everyone,Education
+NDS-controller,TOOLS,3.3,35,916k,1000,Free,0,Everyone,Tools
+DS-11 form,BUSINESS,4.1,3,28M,100,Free,0,Everyone,Business
+SmartCircle Remote DS,BUSINESS,4.1,2,1.6M,500,Free,0,Everyone,Business
+RetroArch,GAME,3.8,21423,84M,1000000,Free,0,Everyone,Action
+DS Speedometer & Odometer,MAPS_AND_NAVIGATION,3.9,22382,6.6M,1000000,Free,0,Everyone,Maps & Navigation
+MegaN64 (N64 Emulator),FAMILY,4.6,877576,12M,10000000,Free,0,Everyone,Casual
+DS-20000S,PRODUCTIVITY,1.8,12,14M,1000,Free,0,Everyone,Productivity
+DS Vision,BUSINESS,4.1,0,38M,5,Free,0,Everyone,Business
+Learn DS [BETA],FAMILY,4.3,9,5.0M,500,Free,0,Everyone,Education
+Deep Sleep Battery Saver Pro,TOOLS,3.9,1417,2.9M,10000,Paid,$3.28,Everyone,Tools
+DS - xR,BUSINESS,4.1,2,1.4M,10,Free,0,Everyone,Business
+DS-Students,FAMILY,4.8,5,8.4M,100,Free,0,Everyone,Education
+DS Thermometer,WEATHER,3.7,631,3.0M,100000,Free,0,Everyone,Weather
+PhotoFrame for Synology DS,PHOTOGRAPHY,4.0,1,2.6M,10,Paid,$4.99,Everyone,Photography
+Deep Sleep Battery Saver,TOOLS,4.1,22032,3.7M,1000000,Free,0,Everyone,Tools
+Draft Simulator for FUT 18,SPORTS,4.6,162933,100M,5000000,Free,0,Everyone,Sports
+DS Flashlight,TOOLS,4.0,127,5.8M,10000,Free,0,Everyone,Tools
+DS-82 form,BUSINESS,4.1,1,28M,100,Free,0,Everyone,Business
+dt Pro,FINANCE,4.8,4,4.5M,1000,Free,0,Everyone,Finance
+DT,LIFESTYLE,4.1,0,8.9M,100,Free,0,Everyone,Lifestyle
+DT Manager,PRODUCTIVITY,4.0,9,3.1M,500,Free,0,Everyone,Productivity
+Real Sheet ∞: Pathfinder + DT,FAMILY,3.5,2,22M,50,Paid,$2.99,Everyone,Role Playing
+DT-CAM,FAMILY,4.2,6,9.9M,1000,Free,0,Everyone,Entertainment
+DT Fieldlink,BUSINESS,3.0,2,49M,500,Free,0,Everyone,Business
+DT Driving Test Theory,FAMILY,4.6,477,1.6M,10000,Free,0,Everyone,Education
+DT Smart,TOOLS,1.6,39,8.9M,1000,Free,0,Everyone,Tools
+Truck Simulator DT 3D,FAMILY,3.8,110,22M,5000,Free,0,Everyone,Simulation
+DT Baby Cam,TOOLS,1.7,10,23M,500,Free,0,Everyone,Tools
+Bloons TD 5,FAMILY,4.6,190086,94M,1000000,Paid,$2.99,Everyone,Strategy
+WPBS-DT,FAMILY,5.0,3,6.3M,500,Free,0,Everyone,Entertainment
+ReadyOp DT,COMMUNICATION,4.6,8,1.1M,1000,Free,0,Everyone,Communication
+Soccer Manager 2018,SPORTS,4.4,63779,95M,1000000,Free,0,Everyone,Sports
+Online Soccer Manager (OSM),SPORTS,4.5,1312936,21M,10000000,Free,0,Everyone,Sports
+DT-VR,FAMILY,3.8,25,9.5M,1000,Free,0,Everyone,Entertainment
+Dt Tracking,AUTO_AND_VEHICLES,4.0,4,24M,100,Free,0,Everyone,Auto & Vehicles
+DT Simple Interval Timer,SPORTS,4.1,10,1.5M,1000,Free,0,Everyone,Sports
+DT Health,MEDICAL,4.2,1,24M,10,Free,0,Everyone,Medical
+DT CLOTHINGS,SHOPPING,5.0,1,7.9M,10,Free,0,Everyone,Shopping
+PAY DT,BUSINESS,4.1,0,5.3M,1,Free,0,Everyone,Business
+Test Application DT 02,ART_AND_DESIGN,4.4,0,1.2M,0,Free,0,Everyone,Art & Design
+Eat Right Diet (by Dt Shreya's Family Diet Clinic),HEALTH_AND_FITNESS,4.3,0,12M,10,Free,0,Everyone,Health & Fitness
+DT Practice,BUSINESS,4.1,6,5.7M,500,Free,0,Everyone,Business
+Dt. Jyothi Srinivas,HEALTH_AND_FITNESS,5.0,18,13M,100,Free,0,Everyone,Health & Fitness
+DT future1 cam,TOOLS,1.0,1,24M,50,Free,0,Everyone,Tools
+DT Freight,PRODUCTIVITY,4.2,0,54M,1,Free,0,Everyone,Productivity
+Johor DT Lock Screen,PERSONALIZATION,4.3,13,3.9M,1000,Free,0,Everyone,Personalization
+PES CLUB MANAGER,SPORTS,4.4,783025,Varies with device,10000000,Free,0,Everyone,Sports
+Riptide GP: Renegade,GAME,4.7,4328,Varies with device,100000,Paid,$2.99,Everyone 10+,Racing
+Wheelie Challenge,GAME,4.6,137338,51M,5000000,Free,0,Everyone,Racing
+DT NO.I,HEALTH_AND_FITNESS,2.4,44,49M,1000,Free,0,Everyone,Health & Fitness
+DT Technologies,SHOPPING,4.3,0,1.3M,10,Free,0,Everyone,Shopping
+DTPay,SHOPPING,4.5,18,994k,1000,Free,0,Everyone,Shopping
+"""i DT"" Fútbol. Todos Somos Técnicos.",SPORTS,4.2,27,3.6M,500,Free,0,Everyone,Sports
+MasterDT,SPORTS,4.2,24,4.1M,100,Free,0,Everyone,Sports
+Top Soccer Manager,SPORTS,4.4,199739,66M,10000000,Free,0,Everyone,Sports
+The Secret Daily Teachings,LIFESTYLE,4.3,206,32M,1000,Paid,$4.99,Everyone,Lifestyle
+Spring flowers theme couleurs d t space,ART_AND_DESIGN,5.0,1,2.9M,100,Free,0,Everyone,Art & Design
+Soccer Board Tactics,SPORTS,4.1,6231,8.9M,100000,Free,0,Everyone,Sports
+Dirt Trackin Sprint Cars,GAME,3.8,499,47M,10000,Paid,$3.99,Everyone,Racing
+senior easy phone,PERSONALIZATION,3.9,168,2.1M,50000,Free,0,Teen,Personalization
+dt.se,NEWS_AND_MAGAZINES,3.1,124,12M,10000,Free,0,Everyone,News & Magazines
+WhatsVPN - Unlimited Free VPN,TOOLS,4.7,24985,7.8M,500000,Free,0,Everyone,Tools
+Cache Cleaner-DU Speed Booster (booster & cleaner),TOOLS,4.5,12759815,15M,100000000,Free,0,Everyone,Tools
+du app,LIFESTYLE,3.5,7578,25M,1000000,Free,0,Everyone,Lifestyle
+DU Battery Saver - Battery Charger & Battery Life,TOOLS,4.5,13479633,14M,100000000,Free,0,Everyone,Tools
+DU Antivirus Security - Applock & Privacy Guard,TOOLS,4.6,436615,10M,10000000,Free,0,Everyone,Tools
+DU Cleaner – Memory cleaner & clean phone cache,TOOLS,4.5,465831,8.9M,10000000,Free,0,Everyone,Tools
+DU Launcher - Boost Your Phone,PERSONALIZATION,4.5,67707,4.8M,1000000,Free,0,Everyone,Personalization
+DU Security,TOOLS,4.4,4847,3.2M,100000,Free,0,Everyone,Tools
+DU Browser—Browse fast & fun,COMMUNICATION,4.3,1133539,4.7M,10000000,Free,0,Everyone,Communication
+DU Privacy-hide apps、sms、file,VIDEO_PLAYERS,4.4,21762,Varies with device,1000000,Free,0,Everyone,Video Players & Editors
+DU Browser Mini(Small&Fast),TOOLS,4.2,20941,2.0M,1000000,Free,0,Everyone,Tools
+Caller ID & Call Block - DU Caller,COMMUNICATION,4.6,93930,14M,5000000,Free,0,Everyone,Communication
+Lock Screen - DU Locker & Lock screen wallpaper,TOOLS,4.5,5174,4.7M,100000,Free,0,Everyone,Tools
+du View,FAMILY,3.8,935,22M,50000,Free,0,Teen,Entertainment
+DU Emoji Keyboard（Simeji）,TOOLS,4.3,19234,14M,500000,Free,0,Everyone,Tools
+"DU GIF Maker: GIF Maker, Video to GIF & GIF Editor",PHOTOGRAPHY,4.6,7605,4.3M,500000,Free,0,Everyone,Photography
+DU Flashlight - Brightest LED & Flashlight Free,TOOLS,4.3,73821,Varies with device,5000000,Free,0,Everyone,Tools
+Upgrade for Android DU Master,TOOLS,3.6,12993,5.2M,1000000,Free,0,Everyone,Tools
+Modern: DU Launcher Theme,PERSONALIZATION,4.2,868,309k,50000,Free,0,Everyone,Personalization
+Weather Forecast Pro,WEATHER,4.7,14051,8.7M,100000,Paid,$3.99,Everyone,Weather
+Night: DU Launcher Theme,PERSONALIZATION,4.3,1419,485k,50000,Free,0,Everyone,Personalization
+DU Collage Maker - Photo Collage & Grid & Layout,PHOTOGRAPHY,4.7,4595,2.5M,100000,Free,0,Everyone,Photography
+Du Chinese – Mandarin Lessons,FAMILY,4.8,3390,9.2M,100000,Free,0,Everyone,Education
+Portes du Soleil,SPORTS,3.1,500,39M,50000,Free,0,Everyone,Sports
+Sword of Chaos - Lame du Chaos,GAME,4.5,23599,96M,100000,Free,0,Teen,Action
+Hadith du jour,FAMILY,4.4,276,Varies with device,50000,Free,0,Everyone,Education
+Bible du Semeur-BDS (French),BOOKS_AND_REFERENCE,4.5,313,6.9M,50000,Free,0,Everyone,Books & Reference
+La citadelle du musulman,BOOKS_AND_REFERENCE,4.5,314,9.8M,50000,Free,0,Everyone,Books & Reference
+Voyance du pyromancien,FAMILY,4.2,22,16M,5000,Free,0,Everyone,Entertainment
+Clean My Android,PRODUCTIVITY,4.7,101163,6.2M,5000000,Free,0,Everyone,Productivity
+Citation du Jour - Motivation,FAMILY,4.1,321,914k,100000,Free,0,Everyone,Education
+La Poupée du Voyant,FAMILY,4.4,265,8.2M,50000,Free,0,Everyone,Entertainment
+Star Chart,FAMILY,4.3,128808,Varies with device,10000000,Free,0,Everyone,Education;Education
+APUS Booster - Space Cleaner & Booster,PRODUCTIVITY,4.6,1048766,13M,10000000,Free,0,Everyone,Productivity
+Officiel du SCRABBLE LAROUSSE,BOOKS_AND_REFERENCE,3.4,116,48M,5000,Paid,$4.60,Everyone,Books & Reference
+Proverbes du monde,FAMILY,4.2,38,2.8M,10000,Free,0,Everyone,Entertainment
+"GO Security－AntiVirus, AppLock, Booster",TOOLS,4.7,1251479,Varies with device,10000000,Free,0,Everyone,Tools
+iSmart DV,VIDEO_PLAYERS,3.6,5692,31M,1000000,Free,0,Everyone,Video Players & Editors
+dv Prompter,VIDEO_PLAYERS,3.7,321,1.3M,50000,Free,0,Everyone,Video Players & Editors
+Sports DV,LIFESTYLE,2.1,86,29M,10000,Free,0,Everyone,Lifestyle
+Live DV,PHOTOGRAPHY,2.0,16,17M,1000,Free,0,Everyone,Photography
+Mini DV,AUTO_AND_VEHICLES,3.5,12,19M,5000,Free,0,Everyone,Auto & Vehicles
+DV-2019 Results,FAMILY,4.3,158,2.6M,10000,Free,0,Everyone,Entertainment
+AKASO DV,TOOLS,2.4,99,71M,10000,Free,0,Everyone,Tools
+DV-LOTTERY 2019 REGISTRATION,FAMILY,4.5,97,2.6M,10000,Free,0,Everyone,Entertainment
+Selfie DV,TOOLS,2.8,29,14M,1000,Free,0,Everyone,Tools
+DV-4036 by Somikon,PHOTOGRAPHY,4.2,17,44M,1000,Free,0,Everyone,Photography
+DV 2019 Entry Guide,BOOKS_AND_REFERENCE,4.5,92,5.1M,10000,Free,0,Everyone,Books & Reference
+Touch DV,PHOTOGRAPHY,4.2,1,11M,50,Free,0,Everyone,Photography
+Porch DV,HOUSE_AND_HOME,2.8,5,13M,1000,Free,0,Everyone,House & Home
+DV 2019 - EDV Photo & Form,BOOKS_AND_REFERENCE,3.9,314,2.6M,50000,Free,0,Everyone,Books & Reference
+SDV Cam,TOOLS,3.2,67,65M,10000,Free,0,Everyone,Tools
+XDV,PHOTOGRAPHY,3.1,6827,8.7M,1000000,Free,0,Everyone,Photography
+WiFi Action Camera,SPORTS,2.4,551,903k,100000,Free,0,Everyone,Sports
+DV Car Service,MAPS_AND_NAVIGATION,4.6,10,25M,100,Free,0,Everyone,Maps & Navigation
+DV Lottery Photo,VIDEO_PLAYERS,2.9,23,4.0M,5000,Free,0,Everyone,Video Players & Editors
+DV Lottery Photo Tool,PHOTOGRAPHY,4.0,223,1.7M,50000,Free,0,Everyone,Photography
+iCam - Webcam Video Streaming,TOOLS,3.7,770,2.4M,10000,Paid,$4.99,Everyone,Tools
+DV KING 4K,PHOTOGRAPHY,2.3,3,8.5M,100,Free,0,Everyone,Photography
+Wifi Action Camera,PHOTOGRAPHY,2.9,118,26M,50000,Free,0,Everyone,Photography
+US DV Lottery 2020 Apply,TRAVEL_AND_LOCAL,4.6,41,2.0M,10000,Free,0,Everyone,Travel & Local
+DV-2019 PHOTO TOOL,FAMILY,4.3,21,2.5M,1000,Free,0,Everyone,Entertainment
+DV ASSIST,FAMILY,5.0,1,18M,100,Free,0,Everyone,Education
+4K Ultra Camera,PHOTOGRAPHY,4.2,382,2.9M,100000,Free,0,Everyone,Photography
+DV Lottery Simulator,FAMILY,4.6,13,1.3M,1000,Free,0,Everyone,Entertainment
+U.S.A DV Lottery Process,FAMILY,4.5,8,1.7M,1000,Free,0,Everyone,Education
+DV Statistics,SOCIAL,4.2,6,2.7M,100,Free,0,Everyone,Social
+DV 2018 Winners Guide,BOOKS_AND_REFERENCE,4.8,11,608k,1000,Free,0,Everyone,Books & Reference
+MelifeCam-M,VIDEO_PLAYERS,3.5,81,22M,10000,Free,0,Everyone,Video Players & Editors
+DV-2019 UK/British,FAMILY,4.6,166,4.2M,5000,Free,0,Everyone,Entertainment
+GoPlus Cam,VIDEO_PLAYERS,3.5,3484,41M,500000,Free,0,Everyone,Video Players & Editors
+GoAction,VIDEO_PLAYERS,3.6,1522,65M,100000,Free,0,Everyone,Video Players & Editors
+DV Portfolio,TOOLS,4.0,0,16M,50,Free,0,Everyone,Tools
+DV Youth,LIFESTYLE,5.0,5,15M,100,Free,0,Everyone,Lifestyle
+DV KING,PHOTOGRAPHY,3.0,2,9.3M,100,Free,0,Everyone,Photography
+DV - Digito Verificador,TOOLS,4.0,2,4.2M,500,Free,0,Everyone,Tools
+DV Web Design Tips,PRODUCTIVITY,4.2,1,5.1M,10,Free,0,Teen,Productivity
+DENVER ACTION CAM 3,PHOTOGRAPHY,2.9,66,8.9M,10000,Free,0,Everyone,Photography
+4K VIDEO PLAYER ULTRA HD,VIDEO_PLAYERS,3.7,20,24M,5000,Free,0,Everyone,Video Players & Editors
+US DV Lottery 2019,TRAVEL_AND_LOCAL,4.6,14,4.0M,1000,Free,0,Everyone,Travel & Local
+BlueDV AMBE,COMMUNICATION,4.2,0,Varies with device,1000,Free,0,Everyone,Communication
+Hotel Insanity,GAME,4.2,3816,31M,100000,Free,0,Teen,Arcade
+SportCAM,TOOLS,3.2,427,9.5M,100000,Free,0,Everyone,Tools
+SportLook,PHOTOGRAPHY,2.5,1283,8.2M,100000,Free,0,Everyone,Photography
+DW - Breaking World News,NEWS_AND_MAGAZINES,4.4,17671,17M,1000000,Free,0,Everyone 10+,News & Magazines
+"DW Learn German - A1, A2, B1 and placement test",FAMILY,4.3,902,1.8M,100000,Free,0,Everyone,Education
+DW Mobile,BUSINESS,2.7,33,Varies with device,10000,Free,0,Everyone,Business
+DW Spectrum™ IPVMS Mobile,BUSINESS,4.0,44,30M,10000,Free,0,Everyone,Business
+DW Amharic by AudioNow Digital,NEWS_AND_MAGAZINES,4.5,322,31M,10000,Free,0,Everyone,News & Magazines
+DW VMAX,TOOLS,3.4,843,8.5M,100000,Free,0,Everyone,Tools
+News: DW Español,NEWS_AND_MAGAZINES,4.3,25,6.3M,1000,Free,0,Everyone,News & Magazines
+DW Contacts & Phone & Dialer,COMMUNICATION,4.3,21186,10M,1000000,Free,0,Everyone,Communication
+DW,NEWS_AND_MAGAZINES,4.1,0,4.8M,10000,Free,0,Everyone 10+,News & Magazines
+DW Arabic By dw-arab.com,NEWS_AND_MAGAZINES,4.3,386,6.0M,50000,Free,0,Everyone,News & Magazines
+DW Espanol,NEWS_AND_MAGAZINES,4.1,0,5.8M,100,Free,0,Everyone,News & Magazines
+News :DW Bangali,NEWS_AND_MAGAZINES,4.1,1,6.3M,10,Free,0,Everyone,News & Magazines
+Learn German: Die Bienenretter,FAMILY,4.0,25,79M,5000,Free,0,Everyone,Educational;Education
+News: DW Hausa,NEWS_AND_MAGAZINES,4.9,9,6.3M,1000,Free,0,Everyone,News & Magazines
+DW Spectrum™ IP VMS,BUSINESS,3.4,102,2.4M,10000,Free,0,Everyone,Business
+DW Audio,FAMILY,4.9,38,5.0M,1000,Free,0,Everyone,Education
+DW Contacts widget,TOOLS,4.3,56,2.0M,1000,Paid,$0.99,Everyone,Tools
+DW فارسی By dw-arab.com,NEWS_AND_MAGAZINES,4.7,11,4.4M,1000,Free,0,Everyone,News & Magazines
+German Listening,FAMILY,4.8,18298,8.0M,500000,Free,0,Everyone,Education
+Deaf World DW,COMMUNICATION,4.3,298,Varies with device,10000,Free,0,Teen,Communication
+DW Event,EVENTS,4.3,9,39M,1000,Free,0,Everyone,Events
+DW Witness,BUSINESS,4.0,6,3.5M,500,Free,0,Everyone,Business
+Fahrschule DW,FAMILY,4.2,5,3.9M,1000,Free,0,Everyone,Education
+Downvids Helper - One touch DW,VIDEO_PLAYERS,3.5,197,9.8M,10000,Free,0,Everyone,Video Players & Editors
+DW Tech Tools,BUSINESS,4.1,1,5.9M,100,Free,0,Everyone,Business
+DW Security,BUSINESS,5.0,6,15M,100,Free,0,Everyone,Business
+News: RFI Hausa,NEWS_AND_MAGAZINES,4.7,10,6.3M,1000,Free,0,Everyone,News & Magazines
+ZAK DW,BUSINESS,4.1,0,3.0M,10,Free,0,Teen,Business
+DW Contacts Wear,TOOLS,4.2,37,2.2M,5000,Free,0,Everyone,Tools
+Hausa Radio,NEWS_AND_MAGAZINES,4.4,3375,4.2M,100000,Free,0,Everyone,News & Magazines
+Digi Dex for DW Next Order @PS4,TOOLS,4.2,155,16M,10000,Free,0,Everyone,Tools
+DW Timer,TOOLS,5.0,9,1.5M,100,Free,0,Everyone,Tools
+DW Streaming,SOCIAL,4.3,0,Varies with device,1000,Free,0,Everyone,Social
+RETRO Shocked DW-6000,PERSONALIZATION,5.0,13,500k,100,Paid,$1.49,Everyone,Personalization
+VMAX IP Plus Mobile Client,BUSINESS,2.0,9,3.4M,1000,Free,0,Everyone,Business
+Rose Gold DW Watch Theme,PERSONALIZATION,4.3,1,3.3M,100,Free,0,Everyone,Personalization
+DW Maps,TRAVEL_AND_LOCAL,3.7,35,13M,10000,Free,0,Everyone,Travel & Local
+DW Uninstall Applications,TOOLS,4.0,0,2.5M,10,Free,0,Everyone,Tools
+Bodyworks DW,HEALTH_AND_FITNESS,4.3,0,10M,10,Free,0,Everyone,Health & Fitness
+DW Cleaner,TOOLS,4.0,7,3.0M,500,Free,0,Everyone,Tools
+DW Missed call cleaner patch,TOOLS,3.9,65,54k,5000,Free,0,Everyone,Tools
+Swahili Radio,NEWS_AND_MAGAZINES,4.5,171,4.8M,10000,Free,0,Everyone,News & Magazines
+Black Classic DW Watch Theme,PERSONALIZATION,4.3,1,2.9M,100,Free,0,Everyone,Personalization
+White Classic Petite Watch Theme for DW,LIFESTYLE,4.1,2,3.0M,500,Free,0,Everyone,Lifestyle
+D.W Bien Être,HEALTH_AND_FITNESS,4.3,0,40M,10,Free,0,Everyone,Health & Fitness
+DX,SHOPPING,3.1,6697,11M,500000,Free,0,Everyone,Shopping
+Direct Express®,FINANCE,4.5,6156,6.6M,500000,Free,0,Everyone,Finance
+Retro City Rampage DX,GAME,4.7,416,16M,10000,Paid,$2.99,Teen,Action
+KeePass DX,TOOLS,4.0,0,Varies with device,5000,Free,0,Everyone,Tools
+PORTABLE SOCCER DX,SPORTS,4.4,552,1.6M,5000,Paid,$1.00,Everyone,Sports
+Across Age DX,FAMILY,3.8,5964,48M,500000,Free,0,Teen,Role Playing
+ZOOKEEPER DX TouchEdition,FAMILY,4.2,3195,4.6M,100000,Paid,$0.99,Everyone,Puzzle
+Ham DX Cluster & Spots Finder,COMMUNICATION,4.5,115,2.8M,5000,Free,0,Everyone,Communication
+KeePass DX Pro,TOOLS,4.0,0,Varies with device,100,Paid,$5.99,Everyone,Tools
+DX Alerts,LIFESTYLE,4.5,22,23M,1000,Free,0,Everyone,Lifestyle
+Piczle Lines DX,FAMILY,4.6,281,26M,5000,Free,0,Everyone,Puzzle
+PORTABLE SOCCER DX Lite,SPORTS,4.2,15068,2.5M,1000000,Free,0,Everyone,Sports
+DX Spots Free,TOOLS,4.5,46,24M,1000,Free,0,Everyone,Tools
+3DAnimeGirl DX DreamPortrait KAWAII Girl DressUp,FAMILY,4.2,449,56M,10000,Free,0,Teen,Casual
+Bubble Shooter DX,FAMILY,4.2,636,4.0M,100000,Free,0,Everyone,Casual
+DX Alert,TOOLS,4.1,27,2.5M,1000,Free,0,Everyone,Tools
+Age of Procreation DX,FAMILY,4.3,1894,40M,100000,Free,0,Mature 17+,Simulation
+Chronolink DX,FAMILY,5.0,7,73M,10,Paid,$0.99,Everyone,Puzzle
+DX Simulation for OOO Dx Belt,FAMILY,4.6,67,31M,10000,Free,0,Everyone,Simulation
+Differential Dx Free,MEDICAL,4.0,238,Varies with device,50000,Free,0,Everyone 10+,Medical
+Tricky Bike Stunt Rider DX,FAMILY,4.4,16,45M,500,Free,0,Everyone,Simulation;Education
+DX Gashacon Sword for Ex-Aid Henshin,FAMILY,4.2,17,42M,1000,Free,0,Everyone,Simulation
+DX Simulation Belt for Build henshin,FAMILY,4.5,182,39M,10000,Free,0,Everyone,Simulation
+Active Soccer 2 DX,SPORTS,3.6,28,48M,500,Paid,$2.99,Everyone,Sports
+DX Simulation for Kabuto Henshin Belt 2018,FAMILY,4.6,14,7.2M,5000,Free,0,Everyone,Simulation
+DX Simulation for Decade Henshin Belt 2018,FAMILY,4.2,23,10M,5000,Free,0,Everyone,Simulation
+Elemental Galaxy Dx - Match3,FAMILY,4.0,127,14M,10000,Free,0,Everyone,Puzzle
+DX Simulation for Double Dx Henshin Belt 2018,FAMILY,4.6,33,11M,5000,Free,0,Everyone,Simulation
+Mircules DX Cluster Lite,COMMUNICATION,4.5,51,21M,5000,Free,0,Everyone,Communication
+DX Simulation Belt for Decade henshin,FAMILY,4.5,64,32M,5000,Free,0,Everyone,Simulation
+Chronolink DX Lite,FAMILY,4.2,2,47M,10,Free,0,Everyone,Puzzle
+Shoot! DX - lights for FREE,GAME,4.3,4,Varies with device,100,Free,0,Everyone,Action
+Bubble Shooter DX AdFree,FAMILY,4.2,1,2.1M,50,Paid,$2.99,Everyone,Casual
+Human Dx,MEDICAL,4.8,6,16M,500,Free,0,Everyone,Medical
+Santa's Monster Shootout DX,GAME,5.0,4,33M,50,Paid,$1.99,Teen,Action
+DX Glow - Clock Widget,PERSONALIZATION,4.4,5,3.4M,50,Paid,$0.99,Everyone,Personalization
+iCluster - The DX-Cluster database,COMMUNICATION,4.2,0,17M,10,Paid,$0.99,Everyone,Communication
+MBU DX Cluster,TOOLS,4.0,5,1.6M,500,Free,0,Everyone,Tools
+Dress Up RagazzA13 DX,FAMILY,3.5,13,42M,100,Paid,$0.99,Everyone,Simulation
+Cloud DX Connected Health,HEALTH_AND_FITNESS,5.0,6,11M,100,Free,0,Everyone,Health & Fitness
+DX Simulation for X-aid Dx Belt,FAMILY,4.0,35,48M,5000,Free,0,Everyone,Simulation
+Unstoppaball DX,FAMILY,4.2,5,40M,50,Paid,$1.49,Everyone,Puzzle
+Differential Dx,MEDICAL,4.0,8,Varies with device,500,Paid,$3.99,Everyone,Medical
+Sokoban Land DX,FAMILY,3.9,46,20M,10000,Paid,$2.99,Everyone,Puzzle
+Multiple Sclerosis Dx & Mgmt.,MEDICAL,4.5,131,60M,10000,Free,0,Everyone,Medical
+Dx Ludo,FAMILY,3.6,215,2.6M,50000,Free,0,Everyone,Puzzle
+My Dy Dice - 3D Dice Roller,LIFESTYLE,4.2,9,22M,100,Free,0,Everyone,Lifestyle
+Dy So Exam,FAMILY,3.0,6,3.2M,1000,Free,0,Everyone,Education
+edp re:dy,TOOLS,3.0,172,Varies with device,10000,Free,0,Everyone,Tools
+Dr. D. Y. Patil Vidyapeeth GBS,FAMILY,4.0,3,5.3M,100,Free,0,Everyone,Education
+edp re:dy smarthome,TOOLS,3.4,30,22M,5000,Free,0,Everyone,Tools
+KPS CHAUHAN DY/DX,FAMILY,4.9,37,10M,100,Free,0,Everyone,Education
+DY Fitness,HEALTH_AND_FITNESS,4.3,0,43M,10,Free,0,Everyone,Health & Fitness
+dy n fly,LIFESTYLE,4.1,1,4.8M,50,Free,0,Everyone,Lifestyle
+Cnady Selfie : You Can Dy Snap Camera,PERSONALIZATION,4.3,8,20M,1000,Free,0,Everyone,Personalization
+junainfo.dy.fi,TRAVEL_AND_LOCAL,4.1,8,1.9M,100,Free,0,Everyone,Travel & Local
+DY TECHNICAL GYAN,BUSINESS,4.0,2,3.3M,10,Free,0,Everyone,Business
+JONACK (D Story Teller),FAMILY,4.4,152,1.2M,10000,Free,0,Everyone,Entertainment
+American Sniper City Fight Shooting Assassin,GAME,4.1,395,54M,50000,Free,0,Teen,Action
+Guardians of Ancora,FAMILY,4.4,969,26M,50000,Free,0,Everyone,Educational;Action & Adventure
+Train Sim Pro,FAMILY,4.0,1763,Varies with device,10000,Paid,$1.49,Everyone,Simulation;Pretend Play
+Displaying You VR,PHOTOGRAPHY,4.2,1,67M,50,Free,0,Everyone,Photography
+Cute Dolphin Keyboard,PERSONALIZATION,4.5,237,6.4M,10000,Free,0,Everyone,Personalization
+Truck Transport Raw Material,FAMILY,4.2,632,50M,100000,Free,0,Everyone,Simulation
+Hidden Camera Detector,TOOLS,3.9,167,2.5M,10000,Free,0,Everyone,Tools
+DYPhyzio-Physiology Forum,FAMILY,4.2,4,1.3M,100,Free,0,Everyone,Education
+Street Skater 3D,GAME,3.6,120852,21M,10000000,Free,0,Teen,Action
+DYPSOET,FAMILY,5.0,8,7.4M,50,Free,0,Everyone,Education
+Triceratops - Dino Robot,FAMILY,4.4,3032,30M,1000000,Free,0,Everyone,Casual
+Differential Equations Steps,FAMILY,3.6,1185,3.9M,100000,Free,0,Everyone,Education
+Dz Dinars Numbers to letters,PRODUCTIVITY,4.7,2807,9.8M,100000,Free,0,Everyone,Productivity
+dz NEWS Algerie,NEWS_AND_MAGAZINES,4.2,2318,4.5M,100000,Free,0,Everyone,News & Magazines
+Siyaha Dz,TRAVEL_AND_LOCAL,4.5,289,9.8M,10000,Free,0,Everyone,Travel & Local
+CCP DZ : Fill out a check | Number in letters DZD,FINANCE,4.7,642,3.2M,10000,Free,0,Everyone,Finance
+DZ Puzzle,FAMILY,4.2,14,47M,10,Paid,$0.99,Everyone,Puzzle
+DZ Mobile Market,SHOPPING,4.3,59,6.0M,10000,Free,0,Everyone,Shopping
+3G DZ Configuration,COMMUNICATION,4.3,488,2.5M,50000,Free,0,Everyone,Communication
+3G/4G Config Dz,TOOLS,4.2,2058,2.3M,100000,Free,0,Everyone,Tools
+Drugs Dz - Algeria,MEDICAL,4.4,187,Varies with device,10000,Free,0,Everyone,Medical
+amm dz,FINANCE,4.1,0,14M,1,Paid,$5.99,Everyone,Finance
+IRIS : Customer Service - DZ Algeria,TRAVEL_AND_LOCAL,4.7,57,7.0M,1000,Free,0,Everyone,Travel & Local
+Numbers Into Words,PRODUCTIVITY,4.4,457,562k,50000,Free,0,Everyone,Productivity
+Dz kayas,FINANCE,4.1,0,14M,1,Paid,$28.99,Everyone,Finance
+Météo Algérie DZ,WEATHER,4.1,1238,4.7M,100000,Free,0,Everyone,Weather
+DZ Popup Video Player,VIDEO_PLAYERS,4.5,83,4.5M,5000,Free,0,Everyone,Video Players & Editors
+DZ PROMOS - Promotions & Sale Alerts in Algeria,SHOPPING,4.1,331,10M,50000,Free,0,Everyone,Shopping
+JNews DZ - Algerian Newspapers,NEWS_AND_MAGAZINES,4.0,146,3.0M,10000,Free,0,Everyone,News & Magazines
+DZ-JOKER,GAME,4.3,6,18M,100,Free,0,Everyone,Arcade
+Super ball DZ,GAME,4.3,24,32M,1000,Free,0,Teen,Action
+Ouedkniss,SHOPPING,4.3,10355,847k,1000000,Free,0,Teen,Shopping
+Files To SD Card Pro,TOOLS,4.2,994,2.8M,100000,Free,0,Everyone,Tools
+News Dz,SOCIAL,4.3,3,9.9M,10,Free,0,Everyone,Social
+My Ooredoo Algeria,TOOLS,4.2,3606,17M,100000,Free,0,Everyone,Tools
+Currency Exchange DZ,FINANCE,4.1,4,2.5M,1000,Free,0,Everyone,Finance
+PHARMAGUIDE (DZ),HEALTH_AND_FITNESS,4.1,131,3.4M,5000,Free,0,Everyone,Health & Fitness
+لعبة تقدر تربح DZ,FAMILY,4.2,238,6.8M,10000,Free,0,Everyone,Education
+DEM DZ,HEALTH_AND_FITNESS,4.3,2,957k,100,Free,0,Teen,Health & Fitness
+chat dz,COMMUNICATION,5.0,8,29M,100,Free,0,Teen,Communication
+Devise Dz,FINANCE,4.0,26,3.6M,1000,Free,0,Everyone,Finance
+BAC DZ Questionnaire,FAMILY,4.0,38,Varies with device,5000,Free,0,Everyone,Education
+Ludo Dz,GAME,4.5,17,28M,500,Free,0,Everyone,Board
+ONEC DZ,FAMILY,4.2,40,3.1M,1000,Free,0,Everyone,Education
+Agent HQ for The Division,FAMILY,4.1,1060,2.5M,100000,Free,0,Everyone,Entertainment
+DZ Urgences,FAMILY,4.2,16,1.6M,500,Free,0,Everyone,Education
+infirmiers,MEDICAL,4.7,125,23M,10000,Free,0,Everyone,Medical
+DZ sim,TOOLS,4.4,417,15M,10000,Free,0,Everyone,Tools
+Tuberculose Dz,MEDICAL,4.9,26,6.1M,1000,Free,0,Everyone,Medical
+DZ Fly Algérie Horaire Vols,TRAVEL_AND_LOCAL,3.6,114,10M,10000,Free,0,Everyone,Travel & Local
+3G to 4G Converter - Simulator,TOOLS,4.2,268,2.4M,10000,Free,0,Everyone,Tools
+dekoreko-dz,SHOPPING,4.3,16,4.6M,500,Free,0,Everyone,Shopping
+ChangeDA - Cours du DZD sur le marché parallèle,FINANCE,4.4,188,3.3M,10000,Free,0,Everyone,Finance
+dz press,NEWS_AND_MAGAZINES,4.1,30,10M,1000,Free,0,Everyone,News & Magazines
+Tunisian Dinar: Exchange rate,FINANCE,4.5,625,3.8M,10000,Free,0,Everyone,Finance
+love sms good morning,COMMUNICATION,4.2,10,3.1M,5000,Free,0,Everyone,Communication
+Dz Camera,TOOLS,4.0,1,33M,10,Free,0,Everyone,Tools
+quran-DZ,SOCIAL,4.3,0,6.2M,10,Free,0,Teen,Social
+DZ Blagues,FAMILY,4.2,580,2.1M,10000,Free,0,Everyone,Entertainment
+DZ Register,PRODUCTIVITY,4.2,0,18M,1,Free,0,Everyone,Productivity
+EA SPORTS UFC®,SPORTS,4.5,2371338,37M,50000000,Free,0,Teen,Sports
+NBA LIVE Mobile Basketball,SPORTS,4.4,1690802,58M,50000000,Free,0,Everyone,Sports
+Need for Speed™ No Limits,GAME,4.4,3344300,22M,50000000,Free,0,Everyone 10+,Racing
+Real Racing 3,FAMILY,4.5,354454,71M,10000000,Free,0,Everyone,Racing;Action & Adventure
+Madden NFL Football,FAMILY,4.5,1455952,Varies with device,10000000,Free,0,Everyone,Sports;Action & Adventure
+EA SPORTS™ FIFA 18 Companion,SPORTS,3.9,282727,63M,10000000,Free,0,Everyone,Sports
+The Simpsons™: Tapped Out,FAMILY,4.3,636995,49M,10000000,Free,0,Teen,Casual
+Plants vs. Zombies™ 2,FAMILY,4.4,567632,15M,10000000,Free,0,Everyone 10+,Casual
+Command & Conquer: Rivals,FAMILY,4.2,0,Varies with device,0,Paid,0,Everyone 10+,Strategy
+Star Wars™: Galaxy of Heroes,FAMILY,4.5,1461698,67M,10000000,Free,0,Everyone 10+,Role Playing
+Dungeon Keeper,FAMILY,4.0,69574,45M,500000,Free,0,Everyone 10+,Strategy
+Lost Journey (Dreamsky),GAME,4.5,32344,29M,1000000,Paid,$0.99,Everyone,Adventure
+TETRIS,FAMILY,4.0,199808,57M,10000000,Free,0,Everyone,Puzzle
+Bejeweled Classic,FAMILY,4.4,203101,Varies with device,5000000,Free,0,Everyone,Casual
+NBA JAM by EA SPORTS™,FAMILY,4.3,56444,43M,500000,Paid,$4.99,Everyone,Sports;Action & Adventure
+EA Plus,TRAVEL_AND_LOCAL,2.5,12,12M,1000,Free,0,Everyone,Travel & Local
+TETRIS Blitz,FAMILY,4.4,201631,96M,5000000,Free,0,Everyone,Puzzle
+POGO Games,FAMILY,3.8,32600,26M,1000000,Free,0,Everyone,Casual
+SW Battlefront Companion,FAMILY,4.4,93870,79M,1000000,Free,0,Everyone,Strategy
+Bejeweled Blitz,FAMILY,4.2,222664,98M,10000000,Free,0,Everyone,Puzzle
+Peggle Blast,GAME,4.1,166251,19M,5000000,Free,0,Everyone,Card
+Heroes of Dragon Age,GAME,4.2,70389,28M,1000000,Free,0,Teen,Action
+SCRABBLE,GAME,3.9,172281,50M,5000000,Free,0,Everyone,Word
+Asphalt Xtreme: Rally Racing,GAME,4.5,567984,39M,10000000,Free,0,Everyone,Racing
+FIFA 16 Soccer,SPORTS,4.1,820577,30M,10000000,Free,0,Everyone,Sports
+League of Stickman 2018- Ninja Arena PVP(Dreamsky),GAME,4.4,32496,99M,1000000,Paid,$0.99,Teen,Action
+Modern Combat 5: eSports FPS,GAME,4.3,2903386,58M,100000000,Free,0,Mature 17+,Action
+Bejeweled Stars: Free Match 3,FAMILY,4.5,85484,Varies with device,1000000,Free,0,Everyone,Puzzle;Brain Games
+Mass Effect: Andromeda APEX HQ,GAME,3.4,4490,92M,100000,Free,0,Everyone 10+,Action
+Mirror’s Edge™ Companion,GAME,3.4,1995,43M,100000,Free,0,Everyone,Action
+Stickman Legends: Shadow Wars,GAME,4.4,38419,100M,1000000,Paid,$0.99,Everyone 10+,Action
+MLB Perfect Inning 2018,SPORTS,4.2,42767,72M,1000000,Free,0,Everyone,Sports
+Gear.Club - True Racing,GAME,4.4,140658,37M,1000000,Free,0,Everyone,Racing
+Plants vs. Zombies™ Watch Face,FAMILY,3.5,33178,3.1M,1000000,Free,0,Everyone,Casual
+Real Football,SPORTS,4.1,585564,33M,10000000,Free,0,Everyone,Sports
+Typical EA Game,FAMILY,4.6,33,3.3M,100,Free,0,Everyone,Casual
+EB Mobile,FAMILY,1.7,1172,5.6M,10000,Free,0,Everyone,Education
+EB Events,TRAVEL_AND_LOCAL,3.3,97,16M,10000,Free,0,Everyone,Travel & Local
+i am EB,PHOTOGRAPHY,5.0,1,5.4M,10,Free,0,Teen,Photography
+EB-Link,BUSINESS,4.8,6,11M,100,Free,0,Everyone,Business
+Debra Care Conference,BUSINESS,4.1,0,30M,50,Free,0,Everyone,Business
+Exchange Bank - EB Mobile,FINANCE,4.6,8,31M,1000,Free,0,Everyone,Finance
+TANGEDCO Mobile App (Official),BUSINESS,3.3,2915,3.3M,500000,Free,0,Everyone,Business
+EB-TV,SPORTS,4.2,6,30M,1000,Free,0,Everyone,Sports
+Free E B Garamond Cool Font,PERSONALIZATION,4.2,410,6.1M,100000,Free,0,Everyone,Personalization
+EB Kit,BUSINESS,4.1,4,5.2M,100,Free,0,Everyone,Business
+Epson iProjection,PRODUCTIVITY,3.5,3930,18M,1000000,Free,0,Everyone,Productivity
+TN e Sevai TN EB Bill Patta Citta EC Birth All Hub,SOCIAL,3.7,23,16M,5000,Free,0,Everyone,Social
+EB Scanner,PRODUCTIVITY,5.0,9,25M,50,Free,0,Everyone,Productivity
+TNEB Bill Online Payment (Tamil),SOCIAL,4.3,7,2.3M,5000,Free,0,Teen,Social
+EB Demo for Android,FAMILY,4.2,0,13M,10,Free,0,Teen,Entertainment
+eBay Kleinanzeigen for Germany,SHOPPING,4.6,318142,Varies with device,10000000,Free,0,Teen,Shopping
+Mental Hospital:EB 2 Lite,GAME,4.1,5341,8.8M,100000,Free,0,Teen,Action
+EB Annual Meetings,BOOKS_AND_REFERENCE,3.5,11,15M,1000,Free,0,Everyone,Books & Reference
+UP EB Bill Payment & Details,SOCIAL,5.0,3,2.4M,50,Free,0,Teen,Social
+EB-Banking (ersetzt),FINANCE,4.1,24,70M,1000,Free,0,Everyone,Finance
+Tamilnadu EB Online Payment,FINANCE,3.7,155,3.9M,100000,Free,0,Everyone,Finance
+Online Kerala EB Bill Pay,FINANCE,4.0,37,3.9M,5000,Free,0,Everyone,Finance
+EB Remote Deposit,BUSINESS,4.1,0,9.0M,10,Free,0,Everyone,Business
+EB-Chat – For my Events,EVENTS,4.4,2,21M,10,Free,0,Teen,Events
+বাংলাflix,FAMILY,4.2,1111,7.3M,100000,Free,0,Everyone,Entertainment
+EB Experience,LIFESTYLE,4.1,0,1.8M,1,Free,0,Everyone,Lifestyle
+TNEB Quick Pay Easy,FINANCE,4.5,28,1.4M,10000,Free,0,Teen,Finance
+TNEB,BUSINESS,3.8,1777,948k,100000,Free,0,Everyone,Business
+TNEB Bill Checker / TNEB Bill Status,FINANCE,2.5,2,5.0M,1000,Free,0,Everyone,Finance
+Skin Disease,BEAUTY,4.0,1,2.2M,100,Free,0,Everyone,Beauty
+Schlaumeier,BOOKS_AND_REFERENCE,4.3,0,688k,5,Paid,$0.99,Everyone,Books & Reference
+Bihar Land Records - RoR and EB Quick Pay,TOOLS,4.0,8,2.2M,1000,Free,0,Everyone,Tools
+TNEB Reading,TOOLS,4.1,28,2.5M,10000,Free,0,Everyone,Tools
+Eb & flow Yoga Studio,HEALTH_AND_FITNESS,4.3,0,7.3M,10,Free,0,Everyone,Health & Fitness
+Audiowalk EB,TRAVEL_AND_LOCAL,4.1,0,90M,10,Free,0,Everyone,Travel & Local
+RPG ブレイジング ソウルズ アクセレイト,FAMILY,3.4,159,3.1M,1000,Paid,$10.99,Teen,Role Playing
+Tamilnadu Electricity Info,TOOLS,3.6,216,811k,10000,Free,0,Everyone,Tools
+Punjab Online - Land Records • EB Bill Pay • RC/DL,TOOLS,3.4,16,4.0M,5000,Free,0,Everyone,Tools
+"energyly (TNEB,BESCOM,MH,DL..)",TOOLS,3.9,627,4.1M,10000,Free,0,Everyone,Tools
+Paraglider Dashboard,SPORTS,4.6,549,2.8M,50000,Free,0,Everyone,Sports
+Goodbox - Mega App,COMMUNICATION,4.3,3429,Varies with device,100000,Free,0,Everyone,Communication
+Exército Brasileiro,PRODUCTIVITY,4.7,1730,16M,100000,Free,0,Everyone,Productivity
+EB Cash Collections,BUSINESS,5.0,1,4.3M,5,Free,0,Everyone,Business
+TN Electricity (TNEB),LIFESTYLE,3.9,73,3.8M,10000,Free,0,Everyone,Lifestyle
+Electrician Calculator Pro,TOOLS,3.9,47,270k,1000,Paid,$14.99,Everyone,Tools
+"Call Blocker - Blacklist, SMS Blocker",COMMUNICATION,4.2,30350,3.7M,1000000,Free,0,Everyone,Communication
+英漢字典 EC Dictionary,FAMILY,4.3,55408,Varies with device,1000000,Free,0,Everyone,Education
+EC - AP & Telangana,BOOKS_AND_REFERENCE,3.5,10,3.0M,5000,Free,0,Everyone,Books & Reference
+TN EC Online New,SOCIAL,4.3,7,2.3M,1000,Free,0,Teen,Social
+"TN Patta, Chitta, EC",TOOLS,4.1,633,3.8M,100000,Free,0,Everyone,Tools
+TN Patta Chitta EC Info,TOOLS,4.2,1611,2.7M,100000,Free,0,Everyone,Tools
+EC music dictionary,TOOLS,4.4,20,2.2M,500,Paid,$1.99,Everyone,Tools
+EC Security,LIFESTYLE,4.5,13,28M,1000,Free,0,Everyone,Lifestyle
+TN Patta Citta & EC,BOOKS_AND_REFERENCE,3.8,48,1.5M,10000,Free,0,Everyone,Books & Reference
+EC - Encumbrance Search - telangana state,BUSINESS,3.4,45,5.5M,10000,Free,0,Everyone,Business
+Ec Solutions Mobile,BUSINESS,4.1,0,4.0M,10,Free,0,Everyone,Business
+Encumbrance Certificate - (Obsolete),BUSINESS,3.9,184,48k,50000,Free,0,Everyone,Business
+"My Handbook : EE, EC, EI, E&T, EEE, EECS",FAMILY,4.5,3776,7.7M,100000,Free,0,Everyone,Education
+ec-Work,PRODUCTIVITY,4.2,3,26M,100,Free,0,Everyone,Productivity
+ec.tv,LIFESTYLE,4.1,0,8.6M,50,Free,0,Everyone,Lifestyle
+EC-HRV test,SPORTS,3.0,9,4.3M,1000,Free,0,Everyone,Sports
+EC MANAGER,VIDEO_PLAYERS,4.1,2,17M,100,Free,0,Everyone,Video Players & Editors
+Barry EC,TOOLS,4.1,14,3.8M,1000,Free,0,Everyone,Tools
+New Holland Agriculture T5 EC,PRODUCTIVITY,4.6,12,15M,1000,Free,0,Everyone,Productivity
+tv-ec,FAMILY,4.2,1,3.4M,50,Free,0,Everyone,Entertainment
+EC Taximeter,PRODUCTIVITY,3.9,162,5.0M,10000,Free,0,Everyone,Productivity
+Walk Freely (Ec Shlire),TOOLS,4.7,62,2.3M,1000,Free,0,Everyone,Tools
+EC Apps List,TOOLS,4.5,2,1.6M,100,Free,0,Everyone,Tools
+AP Stamps and Registration,BOOKS_AND_REFERENCE,3.4,82,2.7M,10000,Free,0,Everyone,Books & Reference
+EC Calgary,FAMILY,5.0,6,8.1M,100,Free,0,Teen,Education
+Victoria EC,TOOLS,5.0,5,3.8M,500,Free,0,Everyone,Tools
+EC SPORTS,SPORTS,5.0,1,6.3M,10,Free,0,Everyone,Sports
+ECナビ×シュフー,LIFESTYLE,4.0,576,7.4M,50000,Free,0,Everyone,Lifestyle
+EC Designer 2.0,TOOLS,4.0,0,12M,50,Free,0,Everyone,Tools
+Arrayanes EC,LIFESTYLE,4.1,2,7.9M,100,Free,0,Everyone,Lifestyle
+EC Reps,BUSINESS,4.0,1,5.4M,100,Free,0,Everyone,Business
+EC QR,PRODUCTIVITY,4.2,0,4.0M,10,Free,0,Everyone,Productivity
+EC Tax,FINANCE,4.9,8,3.1M,500,Free,0,Everyone,Finance
+EC Fairgrounds,FAMILY,5.0,3,5.5M,500,Free,0,Everyone,Entertainment
+CompactiMa EC pH Calibration,BOOKS_AND_REFERENCE,4.3,0,8.4M,100,Free,0,Everyone,Books & Reference
+Kiamichi EC,TOOLS,4.6,7,3.9M,1000,Free,0,Everyone,Tools
+EC Games Datecs,SPORTS,4.2,76,329k,10000,Free,0,Everyone,Sports
+TN Patta /Chitta /EC New,SOCIAL,4.8,5,3.0M,100,Free,0,Teen,Social
+HOLSTON EC,TOOLS,4.1,7,4.2M,1000,Free,0,Everyone,Tools
+FILL EC,BUSINESS,4.1,13,3.8M,100,Free,0,Everyone,Business
+Marítimo EC,TOOLS,4.0,1,5.3M,10,Free,0,Everyone,Tools
+EC-Contractors,HOUSE_AND_HOME,4.2,0,6.0M,1,Free,0,Everyone,House & Home
+GATE Syllabus for EC 2018 & Notifications,FAMILY,4.7,23,4.3M,1000,Free,0,Everyone,Education
+EC Sampler,PRODUCTIVITY,4.2,0,30M,1,Free,0,Everyone,Productivity
+EC Mover,GAME,5.0,5,4.6M,10,Free,0,Everyone,Racing
+SCS eC,PRODUCTIVITY,4.4,7,17M,100,Free,0,Everyone,Productivity
+My EF,FAMILY,3.3,4114,14M,100000,Free,0,Everyone,Education
+EF Mentor: Words,FAMILY,4.0,403,39M,50000,Free,0,Teen,Education
+EF Smart English for Phone,FAMILY,3.5,208,13M,10000,Free,0,Everyone,Education
+My EF Center,FAMILY,2.8,89,35M,10000,Free,0,Everyone,Education
+EF Mentor: Sounds,FAMILY,4.2,19,6.9M,5000,Free,0,Everyone,Education
+EF English Live Business,FAMILY,3.6,496,14M,100000,Free,0,Everyone,Education
+EF Classroom,FAMILY,3.2,190,23M,50000,Free,0,Everyone,Education
+EF English Live for phone,FAMILY,3.6,2210,15M,100000,Free,0,Everyone,Education
+EF Smart English,FAMILY,3.7,150,11M,5000,Free,0,Everyone,Education
+EF English Live Business Tablet,FAMILY,3.3,279,14M,10000,Free,0,Everyone,Education
+EF English Live for tablets,FAMILY,3.1,1242,14M,50000,Free,0,Everyone,Education
+EF Parеnts,FAMILY,4.1,435,17M,50000,Free,0,Everyone,Education
+EF Teacher,FAMILY,3.1,16,17M,1000,Free,0,Everyone,Education
+English Bite,FAMILY,3.5,268,9.8M,10000,Free,0,Everyone,Education
+EF/VR – VR Tours of EF Schools,FAMILY,3.6,17,15M,1000,Free,0,Teen,Education
+EF Events,EVENTS,5.0,7,4.4M,100,Free,0,Teen,Events
+EF Go Ahead Tour Companion,TRAVEL_AND_LOCAL,2.3,23,43M,1000,Free,0,Everyone,Travel & Local
+EF Summits,TRAVEL_AND_LOCAL,4.1,0,19M,100,Free,0,Everyone,Travel & Local
+EF Sidekick,VIDEO_PLAYERS,3.1,36,Varies with device,5000,Free,0,Everyone,Video Players & Editors
+EF-myHR,FINANCE,2.9,26,36M,1000,Free,0,Everyone,Finance
+EF Spelling Bee,FAMILY,3.0,2,9.4M,500,Free,0,Everyone,Education;Education
+Education First FCU Mobile,FINANCE,2.9,204,29M,10000,Free,0,Everyone,Finance
+Travelmoji,FAMILY,3.9,13,10M,500,Free,0,Everyone,Education
+EF Forms,BUSINESS,5.0,2,23M,50,Free,0,Everyone,Business
+EFAmbassador,FAMILY,4.2,5,10M,100,Free,0,Everyone,Education
+Agenda EF,FAMILY,3.4,79,33M,5000,Free,0,Everyone,Education
+EF App,BUSINESS,5.0,8,20M,100,Free,0,Everyone,Business
+EF Lens Simulator,PHOTOGRAPHY,4.2,2,33M,100,Paid,$9.99,Everyone,Photography
+EF Coach,HEALTH_AND_FITNESS,4.8,17,14M,500,Free,0,Everyone,Health & Fitness
+e-Docente EI/anos iniciais EF,FAMILY,4.2,2,2.3M,1000,Free,0,Everyone,Education
+EF Universe: Endless Battle,FAMILY,4.2,5,54M,50,Free,0,Teen,Role Playing
+[EF]ShoutBox,COMMUNICATION,4.2,3,2.5M,100,Free,0,Teen,Communication
+EF Catalogues · Kataloge,BUSINESS,4.1,15,4.3M,500,Free,0,Everyone,Business
+EF Staff,PRODUCTIVITY,4.2,0,11M,100,Free,0,Everyone,Productivity
+EF Academy,HEALTH_AND_FITNESS,5.0,4,15M,50,Free,0,Everyone,Health & Fitness
+EF First,FAMILY,4.2,0,1.6M,1,Free,0,Everyone,Entertainment
+Financial Calculator Pro EF,FINANCE,4.3,634,2.0M,50000,Free,0,Everyone,Finance
+Carrier Landings Pro,FAMILY,4.6,5969,31M,10000,Paid,$12.99,Everyone,Simulation
+EF Calculator,PRODUCTIVITY,4.7,19,Varies with device,1000,Free,0,Everyone,Productivity
+EF Utilities,TOOLS,4.0,0,3.6M,5,Free,0,Everyone,Tools
+EF Financial Control Free,FINANCE,4.4,58,3.7M,10000,Free,0,Everyone,Finance
+أحداث وحقائق | خبر عاجل في اخبار العالم,NEWS_AND_MAGAZINES,4.8,311,14M,5000,Free,0,Everyone 10+,News & Magazines
+Diário Escola Mestres EF,FAMILY,4.2,11,6.6M,1000,Free,0,Everyone,Education
+EF Jumper,GAME,4.3,4,5.1M,100,Free,0,Everyone,Arcade
+StudyLock - Education First,PARENTING,4.1,27,4.6M,1000,Free,0,Everyone,Parenting
+E.F.JUVENTUD MADRID,SPORTS,4.2,3,5.3M,100,Free,0,Everyone,Sports
+English Conversation Courses,FAMILY,4.6,22165,6.8M,1000000,Free,0,Everyone,Education
+Equestria Girls,FAMILY,4.3,392819,53M,10000000,Free,0,Everyone,Role Playing;Action & Adventure
+eG Monitor,PRODUCTIVITY,4.6,8,7.5M,100,Free,0,Everyone,Productivity
+E.G. Chess Free,GAME,4.0,505,23M,10000,Free,0,Everyone,Board
+"EG SIM CARD (EGSIMCARD, 이지심카드)",BUSINESS,2.9,322,1.5M,50000,Free,0,Everyone,Business
+EG-Boost,BUSINESS,4.1,25,2.4M,1000,Free,0,Everyone,Business
+EG Mantenimiento,BUSINESS,4.1,1,25M,50,Free,0,Teen,Business
+EG CrossPad - ASPECT4,BUSINESS,4.1,4,30M,1000,Free,0,Everyone,Business
+EG CrossPad,BUSINESS,4.1,3,Varies with device,1000,Free,0,Everyone,Business
+EG Player,FAMILY,4.2,1,13M,100,Free,0,Everyone,Entertainment
+Bee Mobile EG,FINANCE,4.2,883,6.5M,100000,Free,0,Everyone,Finance
+EG,PRODUCTIVITY,4.2,3,4.4M,100,Free,0,Everyone,Productivity
+E.G. Chess,GAME,4.3,56,23M,1000,Paid,$0.99,Everyone,Board
+EG SIM CARD (EGSIMCARD),TRAVEL_AND_LOCAL,4.4,105,5.0M,10000,Free,0,Everyone,Travel & Local
+EG Retail,BUSINESS,2.4,29,16M,500,Free,0,Everyone,Business
+EG Movi,TOOLS,4.2,40,7.4M,1000,Free,0,Everyone,Tools
+EG Groups,EVENTS,4.4,0,1.1M,10,Free,0,Everyone,Events
+EG Way Life,SOCIAL,4.3,0,1.1M,50,Free,0,Everyone,Social
+EG Tax Service,FINANCE,4.1,1,38M,100,Free,0,Everyone,Finance
+Energenie EG-PM1W Setup Wizard,TOOLS,3.1,17,523k,1000,Free,0,Everyone,Tools
+qEG APP / Química EG SRL,TOOLS,4.0,0,118k,10,Free,0,Everyone,Tools
+EG Classroom Decimals™,FAMILY,3.0,2,18M,50,Paid,$2.99,Everyone,Education;Education
+EGW Writings 2,BOOKS_AND_REFERENCE,4.7,6547,16M,100000,Free,0,Everyone,Books & Reference
+Alipay,FINANCE,3.4,42497,61M,1000000,Free,0,Teen,Finance
+EG | Explore Folegandros,TRAVEL_AND_LOCAL,4.1,0,56M,0,Paid,$3.99,Everyone,Travel & Local
+EGW Writings,BOOKS_AND_REFERENCE,4.7,24278,3.1M,1000000,Free,0,Everyone,Books & Reference
+Bible with EGW Comments,BOOKS_AND_REFERENCE,4.7,3776,12M,100000,Free,0,Everyone,Books & Reference
+Eg Call,COMMUNICATION,4.2,91,6.0M,10000,Free,0,Everyone,Communication
+EG India,LIFESTYLE,5.0,3,4.0M,100,Free,0,Everyone,Lifestyle
+Fashion Pony Girls Dress Up Makeup Game,FAMILY,4.5,256,30M,10000,Free,0,Everyone,Simulation
+My Little Pony Celebration,FAMILY,4.3,63192,17M,1000000,Free,0,Everyone,Simulation;Pretend Play
+My Little Pony AR Guide,BOOKS_AND_REFERENCE,3.3,7993,51M,1000000,Free,0,Everyone,Books & Reference
+MY LITTLE PONY: Magic Princess,FAMILY,4.4,1309728,Varies with device,50000000,Free,0,Everyone,Casual
+Equestria Girl Snapchat Addict,FAMILY,4.2,20,31M,1000,Free,0,Everyone,Educational
+L.A. Crime Stories 2 Mad City Crime,GAME,4.2,3946,42M,100000,Free,0,Teen,Racing
+LA Stories 4 New Order Sandbox 2018,GAME,4.2,17453,99M,1000000,Free,0,Mature 17+,Racing
+SDA Sabbath School Quarterly,BOOKS_AND_REFERENCE,4.7,14773,6.4M,500000,Free,0,Everyone,Books & Reference
+Sirens Fashion Style Game,FAMILY,4.3,2282,22M,500000,Free,0,Everyone,Simulation
+Equestria Amino for MLP,SOCIAL,4.8,8369,63M,50000,Free,0,Teen,Social
+Propertyfinder,LIFESTYLE,4.2,1506,11M,100000,Free,0,Everyone,Lifestyle
+L.A. Crime Stories Mad City Crime,GAME,4.0,30008,99M,1000000,Free,0,Mature 17+,Racing
+My Little Pony: Story Creator,FAMILY,4.2,11002,21M,1000000,Free,0,Everyone,Education;Action & Adventure
+Pocket Little Pony,FAMILY,4.1,47576,14M,1000000,Free,0,Everyone 10+,Simulation
+Dance Magic Fashion Style Games,FAMILY,4.6,2533,46M,100000,Free,0,Everyone,Simulation
+Inventory & Barcode scanner & WIFI scanner,PRODUCTIVITY,4.6,1880,18M,50000,Paid,$1.49,Everyone,Productivity
+MLP Colouring Adventures,FAMILY,3.8,7379,61M,1000000,Free,0,Everyone,Entertainment
+Miraculous Ladybug & Cat Noir - The Official Game,GAME,4.5,185382,99M,10000000,Free,0,Everyone,Action
+Fashion Girls Dress up Makeup,FAMILY,4.4,115,31M,10000,Free,0,Everyone,Simulation
+My Little Pony: Harmony Quest,FAMILY,4.1,148405,26M,10000000,Free,0,Everyone,Casual;Action & Adventure
+Home Pony 2,FAMILY,4.0,20977,26M,1000000,Free,0,Everyone,Simulation
+Eh Volevi!,FAMILY,3.9,1619,7.0M,100000,Free,0,Everyone,Entertainment
+VITEK EH DVR Viewer (Pro),TOOLS,3.5,78,3.3M,10000,Free,0,Everyone,Tools
+Eh Bee Wallpapers HD,PERSONALIZATION,5.0,4,3.9M,100,Free,0,Everyone,Personalization
+EH!,LIFESTYLE,4.6,10,8.7M,1000,Free,0,Everyone,Lifestyle
+Me-eh,FAMILY,4.2,13,62M,100,Free,0,Everyone,Puzzle
+Arogyam EH,MEDICAL,3.6,18,3.5M,1000,Free,0,Everyone,Medical
+Betul Ke Bohong Eh?,GAME,4.2,601,6.4M,100000,Free,0,Everyone,Trivia
+EH National Mobile Banking,FINANCE,4.1,0,Varies with device,50,Free,0,Everyone,Finance
+EH Autolink,BUSINESS,4.1,1,921k,100,Free,0,Everyone,Business
+Eh Amego!,GAME,3.8,13388,7.1M,500000,Free,0,Everyone,Arcade
+Eh Plus English Application,FAMILY,4.2,1,874k,100,Free,0,Everyone,Education
+EH kontrollrakendus,TOOLS,3.4,43,2.3M,5000,Free,0,Everyone,Tools
+Fit the Fat 2,SPORTS,3.8,35746,55M,5000000,Free,0,Everyone,Sports
+My Theme Park: RollerCoaster & Water Park Tycoon,FAMILY,4.2,128,41M,10000,Free,0,Everyone 10+,Strategy
+Doomsday Preppers™,FAMILY,4.2,137167,52M,1000000,Free,0,Everyone,Strategy
+TAXI DRIVER,FAMILY,3.7,7203,32M,1000000,Free,0,Everyone,Simulation
+Crazy Doctor,FAMILY,4.0,267636,13M,10000000,Free,0,Teen,Role Playing
+MazeMilitia Classic Multiplayer Shooting Game,GAME,4.4,1294,44M,50000,Free,0,Mature 17+,Action
+Endress+Hauser Operations,BUSINESS,4.5,234,3.4M,10000,Free,0,Everyone,Business
+ZOMBIE RIPPER,GAME,3.7,16073,94M,500000,Free,0,Mature 17+,Action
+Soldiers of Glory: Modern War,FAMILY,4.2,64815,23M,5000000,Free,0,Teen,Strategy
+Driving School 3D 2017,FAMILY,3.9,5075,48M,500000,Free,0,Everyone,Simulation
+Retro Camera,PHOTOGRAPHY,4.0,125616,Varies with device,10000000,Free,0,Everyone,Photography
+Horror Hospital,GAME,3.7,63986,26M,1000000,Free,0,Teen,Action
+Ludo Family Dice Game,FAMILY,4.2,3593,19M,500000,Free,0,Everyone,Board;Brain Games
+Mad Skills Motocross,GAME,4.0,32522,44M,1000000,Free,0,Everyone,Racing
+Masterchef Cooking Games: Fun Restaurant & Kitchen,FAMILY,3.9,1036,33M,100000,Free,0,Everyone,Casual
+US Army Training Courses Game,FAMILY,4.1,27130,35M,5000000,Free,0,Everyone,Simulation
+Pineapple Pen,GAME,4.3,157264,65M,10000000,Free,0,Everyone,Arcade
+Instant Buttons: The Best Soundboard,FAMILY,4.5,157322,9.2M,5000000,Free,0,Teen,Entertainment
+Guess The Emoji,GAME,4.5,76627,23M,5000000,Free,0,Everyone,Word
+Camping RV Caravan Parking 3D,GAME,3.3,5290,48M,500000,Free,0,Everyone,Racing
+Grand Bat Superhero Flying Assault Rescue Mission,GAME,4.4,1094,37M,500000,Free,0,Teen,Action
+Zombie Frontier,GAME,4.2,326689,20M,10000000,Free,0,Teen,Action
+eHub,BUSINESS,4.2,6969,4.8M,100000,Free,0,Everyone,Business
+Voice Changer,FAMILY,4.1,138050,5.7M,10000000,Free,0,Everyone,Entertainment;Music & Video
+Heart Surgery Emergency Doctor,FAMILY,4.1,2248,29M,100000,Free,0,Teen,Educational
+RUN JUMP RUN-fun games for free,GAME,4.4,661,42M,100000,Free,0,Everyone,Action
+100 Doors of Revenge,FAMILY,4.1,105766,48M,10000000,Free,0,Teen,Puzzle
+Lie Detector Prank,FAMILY,3.9,80313,3.7M,10000000,Free,0,Everyone,Casual
+Virtual Mother Surgery Doctor : Emergency Hospital,FAMILY,3.9,70,61M,10000,Free,0,Teen,Educational
+Princess Palace: Royal Pony,FAMILY,4.4,11442,66M,1000000,Free,0,Everyone,Educational;Creativity
+EI Mobile,FINANCE,3.8,4231,82M,100000,Free,0,Everyone,Finance
+TAMAGO,FAMILY,3.0,42515,1.6M,5000000,Free,0,Everyone,Casual
+Ei Electronics AudioLINK,TOOLS,3.4,59,1.8M,10000,Free,0,Everyone,Tools
+Ei Samay - Bengali News Paper,NEWS_AND_MAGAZINES,4.3,20620,Varies with device,1000000,Free,0,Everyone,News & Magazines
+Vital Tones EI Pro,HEALTH_AND_FITNESS,4.3,2,85M,50,Paid,$9.99,Everyone,Health & Fitness
+EI HabitTracker,FAMILY,4.2,2,981k,100,Free,0,Everyone,Education
+NEMA ei,BUSINESS,5.0,4,12M,100,Free,0,Everyone,Business
+ei,COMMUNICATION,4.2,2,4.5M,10,Free,0,Teen,Communication
+the Egg - crack the egg,FAMILY,4.1,211,14M,10000,Free,0,Everyone,Casual
+Yeled EI,FAMILY,4.2,0,15M,100,Free,0,Everyone,Education
+EI SmartMiles,FINANCE,2.4,9,3.8M,1000,Free,0,Everyone,Finance
+Code on the egg,TOOLS,3.9,146,784k,10000,Free,0,Everyone,Tools
+Sensenuts eI,BUSINESS,4.1,0,Varies with device,5,Free,0,Everyone,Business
+EI!,PRODUCTIVITY,4.2,0,7.7M,10,Free,0,Everyone,Productivity
+EI App 1,FAMILY,4.2,0,13M,10,Free,0,Everyone,Education
+EI Calculator,TOOLS,4.0,8,1.5M,100,Free,0,Everyone,Tools
+Verdant EI,TOOLS,4.0,0,13M,50,Free,0,Everyone,Tools
+Tamago egg,GAME,3.0,49,7.1M,5000,Free,0,Everyone,Trivia
+Ei-ij Spelling Dutch,FAMILY,4.2,20,3.2M,10000,Free,0,Everyone,Education
+Esporte Interativo - Notícias e Resultados Ao Vivo,SPORTS,4.4,4600,21M,500000,Free,0,Everyone,Sports
+Let's Poke The Egg,GAME,3.4,9051,23M,1000000,Free,0,Everyone,Arcade
+Egg,FAMILY,2.9,72,27M,5000,Free,0,Mature 17+,Simulation
+ei Calc,TOOLS,5.0,2,19M,10,Free,0,Everyone,Tools
+Disaster Will Strike,FAMILY,4.5,14692,45M,1000000,Free,0,Everyone,Puzzle
+Egg: clicker,FAMILY,3.7,40678,15M,1000000,Free,0,Everyone,Casual
+Egg for Pou,FAMILY,3.0,59096,Varies with device,5000000,Free,0,Everyone,Casual
+EI App 2,FAMILY,4.2,0,13M,10,Free,0,Everyone,Education
+Survival: Prison Escape,GAME,4.0,127810,33M,10000000,Free,0,Mature 17+,Action
+Crack the blue angry birds egg,FAMILY,3.2,85,2.1M,10000,Free,0,Everyone,Puzzle
+Tamago Tap Clicker Egg,FAMILY,3.6,209,16M,50000,Free,0,Everyone,Casual
+Tap The Easter Egg!,FAMILY,3.2,111,3.3M,5000,Free,0,Everyone,Casual
+Esporte Interativo Plus,SPORTS,3.7,27179,20M,1000000,Free,0,Everyone,Sports
+EI国际,FAMILY,4.7,15,5.2M,1000,Free,0,Everyone,Education
+Egg Baby,FAMILY,4.4,351607,8.7M,5000000,Free,0,Everyone 10+,Casual
+Surprise Eggs,FAMILY,3.9,81543,Varies with device,10000000,Free,0,Everyone,Casual;Pretend Play
+PJ Masks: Moonlight Heroes,FAMILY,4.4,87045,99M,10000000,Free,0,Everyone,Casual;Action & Adventure
+Crack Attack,FAMILY,4.3,31970,77M,1000000,Free,0,Everyone,Puzzle
+Aaj Bangla: ei samay er khobor,NEWS_AND_MAGAZINES,4.9,34,3.8M,1000,Free,0,Everyone,News & Magazines
+Break the Egg,FAMILY,2.6,366,6.0M,50000,Free,0,Everyone,Entertainment
+"Kolkata News:Anandbazar Patrika,ei samay&AllRating",NEWS_AND_MAGAZINES,5.0,10,5.0M,100,Free,0,Everyone,News & Magazines
+PJ Masks: HQ,FAMILY,4.1,13731,55M,1000000,Free,0,Everyone,Entertainment;Action & Adventure
+Ei Somoy & Dainik Sangbad & Statesman (PDF),NEWS_AND_MAGAZINES,4.0,4,5.3M,100,Free,0,Everyone,News & Magazines
+TAMAGO Monsters Returns,GAME,4.1,104583,37M,1000000,Free,0,Everyone,Arcade
+EJ.by,NEWS_AND_MAGAZINES,4.1,10,2.3M,500,Free,0,Everyone,News & Magazines
+EJ Elite Prospects League,SPORTS,3.3,3,12M,1000,Free,0,Everyone,Sports
+Super Sport Car Simulator,FAMILY,4.2,58553,50M,1000000,Free,0,Everyone,Simulation
+EJ Insight,NEWS_AND_MAGAZINES,4.0,33,280k,1000,Free,0,Everyone,News & Magazines
+Ambulance Rescue Simulator 17,FAMILY,4.3,6669,31M,1000000,Free,0,Everyone,Simulation
+EJ Trívia Game,FAMILY,4.2,1,19M,1,Free,0,Everyone,Puzzle
+Bad Piggies HD,FAMILY,4.4,764967,69M,10000000,Free,0,Everyone,Puzzle
+EJ messenger,COMMUNICATION,5.0,1,25M,10,Free,0,Teen,Communication
+Traffic Sniper Counter Attack,GAME,4.3,5339,38M,1000000,Free,0,Teen,Action
+Rope Superhero Unlimited,GAME,4.4,6735,26M,1000000,Free,0,Mature 17+,Action
+Painel EJ SSH - INTERNET GRÁTIS,TOOLS,4.0,10,13M,50,Free,0,Everyone,Tools
+EJ Ecuador,LIFESTYLE,4.1,9,6.8M,100,Free,0,Teen,Lifestyle
+Ej-buy,BUSINESS,4.1,2,4.1M,5,Free,0,Everyone,Business
+Extreme Super Car Driving 3D,GAME,3.9,23104,48M,1000000,Free,0,Everyone,Racing
+Footej Camera,PHOTOGRAPHY,4.3,13258,Varies with device,1000000,Free,0,Everyone,Photography
+Sport Car Simulator,FAMILY,4.0,48731,68M,5000000,Free,0,Everyone,Simulation
+Fast Racing Car Simulator,GAME,3.8,8482,45M,1000000,Free,0,Everyone,Racing
+Silence Premium Do Not Disturb,TOOLS,4.5,3356,Varies with device,10000,Paid,$2.95,Everyone,Tools
+パーリーゲイツ公式通販｜EJ STYLE（イージェイスタイル）,SHOPPING,4.3,1,9.3M,100,Free,0,Everyone,Shopping
+Beach Head Shooting Assault,GAME,3.8,555,44M,100000,Free,0,Teen,Action
+Stickman Warriors Heroes 2,GAME,4.4,13714,41M,1000000,Free,0,Everyone 10+,Action
+Dead Target Zombie Shooting US Sniper Killer Squad,GAME,4.3,240,65M,50000,Free,0,Teen,Action
+Learn Music Notes,FAMILY,4.7,143,4.4M,1000,Paid,$1.99,Everyone,Music;Music & Video
+Luxury Car Simulator,FAMILY,3.9,35989,46M,1000000,Free,0,Everyone,Simulation
+Dubai Racing,GAME,4.2,16237,23M,500000,Free,0,Everyone,Racing
+Office Bike Racing Simulator,FAMILY,3.8,21149,30M,1000000,Free,0,Everyone,Simulation
+Pregnant Mom Surgery Newborn Twins Baby Birth Care,FAMILY,4.3,95,28M,10000,Free,0,Teen,Educational
+Pet Beauty Salon,FAMILY,3.8,20292,47M,1000000,Free,0,Everyone,Educational;Creativity
+Booking Revolution,SPORTS,4.2,140883,59M,5000000,Free,0,Teen,Sports
+Nights Keeper (do not disturb),LIFESTYLE,4.5,16426,1.6M,500000,Free,0,Everyone,Lifestyle
+Farming Simulator 16,FAMILY,4.2,32812,14M,500000,Paid,$2.99,Everyone,Simulation;Education
+Lily & Leo - Crazy Circus Day,FAMILY,3.6,8091,43M,1000000,Free,0,Everyone,Casual;Pretend Play
+WIZARD Card Game,GAME,4.0,48,4.1M,1000,Paid,$1.99,Everyone,Card
+"Period Tracker, Pregnancy Calculator & Calendar 🌸",HEALTH_AND_FITNESS,4.3,0,Varies with device,10000,Free,0,Everyone,Health & Fitness
+Fake Call From Wengie Prank,FAMILY,3.5,352,3.8M,50000,Free,0,Everyone,Entertainment
+Robot Fighting Games™ - Real Boxing Champions 3D,GAME,4.4,30,47M,5000,Free,0,Everyone,Action
+Ghost Hunting camera,GAME,3.5,3048,24M,500000,Free,0,Teen,Action
+Santa Panda Bubble Christmas,GAME,4.1,101,31M,10000,Free,0,Everyone,Arcade
+TeamWard – live help for LoL,FAMILY,4.8,3136,2.7M,100000,Free,0,Everyone,Entertainment
+3D Metal Piano Keys Keyboard Theme,FOOD_AND_DRINK,4.4,467,7.3M,100000,Free,0,Everyone,Food & Drink
+OffRoad US Army Train Driving Simulator,FAMILY,4.3,1216,59M,500000,Free,0,Everyone 10+,Simulation
+Do Not Disturb! 2 - Challenge Your Prank Skills!,FAMILY,4.0,34417,48M,1000000,Free,0,Everyone,Educational
+WiFi Tether Router,COMMUNICATION,4.2,5599,1.3M,100000,Paid,$2.90,Everyone,Communication
+Local weather Forecast,WEATHER,4.4,5482,12M,1000000,Free,0,Everyone,Weather
+Kiss Me! Lip Kissing Test,FAMILY,3.5,191,5.0M,50000,Free,0,Everyone,Entertainment
+Smoke Effect Name Art Maker-Avatar Text Art Editor,PERSONALIZATION,4.3,1961,6.6M,100000,Free,0,Everyone,Personalization
+The Emirates App,TRAVEL_AND_LOCAL,4.4,22776,55M,1000000,Free,0,Everyone,Travel & Local
+ek tuhi,VIDEO_PLAYERS,4.7,316,2.8M,10000,Free,0,Everyone,Video Players & Editors
+Master E.K,FAMILY,5.0,90,Varies with device,1000,Free,0,Everyone,Education
+EK Platinum,LIFESTYLE,3.8,52,10M,10000,Free,0,Everyone,Lifestyle
+EK Bailey Preaching Conference,EVENTS,5.0,3,30M,500,Free,0,Everyone,Events
+Ek Maratha,SOCIAL,4.8,725,3.7M,10000,Free,0,Teen,Social
+Ek Onkar,FAMILY,4.9,107,18M,10000,Free,0,Everyone,Entertainment
+Racing Moto,GAME,4.3,697805,7.4M,50000000,Free,0,Everyone,Racing
+Pyaar Ek Dhoka hai Game - Anti Valentines,FAMILY,4.2,8,17M,100,Free,0,Everyone,Casual
+Pyaar Ek Dhoka,FAMILY,5.0,18,1.3M,50,Free,0,Everyone,Casual
+Ek Biladi Jadi Video Song,FAMILY,4.2,3,3.7M,5000,Free,0,Everyone,Entertainment
+Duaa Ek Ibaadat,BOOKS_AND_REFERENCE,4.9,122,26M,5000,Free,0,Everyone,Books & Reference
+Ek Onkar Mantras,LIFESTYLE,4.9,82,5.0M,5000,Free,0,Everyone,Lifestyle
+Alex Fuel Calculator for EK,TOOLS,4.9,19,3.3M,500,Free,0,Everyone,Tools
+Ringtones Of Ek Onkar,FAMILY,4.5,6,3.9M,1000,Free,0,Everyone,Entertainment
+EK Carevec,FAMILY,4.2,1,29M,10,Free,0,Teen,Entertainment
+Ek Kahani Aisi Bhi Season 2 - The Horror Story,FAMILY,4.5,28,5.6M,1000,Free,0,Teen,Entertainment
+Ek Bander Ne Kholi Dukan,FAMILY,5.0,10,3.0M,10000,Free,0,Everyone,Entertainment
+Hum Ek Hain 2.02,SOCIAL,5.0,2,1.8M,10,Free,0,Teen,Social
+Ek Kahani Aisi Bhi Season 3 - The Horror Story,FAMILY,3.0,1,5.8M,100,Free,0,Teen,Entertainment
+Ek IRA,COMMUNICATION,4.2,0,5.7M,10,Free,0,Everyone,Communication
+Sanu Ek Pal Chain - Raid,TOOLS,4.0,1,2.6M,500,Free,0,Everyone,Tools
+Sai Baba - Sabka Malik Ek,PRODUCTIVITY,4.9,42,38M,1000,Free,0,Everyone,Productivity
+Ek Vote,PRODUCTIVITY,5.0,43,6.2M,500,Free,0,Everyone,Productivity
+Asha Ek Hope - ALS/ MND,MEDICAL,5.0,2,11M,100,Free,0,Everyone,Medical
+Meslek Lisesi YGS Ek Puan,FAMILY,4.2,11,1.5M,1000,Free,0,Everyone,Education
+Airplane Pilot Car Transporter,FAMILY,4.1,182363,62M,10000000,Free,0,Everyone,Simulation
+Mahila Vashikaran(Ek rat me)-Hindi,FAMILY,4.2,0,4.0M,1000,Free,0,Everyone,Entertainment
+Ek Kauwa Pyasa Tha,FAMILY,4.1,35,3.1M,50000,Free,0,Everyone,Entertainment
+Train Racing Games 3D 2 Player,GAME,4.3,192374,56M,10000000,Free,0,Everyone,Racing
+Video Maker with Photo and Music,PHOTOGRAPHY,4.3,4871,30M,1000000,Free,0,Everyone,Photography
+SIM Card Info,TOOLS,4.1,4234,1.9M,1000000,Free,0,Everyone,Tools
+Toilet Ek Prem Katha Songs Lyrics in Hindi,FAMILY,4.7,3,2.0M,1000,Free,0,Everyone,Entertainment
+Ek Do Teen Song Videos - Baaghi 2 Video Songs,FAMILY,4.2,2,4.5M,1000,Free,0,Everyone,Entertainment
+Sanu Ek Pal Chain Song Videos - RAID Movie Songs,FAMILY,4.9,11,4.3M,5000,Free,0,Everyone,Entertainment
+"Phogy, 3D Camera",PHOTOGRAPHY,4.0,35725,9.9M,1000000,Free,0,Everyone,Photography
+Ek Qissa He Quran Se (Qurani Waqiyat),FAMILY,5.0,4,2.0M,100,Free,0,Everyone,Entertainment
+Lyrics of Ek Paheli Leela,FAMILY,5.0,4,2.3M,500,Free,0,Everyone,Entertainment
+Ek-yatri: Travel where you Belong,TRAVEL_AND_LOCAL,4.1,0,29M,1,Free,0,Everyone,Travel & Local
+Exiled Kingdoms RPG,FAMILY,4.6,49210,99M,1000000,Free,0,Everyone 10+,Role Playing
+Sabka Malik Ek Sai,SOCIAL,4.2,17,5.1M,1000,Free,0,Teen,Social
+Voice Lock Screen,LIFESTYLE,3.7,6667,2.7M,1000000,Free,0,Everyone,Lifestyle
+Shabad Gurubani Punjabi mp3 free - Ek Onkar Satnam,FAMILY,5.0,5,64M,100,Free,0,Everyone,Entertainment
+Bus Driver 3D: Hill Station,FAMILY,4.3,31705,49M,5000000,Free,0,Everyone,Simulation
+Extreme Motorbike Jump 3D,FAMILY,4.0,94308,79M,10000000,Free,0,Everyone,Simulation
+el,FAMILY,4.3,32405,47M,1000000,Free,0,Everyone,Casual
+El Pollo Loco - Loco Rewards,FOOD_AND_DRINK,4.0,848,25M,100000,Free,0,Everyone,Food & Drink
+El Chavo,FAMILY,4.0,751,49M,10000,Paid,$0.99,Everyone,Casual
+EL AL Flights,TRAVEL_AND_LOCAL,3.1,1563,36M,100000,Free,0,Everyone,Travel & Local
+DreamStream By EL AL,TRAVEL_AND_LOCAL,3.4,595,22M,100000,Free,0,Everyone,Travel & Local
+Learn English with El Chavo.,FAMILY,4.2,6133,7.0M,100000,Free,0,Everyone,Education
+Learn Math with el Chavo,FAMILY,4.2,840,60M,100000,Free,0,Everyone,Education
+El Nuevo Día,NEWS_AND_MAGAZINES,4.1,8011,13M,500000,Free,0,Everyone 10+,News & Magazines
+EL NORTE,NEWS_AND_MAGAZINES,3.4,2436,Varies with device,100000,Free,0,Everyone,News & Magazines
+El Nueve,NEWS_AND_MAGAZINES,4.1,221,3.2M,50000,Free,0,Teen,News & Magazines
+El Laberinto del Demonio 3D,FAMILY,4.0,20421,31M,1000000,Free,0,Teen,Puzzle
+Monastery of El Escorial,TRAVEL_AND_LOCAL,4.1,12,50M,1000,Paid,$1.99,Everyone,Travel & Local
+Learn to code with el Chavo,FAMILY,3.9,5933,60M,1000000,Free,0,Everyone,Educational
+El Falı,FAMILY,4.8,36968,16M,1000000,Free,0,Everyone,Entertainment
+El Laberinto del Demonio 2,FAMILY,4.1,3654,25M,100000,Free,0,Teen,Puzzle
+TV Local El Salvador,FAMILY,4.3,323,3.6M,10000,Free,0,Everyone,Entertainment
+Tigo Money El Salvador,FINANCE,4.3,4642,3.5M,100000,Free,0,Everyone,Finance
+Hangman,FAMILY,4.4,23302,12M,5000000,Free,0,Everyone,Puzzle
+Explora con el Chavo,FAMILY,4.2,0,Varies with device,100000,Free,0,Everyone,Educational
+El Dorado App,TRAVEL_AND_LOCAL,4.4,221,33M,10000,Free,0,Everyone,Travel & Local
+Adivina el cantante de Trap y Reggaeton,GAME,4.5,1914,24M,100000,Free,0,Everyone,Trivia
+The translator,TOOLS,4.5,23805,4.1M,1000000,Free,0,Everyone,Tools
+Fernanfloo,GAME,4.8,526595,49M,10000000,Free,0,Everyone 10+,Arcade
+Weather 14 Days,WEATHER,4.4,279917,Varies with device,10000000,Free,0,Everyone,Weather
+The dollar in mexico,FINANCE,4.5,4254,3.2M,100000,Free,0,Everyone,Finance
+Real Madrid App,SPORTS,4.6,161423,73M,5000000,Free,0,Everyone,Sports
+OWLIE BOO,FAMILY,4.6,834,22M,100000,Free,0,Everyone,Puzzle;Education
+Trazado de tuberia El Tubero,TOOLS,4.5,313,4.4M,10000,Paid,$1.97,Everyone,Tools
+Adivina el Emoji,GAME,4.3,2536,32M,100000,Free,0,Everyone,Trivia
+Weather by eltiempo.es,WEATHER,4.2,67854,Varies with device,5000000,Free,0,Everyone,Weather
+The Game of Life,GAME,4.4,18652,63M,100000,Paid,$2.99,Everyone,Board
+Spanish English Translator,BOOKS_AND_REFERENCE,4.2,87919,Varies with device,10000000,Free,0,Teen,Books & Reference
+The Holy Rosary,LIFESTYLE,4.7,56197,15M,1000000,Free,0,Everyone,Lifestyle
+Western Union US - Send Money Transfers Quickly,FINANCE,4.5,80904,16M,5000000,Free,0,Everyone,Finance
+"Maps, GPS Navigation & Directions, Street View",MAPS_AND_NAVIGATION,4.2,207440,6.4M,10000000,Free,0,Everyone,Maps & Navigation
+Human Anatomy Atlas 2018: Complete 3D Human Body,MEDICAL,4.5,2923,25M,100000,Paid,$24.99,Everyone,Medical
+Red Hands – 2-Player Games,GAME,4.2,93608,Varies with device,10000000,Free,0,Everyone,Action
+Narcos: Cartel Wars,FAMILY,4.7,244797,52M,5000000,Free,0,Teen,Strategy
+Get 'Em,GAME,4.1,7904,21M,500000,Free,0,Everyone 10+,Action
+EM Launcher for EMUI,PERSONALIZATION,4.1,3175,2.3M,500000,Free,0,Everyone,Personalization
+Live Hold’em Pro Poker - Free Casino Games,GAME,4.6,1123190,Varies with device,10000000,Free,0,Teen,Card
+Beach Shoot Em Up: Head Hunter,GAME,4.4,1218,15M,500000,Free,0,Everyone 10+,Action
+Connect'Em,FAMILY,4.5,49381,6.8M,1000000,Free,0,Everyone,Puzzle
+Stick 'Em Up 2 Starter Edition,GAME,3.8,2102,40M,100000,Free,0,Everyone 10+,Action
+Shoot`Em Down: Shooting game,GAME,3.9,7972,88M,500000,Free,0,Teen,Action
+Texas Hold’em Poker + | Social,GAME,3.5,4416,59M,500000,Free,0,Teen,Casino
+PlayTexas Hold'em Poker Free,GAME,3.8,3543,Varies with device,1000000,Free,0,Teen,Card
+EM Launcher Pro,PERSONALIZATION,4.2,35,24k,1000,Paid,$3.99,Everyone,Personalization
+HAWK – Force of an Arcade Shooter. Shoot 'em up,GAME,4.6,190274,46M,5000000,Free,0,Everyone,Arcade
+Shoot Em Down Free,FAMILY,3.7,2850,39M,500000,Free,0,Everyone,Puzzle
+Game for KIDS: KIDS match'em,FAMILY,4.4,7006,6.9M,1000000,Free,0,Everyone,Education
+Texas Hold'em Poker,GAME,3.6,12846,14M,1000000,Free,0,Teen,Casino
+Nuke Em All,FAMILY,3.4,2714,52M,500000,Free,0,Mature 17+,Casual
+Poker Equity Calculator Pro for No Limit Hold'em,GAME,4.0,21,14M,5000,Paid,$0.99,Everyone,Card
+Poker Live! 3D Texas Hold'em,GAME,4.3,6143,37M,100000,Free,0,Teen,Casino
+"CBS Sports App - Scores, News, Stats & Watch Live",SPORTS,4.3,91035,Varies with device,5000000,Free,0,Everyone,Sports
+Fun Texas Hold'em Poker,GAME,4.5,32831,24M,500000,Free,0,Teen,Casino
+Elevator Simulator Lift EM ALL,FAMILY,4.4,2941,28M,100000,Free,0,Teen,Simulation
+Dragonplay™ Poker Texas Holdem,GAME,4.5,197979,Varies with device,1000000,Free,0,Teen,Card
+Punch em,GAME,4.1,2208,4.4M,500000,Free,0,Everyone,Arcade
+Zynga Poker – Texas Holdem,GAME,4.4,1986068,52M,50000000,Free,0,Teen,Casino
+Boyaa Poker (En) – Social Texas Hold’em,GAME,4.3,71468,51M,1000000,Free,0,Teen,Card
+World Series of Poker – WSOP Free Texas Holdem,GAME,4.5,910051,76M,10000000,Free,0,Teen,Card
+Connect'Em Halloween,FAMILY,4.5,6673,4.4M,500000,Free,0,Everyone,Puzzle
+Yahoo Fantasy Sports - #1 Rated Fantasy App,SPORTS,4.2,277939,Varies with device,5000000,Free,0,Mature 17+,Sports
+Texas Holdem Poker Pro,GAME,4.5,114479,26M,5000000,Free,0,Teen,Card
+Rage Fight of Streets - Beat Em Up Game,GAME,4.3,1489,67M,100000,Free,0,Teen,Action
+HANGAME Casino - Baccarat & Texas Hold'em,GAME,4.1,8608,46M,500000,Free,0,Teen,Casino
+PokerStars Play: Free Texas Holdem Poker Game,GAME,4.6,14989,78M,500000,Free,0,Teen,Card
+Yoong: Kick 'Em Up!,SPORTS,4.3,7107,33M,100000,Free,0,Everyone,Sports
+Texas Holdem Poker,GAME,4.0,127831,26M,10000000,Free,0,Teen,Card
+Instabridge - Free WiFi Passwords and Hotspots,TOOLS,4.4,211308,Varies with device,10000000,Free,0,Everyone,Tools
+Big Fish Casino – Play Slots & Vegas Games,GAME,4.4,382100,Varies with device,10000000,Free,0,Teen,Casino
+Em Fuga Brasil,FAMILY,4.2,1317,60M,100000,Free,0,Everyone,Simulation
+LocaToWeb - Live GPS tracking,SPORTS,4.6,200,3.0M,1000,Paid,$2.49,Everyone,Sports
+TRANSFORMERS: Forged to Fight,GAME,4.6,291941,90M,10000000,Free,0,Everyone 10+,Action
+Texas Holdem & Omaha Poker: Pokerist,GAME,4.3,187200,28M,10000000,Free,0,Teen,Card
+Governor of Poker 2 - OFFLINE POKER GAME,GAME,4.3,246538,60M,5000000,Free,0,Teen,Card
+Squadron - Bullet Hell Shooter,GAME,4.2,177542,40M,10000000,Free,0,Everyone,Arcade
+Telemundo Deportes - En Vivo,SPORTS,4.5,36255,25M,1000000,Free,0,Everyone,Sports
+Holy Knight EN,FAMILY,4.0,26202,41M,1000000,Free,0,Teen,Role Playing
+Hello English: Learn English,FAMILY,4.6,750321,Varies with device,10000000,Free,0,Everyone,Education
+Dictionary - Merriam-Webster,BOOKS_AND_REFERENCE,4.5,454412,Varies with device,10000000,Free,0,Everyone,Books & Reference
+English in a Month Free,FAMILY,3.8,6577,13M,1000000,Free,0,Everyone,Education
+Words With Friends – Play Free,GAME,4.3,711719,Varies with device,10000000,Free,0,Everyone,Word
+FRANCE 24,NEWS_AND_MAGAZINES,4.3,47069,Varies with device,5000000,Free,0,Everyone 10+,News & Magazines
+JW Library,BOOKS_AND_REFERENCE,4.9,922752,Varies with device,10000000,Free,0,Everyone,Books & Reference
+Learn Body Parts in English,FAMILY,4.0,7243,42M,1000000,Free,0,Everyone,Education
+ai.type keyboard Plus + Emoji,TOOLS,4.5,57076,35M,100000,Paid,$4.49,Everyone,Tools
+Edmodo,FAMILY,4.1,200214,18M,10000000,Free,0,Everyone,Education
+Learn English Daily,FAMILY,4.5,7881,53M,500000,Free,0,Everyone,Education
+Orfox: Tor Browser for Android,COMMUNICATION,4.2,44233,31M,10000000,Free,0,Everyone,Communication
+"NewsDog - Latest News, Breaking News, Local News",NEWS_AND_MAGAZINES,4.4,291901,4.3M,10000000,Free,0,Mature 17+,News & Magazines
+Keyboard ManMan,TOOLS,4.4,121304,Varies with device,10000000,Free,0,Everyone,Tools
+RightNow English Conversation,FAMILY,4.0,5118,11M,1000000,Free,0,Everyone,Education
+HTC Sense Input - EN,TOOLS,4.3,24175,8.5M,5000000,Free,0,Everyone,Tools
+"busuu: Learn Languages - Spanish, English & More",FAMILY,4.3,207294,21M,10000000,Free,0,Everyone 10+,Education
+Classic Words Solo,GAME,4.4,135739,Varies with device,5000000,Free,0,Everyone,Word
+"Ginger Keyboard - Emoji, GIFs, Themes & Games",PRODUCTIVITY,4.4,162831,43M,5000000,Free,0,Everyone,Productivity
+English Audio Books - Librivox,FAMILY,4.0,10773,10M,1000000,Free,0,Everyone,Education
+Learn Top 300 English Words,FAMILY,4.7,61600,3.4M,1000000,Free,0,Everyone,Education
+"Univision Deportes: Liga MX, MLS, Fútbol En Vivo",SPORTS,4.2,75566,Varies with device,5000000,Free,0,Everyone,Sports
+Chess Free,GAME,4.5,1375988,15M,50000000,Free,0,Everyone,Board
+Oxford Dictionary of English : Free,BOOKS_AND_REFERENCE,4.1,364452,7.1M,10000000,Free,0,Everyone,Books & Reference
+English Hindi Dictionary,BOOKS_AND_REFERENCE,4.4,384368,Varies with device,10000000,Free,0,Everyone,Books & Reference
+English to Hindi Dictionary,BOOKS_AND_REFERENCE,4.1,71328,11M,5000000,Free,0,Everyone,Books & Reference
+EO.TRADE - Coin sale,FINANCE,4.3,95,1.5M,10000,Free,0,Everyone,Finance
+EO Network,BUSINESS,3.5,13,21M,1000,Free,0,Teen,Business
+The EO Bar,HEALTH_AND_FITNESS,4.7,416,34M,10000,Paid,$6.99,Everyone,Health & Fitness
+EO Mumbai,COMMUNICATION,4.2,0,11M,10,Free,0,Everyone,Communication
+EO Global,BUSINESS,2.6,13,8.9M,1000,Free,0,Everyone,Business
+EO SouthAsia,BUSINESS,4.2,8,19M,100,Free,0,Teen,Business
+EO RAIPUR,SOCIAL,4.3,1,4.2M,10,Free,0,Teen,Social
+EO Forum,BUSINESS,4.1,0,1.1M,100,Free,0,Everyone,Business
+EO Events,BUSINESS,4.1,0,11M,10,Free,0,Teen,Business
+EO KOREA,BUSINESS,4.1,0,14M,50,Free,0,Teen,Business
+EO App. SelfCompassion to you,HEALTH_AND_FITNESS,4.3,1,Varies with device,100,Free,0,Everyone,Health & Fitness
+EO GSEA,BUSINESS,4.1,1,30M,10,Free,0,Everyone,Business
+EO Guide,HEALTH_AND_FITNESS,4.3,15,24M,1000,Paid,$4.99,Everyone,Health & Fitness
+EO SA Benefits,BUSINESS,4.1,0,518k,10,Free,0,Everyone,Business
+FAST EO,EVENTS,5.0,1,Varies with device,10,Free,0,Everyone,Events
+23rd QM BDE EO,BUSINESS,4.1,0,6.3M,10,Free,0,Everyone,Business
+EO Bijbel Open,LIFESTYLE,4.3,102,41M,10000,Free,0,Everyone,Lifestyle
+EO LAC,LIFESTYLE,4.1,0,18M,10,Free,0,Everyone,Lifestyle
+EO Hub,BUSINESS,4.1,0,5.2M,50,Free,0,Teen,Business
+Kenny e o Cupcake,FAMILY,4.2,0,6.7M,1,Free,0,Everyone,Arcade;Action & Adventure
+EO,BUSINESS,4.1,0,3.1M,50,Free,0,Everyone,Business
+4Eternity EO,BUSINESS,4.1,0,2.0M,10,Free,0,Everyone,Business
+Masha and the Bear,FAMILY,4.4,15105,36M,1000000,Free,0,Everyone,Education
+Free games: Masha and the Bear,FAMILY,4.3,34514,60M,5000000,Free,0,Everyone,Puzzle;Brain Games
+Masha and the Bear- House Cleaning Games for Girls,FAMILY,4.2,0,74M,100,Paid,$1.99,Everyone,Educational;Pretend Play
+EO Hotels,TRAVEL_AND_LOCAL,4.1,4,11M,100,Free,0,Everyone,Travel & Local
+Masha and the Bear Child Games,FAMILY,4.1,288606,92M,10000000,Free,0,Everyone,Adventure;Education
+Masha and the Bear - Hair Salon and MakeUp Games,FAMILY,4.2,1,83M,100,Paid,$2.49,Everyone,Role Playing;Education
+Masha and Bear: Cooking Dash,FAMILY,4.3,151374,54M,10000000,Free,0,Everyone,Role Playing;Brain Games
+Masha and the Bear: Evolution,FAMILY,4.5,2062,42M,500000,Free,0,Everyone,Strategy;Education
+Cryptocurrency Trading - How To Trade Crypto,FINANCE,4.1,1,23M,100,Free,0,Everyone,Finance
+Masha and the Bear. Games for kids,FAMILY,4.6,6231,31M,1000000,Free,0,Everyone,Educational;Pretend Play
+Masha and The Bear Jam Day Match 3 games for kids,FAMILY,4.6,50060,98M,1000000,Free,0,Everyone,Puzzle;Brain Games
+Where's My Water?,FAMILY,4.7,188740,69M,1000000,Paid,$1.99,Everyone,Puzzle;Brain Games
+O Céu e o Inferno,BOOKS_AND_REFERENCE,4.3,14,754k,500,Paid,$0.99,Everyone,Books & Reference
+Frozen Free Fall,FAMILY,4.3,1574546,37M,50000000,Free,0,Everyone,Puzzle;Action & Adventure
+Urban Car Simulator,FAMILY,4.2,23292,20M,1000000,Free,0,Everyone,Simulation
+Masha and the Bear: House Cleaning Games for Girls,FAMILY,4.5,43852,77M,10000000,Free,0,Everyone,Role Playing;Pretend Play
+Masha and The Bear Puzzle Game,FAMILY,4.3,13330,73M,1000000,Free,0,Everyone,Puzzle;Brain Games
+Masha and the Bear. Educational Games,FAMILY,4.5,46369,33M,10000000,Free,0,Everyone,Educational;Brain Games
+Bluetooth Pair,TOOLS,3.5,1960,2.7M,1000000,Free,0,Everyone,Tools
+Sports Car Driving Simulator 2018,GAME,4.3,2178,57M,500000,Free,0,Everyone,Racing
+Masha and the Bear: Good Night!,FAMILY,4.6,29155,83M,1000000,Free,0,Everyone,Educational;Pretend Play
+Masha and the Bear: Climb Racing and Car Games,FAMILY,4.5,2200,73M,1000000,Free,0,Everyone,Racing;Pretend Play
+Episode - Choose Your Story,FAMILY,4.3,1842381,Varies with device,50000000,Free,0,Teen,Simulation
+Out There Chronicles - Ep. 1,FAMILY,4.4,1516,44M,50000,Paid,$2.99,Everyone,Role Playing
+EP FCU,FINANCE,4.1,2,2.8M,100,Free,0,Everyone,Finance
+EP Home Energy Hub,PRODUCTIVITY,4.2,4,13M,100,Free,0,Everyone,Productivity
+EP,BUSINESS,4.1,3,2.1M,100,Free,0,Everyone,Business
+EP Spotter,FAMILY,3.4,9,28M,500,Free,0,Everyone,Entertainment
+EP Mobile,MEDICAL,4.3,267,2.3M,50000,Free,0,Everyone,Medical
+EP RSS Reader,COMMUNICATION,3.8,4,892k,100,Free,0,Everyone,Communication
+Out There Chronicles - Ep. 2,FAMILY,4.5,144,70M,1000,Paid,$2.99,Teen,Role Playing
+EP Cloud,PRODUCTIVITY,4.2,9,2.3M,10,Free,0,Everyone,Productivity
+eP Scanner,EVENTS,4.4,0,20M,100,Free,0,Everyone,Events
+EP McGuffey Primer,FAMILY,4.2,0,Varies with device,50,Paid,$1.99,Everyone,Education
+EP Church Annapolis,LIFESTYLE,5.0,2,8.8M,100,Free,0,Everyone,Lifestyle
+EP Horlogerie,LIFESTYLE,4.9,18,24M,1000,Free,0,Everyone,Lifestyle
+ep-liggare - Elektronisk personalliggare,TOOLS,4.0,0,21M,100,Free,0,Everyone,Tools
+EP Calipers,MEDICAL,4.2,4,15M,100,Paid,$0.99,Everyone,Medical
+EP Radio,FAMILY,5.0,3,154k,50,Free,0,Everyone,Entertainment
+EP Joaillerie,LIFESTYLE,4.1,54,21M,5000,Free,0,Teen,Lifestyle
+Tester EP,TOOLS,4.0,9,4.8M,100,Free,0,Everyone,Tools
+The Great Wobo Escape Ep. 1,GAME,4.2,5449,20M,500000,Free,0,Everyone 10+,Action
+The Visitor: Ep.2 - Sleepover Slaughter,GAME,4.3,5731,31M,1000000,Free,0,Mature 17+,Adventure
+Superbrothers Sword & Sworcery,GAME,4.4,11023,16M,100000,Paid,$3.99,Teen,Adventure
+EP Lab Digest,MEDICAL,2.3,11,12M,500,Free,0,Everyone,Medical
+EP Research Service,BOOKS_AND_REFERENCE,4.7,14,27M,1000,Free,0,Everyone,Books & Reference
+eP Finder,AUTO_AND_VEHICLES,4.2,0,6.3M,10,Free,0,Everyone,Auto & Vehicles
+EP Music,FAMILY,4.2,0,11M,10,Free,0,Everyone,Entertainment
+EP Coding,MEDICAL,4.2,0,2.0M,50,Paid,$0.99,Everyone,Medical
+EP Kalkulator el. energije,TOOLS,4.4,13,1.5M,100,Free,0,Everyone,Tools
+The Great Wobo Escape Ep.1,FAMILY,4.3,11,20M,500,Paid,$1.99,Everyone 10+,Action;Action & Adventure
+The Visitor: Ep.1 - Kitty Cat Carnage,GAME,4.4,3017,39M,500000,Free,0,Mature 17+,Adventure
+EP Cook Book,MEDICAL,4.2,0,3.2M,0,Paid,$200.00,Everyone,Medical
+Dr.Slender Ep 1 Guide (Eng),GAME,4.0,454,27M,10000,Free,0,Teen,Arcade
+Decay: The Mare - Ep.1 (Trial),GAME,3.6,5291,7.2M,100000,Free,0,Teen,Adventure
+EP Search and Find,FAMILY,4.2,20,23M,500,Free,0,Everyone,Casual
+What's Your Story?™ ft Charmed,FAMILY,4.1,39661,47M,1000000,Free,0,Teen,Role Playing
+EP Gem Hunter,GAME,4.6,79,31M,1000,Free,0,Everyone 10+,Action
+EP Chain Reaction,FAMILY,3.9,249,21M,10000,Free,0,Everyone,Casual;Brain Games
+Gate Of Death Ep: 1,GAME,4.4,7,34M,100,Free,0,Everyone,Adventure
+EP Mobil,SHOPPING,4.3,3,5.3M,100,Free,0,Everyone,Shopping
+Sonic 4™ Episode I,GAME,3.7,8014,37M,100000,Paid,$2.99,Everyone,Arcade
+Naruto Shippuden - Watch Free!,VIDEO_PLAYERS,3.9,141515,5.7M,10000000,Free,0,Teen,Video Players & Editors
+Lean EQ,BUSINESS,4.1,6,10M,10,Paid,$89.99,Everyone,Business
+Operate Now: Hospital,FAMILY,4.3,254861,52M,10000000,Free,0,Teen,Simulation
+Multi Surgery ER Emergency Hospital : Doctor Game,FAMILY,4.1,227,69M,10000,Free,0,Teen,Educational
+ER Surgery Simulator,FAMILY,3.6,19601,56M,1000000,Free,0,Everyone 10+,Casual
+Dentist Surgery ER Emergency Doctor Hospital Games,FAMILY,3.5,2580,53M,100000,Free,0,Everyone,Simulation
+Eye Transplant : ER Emergency Hospital,FAMILY,3.9,1938,62M,1000000,Free,0,Teen,Educational
+Lifeguard Beach Rescue ER Emergency Hospital Games,FAMILY,3.9,519,76M,100000,Free,0,Everyone,Simulation
+Hospital ER Emergency Heart Surgery: Doctor Games,FAMILY,3.8,1652,71M,100000,Free,0,Everyone,Simulation
+Superhero Doctor 2 -ER Surgery,FAMILY,4.0,39647,72M,10000000,Free,0,Everyone 10+,Casual
+ER,LIFESTYLE,4.1,2,28M,500,Free,0,Everyone,Lifestyle
+Noot-Noot-er!,FAMILY,4.5,74,2.8M,5000,Free,0,Everyone,Entertainment
+Doctor X - ER On Wheels,FAMILY,3.6,12781,51M,1000000,Free,0,Everyone,Casual;Pretend Play
+Foot Surgery Hospital Simulator: ER Doctor Games,FAMILY,3.9,314,28M,100000,Free,0,Everyone,Casual
+ER Heart Surgery - Emergency Simulator Game,FAMILY,4.3,429,40M,100000,Free,0,Everyone,Educational
+Pregnant Mom ER Emergency Doctor Hospital Games,FAMILY,4.0,325,27M,50000,Free,0,Everyone,Educational
+Doctr – ER wait times in Canada,MEDICAL,4.2,980,Varies with device,50000,Free,0,Everyone,Medical
+Plastic Surgery Surgeon Simulator Er Doctor Games,FAMILY,3.7,3482,37M,500000,Free,0,Everyone,Casual
+Shoulder Surgery ER Emergency Doctor Game,FAMILY,3.9,55,46M,10000,Free,0,Teen,Educational
+Superhero Doctor 3 ER Surgery,FAMILY,4.2,2801,50M,500000,Free,0,Everyone,Casual
+Mom Doctor ER Emergency Family Game,FAMILY,3.5,173,49M,10000,Free,0,Everyone,Educational
+ER Blood Draw Doctor & Surgeon,FAMILY,4.0,154,58M,50000,Free,0,Teen,Educational
+"ER Emergency Hospital - Brain, Knee, Eye Surgery",FAMILY,3.8,25,41M,1000,Free,0,Teen,Educational
+Super Doctor 1-Pregnant Mom ER Surgery Simulator,FAMILY,4.1,290,73M,10000,Free,0,Teen,Role Playing
+Multi Surgery Hospital Pro: Virtual Doctor ER Game,FAMILY,4.2,23,33M,1000,Free,0,Teen,Casual
+Clumsy Santa ER Surgery,FAMILY,4.1,214,46M,100000,Free,0,Teen,Casual
+Little Eye Surgery Simulator - ER Doctor Game,FAMILY,4.4,12,19M,1000,Free,0,Teen,Casual
+Spinal Cord Surgery Doctor: Operation ER surgery,FAMILY,3.7,52,32M,10000,Free,0,Everyone 10+,Role Playing
+ER Neck Surgery: Hospital Christmas Emergency,FAMILY,4.2,11,30M,5000,Free,0,Everyone 10+,Role Playing
+Super Doctor 2 - My Newborn Baby ER Injection,FAMILY,4.7,54,92M,1000,Free,0,Teen,Role Playing
+Virtual Brain Surgery Simulator : Kid ER Emergency,FAMILY,3.8,20,55M,5000,Free,0,Teen,Educational
+Crazy ER Open Heart Surgery Simulator,FAMILY,4.0,2936,45M,500000,Free,0,Everyone,Simulation
+ER Injection Simulator: Blood Test Doctor Hospital,FAMILY,4.2,3263,47M,1000000,Free,0,Everyone 10+,Role Playing
+Kids Doctor ER Emergency Rescue Kids Hospital Game,FAMILY,3.8,515,85M,100000,Free,0,Everyone,Simulation
+Heart Surgery Doctor - ER Emergency Game,FAMILY,3.9,2510,48M,500000,Free,0,Everyone 10+,Educational
+Virtual Mom Surgery Doctor : ER Emergency Hospital,FAMILY,4.0,1130,77M,100000,Free,0,Teen,Educational
+ER Doctor Kids Emergency Room,FAMILY,3.1,4798,30M,500000,Free,0,Teen,Casual
+ER Assist,PRODUCTIVITY,5.0,3,28M,10,Free,0,Everyone,Productivity
+Blood Injection : ER Emergency Doctor ER injection,FAMILY,3.5,246,35M,50000,Free,0,Teen,Casual
+Lead'er,FINANCE,4.1,54,5.8M,5000,Free,0,Everyone,Finance
+Doctor Games For Girls - Hospital ER,FAMILY,4.5,51,39M,5000,Free,0,Everyone,Casual
+Open Heart Surgery Hospital ER: Crazy Doctor Sim,FAMILY,4.7,7,25M,1000,Free,0,Teen,Casual
+Hand Doctor Games ER Surgery Simulator,FAMILY,4.1,120,32M,10000,Free,0,Everyone,Casual
+Get SMART ER/LA Opioids,MEDICAL,4.2,0,8.9M,500,Free,0,Everyone,Medical
+ER Doctor City Emergency - Surgery City Doc FREE,FAMILY,3.9,1909,84M,100000,Free,0,Teen,Educational
+ER Hospital Simulator,FAMILY,4.0,286,60M,100000,Free,0,Everyone,Simulation
+DMC ER Now,MEDICAL,4.3,6,5.3M,1000,Free,0,Everyone,Medical
+Nose Surgery ER Simulator Lite,FAMILY,3.1,269,39M,50000,Free,0,Teen,Educational
+FAHREDDİN er-RÂZİ TEFSİRİ,BOOKS_AND_REFERENCE,4.3,9,20M,1000,Free,0,Everyone,Books & Reference
+Cardinal Glennon ER Reference,MEDICAL,4.2,19,20M,1000,Free,0,Everyone 10+,Medical
+The NBC App - Watch Live TV and Full Episodes,FAMILY,4.1,58104,17M,5000000,Free,0,Teen,Entertainment
+Scanner Radio - Fire and Police Scanner,FAMILY,4.4,175509,Varies with device,10000000,Free,0,Everyone,Entertainment
+Fill 'er Up,TRAVEL_AND_LOCAL,3.2,58,18k,5000,Free,0,Everyone,Travel & Local
+SnakeBite911 ER,MEDICAL,4.2,1,42M,500,Free,0,Everyone,Medical
+Ankle Surgery ER Emergency,FAMILY,3.3,10449,29M,1000000,Free,0,Teen,Educational
+Voxer Walkie Talkie Messenger,COMMUNICATION,4.3,230564,Varies with device,10000000,Free,0,Everyone,Communication
+ES File Explorer/Manager PRO,PRODUCTIVITY,4.7,81614,6.6M,500000,Paid,$2.99,Everyone,Productivity
+ES Task Manager (Task Killer ),BUSINESS,4.3,171771,3.2M,10000000,Free,0,Everyone,Business
+ES Audio Player ( Shortcut ),VIDEO_PLAYERS,4.2,1236,33k,100000,Free,0,Everyone,Video Players & Editors
+ES Disk Analyzer - Storage Space,PRODUCTIVITY,4.7,5867,4.4M,100000,Free,0,Everyone,Productivity
+ES App Locker,TOOLS,4.3,32207,3.4M,1000000,Free,0,Everyone,Tools
+ES Chromecast plugin,LIBRARIES_AND_DEMO,4.2,23859,860k,1000000,Free,0,Everyone,Libraries & Demo
+ES Material Theme for Pro,PRODUCTIVITY,4.2,14428,1.2M,1000000,Free,0,Everyone,Productivity
+ES Holo Theme for Pro,PRODUCTIVITY,4.2,4737,1.7M,500000,Free,0,Everyone,Productivity
+ES File Explorer,TOOLS,4.1,278,2.8M,100000,Free,0,Everyone,Tools
+ES Dark Theme for free,TOOLS,4.2,7851,364k,1000000,Free,0,Everyone,Tools
+ES Classic Theme,TOOLS,4.3,20865,2.2M,1000000,Free,0,Everyone,Tools
+ES Themes -- Classic Theme,PERSONALIZATION,4.4,77609,1.9M,1000000,Free,0,Everyone,Personalization
+ES Holo Theme,TOOLS,4.3,11449,1.7M,500000,Free,0,Everyone,Tools
+"ES File Explorer & Manager, Locker Xplorer 2018",TOOLS,3.5,11,3.0M,1000,Free,0,Everyone,Tools
+ES Summer Chill Theme for Free,TOOLS,4.3,940,387k,100000,Free,0,Everyone,Tools
+Furrion ES Control,VIDEO_PLAYERS,1.8,26,2.7M,5000,Free,0,Everyone,Video Players & Editors
+OpenGL ES Extensions - The OpenGL Utility,TOOLS,4.2,513,2.0M,50000,Free,0,Everyone,Tools
+File Ex - ES File Explorer,TOOLS,4.2,24,5.0M,1000,Free,0,Everyone,Tools
+OpenGL ES CapsViewer,TOOLS,4.6,78,375k,10000,Free,0,Everyone,Tools
+ES-IPTV,VIDEO_PLAYERS,4.0,944,11M,50000,Free,0,Everyone,Video Players & Editors
+OpenGL-ES Info,TOOLS,4.3,249,626k,10000,Free,0,Everyone,Tools
+Dr. ES PV Calculator,TOOLS,5.0,19,11M,500,Free,0,Everyone,Tools
+ES File Explorer & File Manager 2018,TOOLS,3.8,24,2.9M,5000,Free,0,Everyone,Tools
+HTC Sense Input - ES,TOOLS,4.3,3509,6.5M,1000000,Free,0,Everyone,Tools
+2019 Tricks Es File Explores,TOOLS,3.0,4,2.0M,1000,Free,0,Everyone,Tools
+ES Billing System (Offline App),PRODUCTIVITY,5.0,1,4.2M,100,Free,0,Everyone,Productivity
+ES Anywhere,BUSINESS,4.7,10,Varies with device,100,Free,0,Everyone,Business
+YEBIS OpenGL ES 3.0 Tech Demo,FAMILY,4.6,380,6.7M,10000,Free,0,Everyone,Entertainment
+RAR,TOOLS,4.4,669901,Varies with device,50000000,Free,0,Everyone,Tools
+Advanced calculator fx 991 es plus & 991 ms plus,FAMILY,4.7,7252,9.2M,500000,Free,0,Everyone,Education
+ES Solar,BUSINESS,5.0,3,4.7M,100,Free,0,Everyone,Business
+File Manager by Xiaomi: release file storage space,TOOLS,4.8,337532,15M,10000000,Free,0,Everyone,Tools
+ESLock File Recovery Lite,PRODUCTIVITY,3.0,460,161k,50000,Free,0,Everyone,Productivity
+Castle Clash: Epic Empire ES,FAMILY,4.6,584070,24M,5000000,Free,0,Everyone 10+,Strategy
+¿Es Vegan?,FOOD_AND_DRINK,4.6,438,1.7M,10000,Free,0,Everyone,Food & Drink
+ES-1,COMMUNICATION,4.2,6,2.7M,500,Free,0,Everyone,Communication
+Moto File Manager,TOOLS,4.1,38679,5.9M,10000000,Free,0,Everyone,Tools
+School scientific calculator fx 500 es plus 500 ms,FAMILY,4.6,1553,9.2M,100000,Free,0,Everyone,Education
+Esto Es Guerra TVN,FAMILY,4.5,1303,13M,100000,Free,0,Everyone,Entertainment
+Economic Times : Market News,NEWS_AND_MAGAZINES,4.3,93708,Varies with device,5000000,Free,0,Everyone,News & Magazines
+ET Markets : NSE & BSE India,FINANCE,4.2,24980,9.2M,1000000,Free,0,Everyone,Finance
+HBO NOW: Stream TV & Movies,FAMILY,3.9,61230,Varies with device,10000000,Free,0,Teen,Entertainment
+ET Telecom from Economic Times,NEWS_AND_MAGAZINES,4.7,273,6.3M,10000,Free,0,Everyone,News & Magazines
+Égalité et Réconciliation,NEWS_AND_MAGAZINES,4.9,58,3.8M,500,Paid,$2.99,Everyone,News & Magazines
+Economic Times : Market News Go Edition,NEWS_AND_MAGAZINES,4.3,39,4.2M,5000,Free,0,Everyone,News & Magazines
+Hymnes et Louanges,BOOKS_AND_REFERENCE,4.4,1877,5.7M,100000,Free,0,Everyone,Books & Reference
+Lire avec Sami et Julie,FAMILY,3.6,569,18M,100000,Free,0,Everyone,Educational;Education
+Lettre et demande d'emploi,FAMILY,4.6,302,9.9M,100000,Free,0,Everyone,Education
+MAPS.ME – Offline Map and Travel Navigation,TRAVEL_AND_LOCAL,4.5,932870,Varies with device,50000000,Free,0,Everyone,Travel & Local
+Recettes Faciles et Rapides,FOOD_AND_DRINK,4.2,95,12M,50000,Free,0,Everyone,Food & Drink
+Blagues et Histoires Drôles,FAMILY,3.9,859,5.3M,100000,Free,0,Teen,Entertainment
+Lettre de motivation et CV,FAMILY,4.3,979,9.9M,100000,Free,0,Everyone,Education
+Anime et Manga Amino en Français,SOCIAL,4.8,3782,63M,50000,Free,0,Teen,Social
+Google Arts & Culture,FAMILY,3.7,24137,Varies with device,5000000,Free,0,Everyone,Education
+"Moneycontrol – Stocks, Sensex, Mutual Funds, IPO",FINANCE,4.4,281635,Varies with device,5000000,Free,0,Everyone,Finance
+CNBC: Breaking Business News & Live Market Data,FINANCE,4.2,24666,Varies with device,1000000,Free,0,Everyone,Finance
+Google Earth,TRAVEL_AND_LOCAL,4.3,2339098,Varies with device,100000000,Free,0,Everyone,Travel & Local
+"Groupon - Shop Deals, Discounts & Coupons",SHOPPING,4.6,1371082,Varies with device,50000000,Free,0,Teen,Shopping
+"Photo Lab Picture Editor: face effects, art frames",PHOTOGRAPHY,4.5,1536512,Varies with device,50000000,Free,0,Everyone,Photography
+Google News,NEWS_AND_MAGAZINES,3.9,878065,13M,1000000000,Free,0,Teen,News & Magazines
+Empires and Allies,FAMILY,4.3,398746,Varies with device,10000000,Free,0,Everyone 10+,Strategy
+Beauty and the Beast,FAMILY,4.4,70883,31M,1000000,Free,0,Everyone,Puzzle;Creativity
+Hornet - Gay Social Network,SOCIAL,4.0,163679,Varies with device,5000000,Free,0,Mature 17+,Social
+Learn Italian with MosaLingua,FAMILY,4.7,1719,Varies with device,50000,Paid,$4.99,Teen,Education
+iTranslate Translator & Dictionary,PRODUCTIVITY,4.3,201718,35M,10000000,Free,0,Everyone,Productivity
+Oggy,GAME,4.5,49971,61M,5000000,Free,0,Everyone,Arcade
+MomentCam Cartoons & Stickers,PHOTOGRAPHY,4.2,1260143,Varies with device,50000000,Free,0,Everyone,Photography
+News by The Times of India Newspaper - Latest News,NEWS_AND_MAGAZINES,4.2,522205,Varies with device,10000000,Free,0,Everyone,News & Magazines
+Amino: Communities and Chats,SOCIAL,4.8,1264084,62M,10000000,Free,0,Teen,Social
+Nike Training Club - Workouts & Fitness Plans,HEALTH_AND_FITNESS,4.6,251618,93M,10000000,Free,0,Everyone,Health & Fitness
+Pocket Mortys,FAMILY,4.5,174215,93M,10000000,Free,0,Everyone,Simulation
+Hangouts Dialer - Call Phones,COMMUNICATION,4.0,122512,79k,10000000,Free,0,Everyone,Communication
+"Ideal Weight, BMI Calculator",HEALTH_AND_FITNESS,4.2,112384,5.0M,5000000,Free,0,Everyone,Health & Fitness
+Epson iPrint,TOOLS,4.1,108169,Varies with device,10000000,Free,0,Everyone,Tools
+Offline Maps & Navigation,TRAVEL_AND_LOCAL,4.7,193364,33M,5000000,Free,0,Everyone,Travel & Local
+Voice changer with effects,FAMILY,4.2,1260903,8.7M,50000000,Free,0,Everyone,Entertainment
+Fitness & Bodybuilding,HEALTH_AND_FITNESS,4.6,95201,61M,5000000,Free,0,Everyone,Health & Fitness
+A+ Gallery - Photos & Videos,PHOTOGRAPHY,4.5,223941,Varies with device,10000000,Free,0,Everyone,Photography
+EU Mobile Money,FINANCE,3.9,460,6.1M,100000,Free,0,Everyone,Finance
+European Union Simulator,FAMILY,3.6,688,26M,50000,Free,0,Everyone,Simulation
+EU Charter,BOOKS_AND_REFERENCE,4.6,33,37M,1000,Free,0,Everyone,Books & Reference
+EU Council,COMMUNICATION,4.2,7,19M,1000,Free,0,Everyone,Communication
+EU Flags Free Live Wallpaper,PERSONALIZATION,3.4,730,2.3M,100000,Free,0,Everyone,Personalization
+myLPG.eu,TRAVEL_AND_LOCAL,4.2,556,4.4M,50000,Free,0,Everyone,Travel & Local
+YouCamp EU,TRAVEL_AND_LOCAL,3.4,39,32M,1000,Paid,$2.56,Everyone,Travel & Local
+EU Economy,PRODUCTIVITY,3.6,47,879k,5000,Free,0,Everyone,Productivity
+Flag of European Union,PERSONALIZATION,4.2,36,5.3M,1000,Free,0,Everyone,Personalization
+EU Data Protection,BOOKS_AND_REFERENCE,3.5,29,17M,1000,Free,0,Everyone,Books & Reference
+Flag Of European Union LWP,PERSONALIZATION,4.3,88,4.2M,1000,Free,0,Everyone,Personalization
+European Union Flag LWP,PERSONALIZATION,4.3,3,5.3M,100,Free,0,Everyone,Personalization
+Council Voting Calculator,COMMUNICATION,3.9,33,3.4M,5000,Free,0,Everyone,Communication
+EU Flags Live Wallpaper,PERSONALIZATION,4.3,444,12M,10000,Paid,$0.99,Everyone,Personalization
+EU FTL Calculator,BUSINESS,3.6,60,1.8M,10000,Free,0,Everyone,Business
+The EU Relocation Programme,FAMILY,4.2,27,12M,1000,Free,0,Everyone,Education
+Passenger rights,TRAVEL_AND_LOCAL,3.9,442,2.5M,50000,Free,0,Everyone,Travel & Local
+EU Mobile Money Partenaire Commercial,FINANCE,4.3,70,3.9M,10000,Free,0,Everyone,Finance
+Eurostat Country Profiles,PRODUCTIVITY,3.7,87,2.0M,10000,Free,0,Everyone,Productivity
+EU in the World,FAMILY,4.2,8,7.2M,100,Free,0,Everyone,Entertainment
+My EU,FAMILY,3.8,4,13M,100,Free,0,Everyone,Education
+Invasion: Defend EU,GAME,4.3,7,20M,50,Free,0,Everyone,Arcade
+R-EU-READY,GAME,4.1,13,16M,500,Free,0,Everyone,Trivia
+taxi.eu,TRAVEL_AND_LOCAL,4.1,1865,22M,100000,Free,0,Everyone,Travel & Local
+CVRIA,BUSINESS,4.7,68,3.5M,10000,Free,0,Everyone,Business
+Speed Racing Ultimate 2,GAME,4.1,66894,Varies with device,1000000,Free,0,Everyone 10+,Racing
+EU Flag Live Wallpaper,PERSONALIZATION,4.3,19,2.3M,1000,Free,0,Everyone,Personalization
+TAXLANDIA,FAMILY,1.9,141,65M,1000,Free,0,Everyone,Educational
+European Solidarity Corps,SOCIAL,3.6,9,21M,1000,Free,0,Teen,Social
+Have your say on Europe,COMMUNICATION,3.8,19,21M,500,Free,0,Everyone,Communication
+EU CBRNE Glossary,LIBRARIES_AND_DEMO,4.2,3,20M,500,Free,0,Everyone,Libraries & Demo
+Doorstep EU,NEWS_AND_MAGAZINES,4.5,67,12M,1000,Free,0,Everyone,News & Magazines
+EURES - Your Job in Europe,BUSINESS,2.7,358,2.0M,50000,Free,0,Everyone,Business
+Autoroute.EU,BUSINESS,4.1,10,2.7M,1000,Free,0,Everyone,Business
+Invasive Alien Species Europe,FAMILY,4.5,13,13M,1000,Free,0,Everyone,Education
+Countries of the European Union (Quiz),GAME,4.3,11,7.0M,100,Free,0,Everyone,Trivia
+EU Exit poll,LIFESTYLE,5.0,10,9.4M,100,Free,0,Everyone,Lifestyle
+Schengen/EU App,TOOLS,4.0,24,11M,1000,Free,0,Everyone,Tools
+I Know Stuff,GAME,4.2,214923,Varies with device,5000000,Free,0,Everyone,Trivia
+EU WHO War,FAMILY,4.2,0,1.2M,50,Free,0,Everyone,Education
+Lazionews.eu,NEWS_AND_MAGAZINES,4.1,25,18M,1000,Free,0,Everyone,News & Magazines
+Brexit EU,FAMILY,4.4,7,7.5M,500,Free,0,Everyone,Casual
+Eu sou Rico,FINANCE,4.1,0,2.6M,0,Paid,$30.99,Everyone,Finance
+EU Life Explorer,NEWS_AND_MAGAZINES,4.0,2,12M,50,Free,0,Everyone,News & Magazines
+E.U. Trademark Search Tool,BUSINESS,4.1,0,3.1M,10,Free,0,Everyone,Business
+EU VAT Checker,BUSINESS,3.1,7,39k,1000,Free,0,Everyone,Business
+Dotti EU,BUSINESS,4.1,15,4.3M,1000,Free,0,Everyone,Business
+EU RCD Guide,BOOKS_AND_REFERENCE,4.3,0,45M,10,Paid,$3.61,Everyone,Books & Reference
+daskal.eu,FAMILY,5.0,5,15M,50,Free,0,Everyone,Education
+Intra- and extra-EU trade data,FINANCE,4.1,1,2.5M,100,Free,0,Everyone,Finance
+Programi podrške EU,COMMUNICATION,4.2,0,5.4M,100,Free,0,Everyone,Communication
+EU FP7 Adventure,BUSINESS,4.1,2,5.2M,100,Free,0,Everyone,Business
+GastroHunter.EU,LIFESTYLE,4.1,1,1.5M,10,Free,0,Everyone,Lifestyle
+EU IP Codes,BOOKS_AND_REFERENCE,4.3,2,970k,100,Free,0,Everyone,Books & Reference
+Eu Sou Rico,FINANCE,4.1,0,1.4M,0,Paid,$394.99,Everyone,Finance
+MOTOBAZAR EU,LIFESTYLE,4.1,1,2.0M,100,Free,0,Everyone,Lifestyle
+TattooSupplies.eu,SHOPPING,4.3,31,34M,1000,Free,0,Everyone,Shopping
+IF YOU TO EU PEGO,FAMILY,4.2,3,2.1M,100,Paid,$1.26,Everyone,Entertainment
+VAT Checker for EU company,BUSINESS,4.7,78,Varies with device,1000,Free,0,Everyone,Business
+Inbox.eu,COMMUNICATION,3.7,98,9.7M,10000,Free,0,Everyone,Communication
+CALIOPE EU: Air Quality,HEALTH_AND_FITNESS,3.9,21,2.2M,1000,Free,0,Everyone,Health & Fitness
+Konferencija.eu,BUSINESS,4.1,3,1.6M,10,Free,0,Everyone,Business
+Reisedealz.eu,SOCIAL,4.3,0,10M,10,Free,0,Everyone,Social
+Going Abroad,FAMILY,3.0,606,42M,50000,Free,0,Everyone 10+,Educational
+EU GDPR RiskCalc,BUSINESS,4.1,1,13M,50,Free,0,Everyone,Business
+EU Whoiswho,BUSINESS,4.1,0,2.7M,10,Free,0,Everyone,Business
+EU Brazil Green Business Forum,PRODUCTIVITY,4.2,0,8.7M,10,Free,0,Everyone,Productivity
+EU-Schwerbehinderung,NEWS_AND_MAGAZINES,4.1,3,32M,100,Free,0,Everyone 10+,News & Magazines
+SK Bosnia Online EU Teplice,SPORTS,4.2,2,10M,5,Free,0,Everyone,Sports
+Campervan.Guide Pro,TRAVEL_AND_LOCAL,4.2,238,67M,10000,Paid,$5.99,Everyone,Travel & Local
+Qserve EU MDR First Aid,BUSINESS,3.0,2,17M,100,Free,0,Everyone,Business
+I'm Rich/Eu sou Rico/أنا غني/我很有錢,LIFESTYLE,4.1,0,40M,0,Paid,$399.99,Everyone,Lifestyle
+TrainPal EU- Book German Train Tickets,MAPS_AND_NAVIGATION,4.1,1,21M,100,Free,0,Everyone,Maps & Navigation
+Strawberry Shortcake Ice Cream Island,FAMILY,4.2,32200,15M,5000000,Free,0,Everyone,Casual;Pretend Play
+NativeScript Developer Day EU,BUSINESS,4.1,2,12M,100,Free,0,Everyone,Business
+EU FP7 SAM,BUSINESS,4.1,0,9.7M,10,Free,0,Everyone,Business
+Rail Planner Eurail/Interrail,MAPS_AND_NAVIGATION,4.2,3596,31M,1000000,Free,0,Everyone,Maps & Navigation
+eu sou franky,BUSINESS,3.7,195,4.0M,10000,Free,0,Everyone,Business
+Tasker,TOOLS,4.6,43045,Varies with device,1000000,Paid,$2.99,Everyone,Tools
+efootwear.eu - online store,SHOPPING,4.5,928,8.6M,100000,Free,0,Everyone,Shopping
+ChargeHub - Find EV & Tesla Charging Stations,MAPS_AND_NAVIGATION,4.6,796,25M,50000,Free,0,Everyone,Maps & Navigation
+PlugShare,MAPS_AND_NAVIGATION,4.7,4501,26M,100000,Free,0,Teen,Maps & Navigation
+NEXTCHARGE - Charging Stations,MAPS_AND_NAVIGATION,4.3,891,6.4M,50000,Free,0,Everyone,Maps & Navigation
+NissanConnect® EV & Services,LIFESTYLE,2.3,853,88M,50000,Free,0,Everyone,Lifestyle
+EV Connect,MAPS_AND_NAVIGATION,2.8,25,5.8M,1000,Free,0,Everyone,Maps & Navigation
+HondaLink EV,TOOLS,2.8,44,41M,10000,Free,0,Everyone,Tools
+EV Stations Hawaii,MAPS_AND_NAVIGATION,3.6,7,2.5M,1000,Free,0,Everyone,Maps & Navigation
+Emerge EV App (eBike App),LIFESTYLE,3.0,26,Varies with device,1000,Free,0,Everyone,Lifestyle
+EV Trip Optimizer for Tesla,AUTO_AND_VEHICLES,3.2,46,6.6M,1000,Free,0,Everyone,Auto & Vehicles
+JuiceNet - Smart EV Charging,MAPS_AND_NAVIGATION,3.5,106,24M,5000,Free,0,Everyone,Maps & Navigation
+Zap-Map: EV charging points UK,MAPS_AND_NAVIGATION,3.8,181,9.8M,10000,Free,0,Everyone,Maps & Navigation
+EV Charging,MAPS_AND_NAVIGATION,3.5,8,32M,1000,Free,0,Everyone,Maps & Navigation
+Simple EV Calc,PRODUCTIVITY,4.2,105,72M,1000,Free,0,Everyone,Productivity
+CHOSEN - EV Smart Charger,AUTO_AND_VEHICLES,4.2,1,19M,10,Free,0,Everyone,Auto & Vehicles
+Electric Car Charging Points: Ev charger Stations,MAPS_AND_NAVIGATION,4.5,8,8.1M,100,Free,0,Everyone,Maps & Navigation
+ELMO EV Charging,MAPS_AND_NAVIGATION,3.4,14,6.2M,1000,Free,0,Everyone,Maps & Navigation
+Bolt - EV Charging Service,AUTO_AND_VEHICLES,3.0,9,8.4M,100,Free,0,Everyone,Auto & Vehicles
+To-U - free EV public charging,TRAVEL_AND_LOCAL,4.4,75,19M,1000,Free,0,Everyone,Travel & Local
+Light Meter - EV,PHOTOGRAPHY,4.0,26,8.5M,1000,Free,0,Everyone,Photography
+Mas Akıllı Ev,HOUSE_AND_HOME,4.2,13,43M,100,Free,0,Everyone,House & Home
+EV Finder,TOOLS,4.3,29,23M,1000,Free,0,Everyone,Tools
+SpeedApp EV,AUTO_AND_VEHICLES,4.2,0,48M,5,Free,0,Everyone,Auto & Vehicles
+EV Real Estate Search,LIFESTYLE,4.1,88,20M,5000,Free,0,Everyone,Lifestyle
+Ev Dizayn,LIFESTYLE,3.6,30,5.2M,5000,Free,0,Everyone,Lifestyle
+Power Plug EV charger,MAPS_AND_NAVIGATION,3.7,13,3.9M,1000,Free,0,Everyone,Maps & Navigation
+Builder Craft: House Building & Exploration,FAMILY,4.2,20807,52M,1000000,Free,0,Everyone 10+,Simulation
+Texas Hold'em EV Calculator,TOOLS,3.7,6,1.3M,1000,Free,0,Everyone,Tools
+Bird - Enjoy The Ride,TRAVEL_AND_LOCAL,4.3,2649,25M,500000,Free,0,Everyone,Travel & Local
+AÖF Ev İdaresi 1. Sınıf,FAMILY,4.2,2,11M,1000,Free,0,Everyone,Education
+EV Bon Dictionary,FAMILY,4.2,11,16M,500,Free,0,Everyone,Education
+German Vocabulary Trainer,FAMILY,3.3,1218,1.0M,100000,Free,0,Everyone,Education
+REV Robotic Enhance Vehicles,FAMILY,4.4,2558,61M,100000,Free,0,Everyone,Entertainment
+Home Workout - No Equipment,HEALTH_AND_FITNESS,4.8,432160,15M,10000000,Free,0,Everyone,Health & Fitness
+myChevrolet,LIFESTYLE,3.5,6747,Varies with device,1000000,Free,0,Everyone,Lifestyle
+Electric Car Taxi Driver: NY City Cab Taxi Games,FAMILY,4.0,5886,54M,1000000,Free,0,Everyone,Simulation
+EV Calculator,TOOLS,4.9,85,19M,1000,Free,0,Everyone,Tools
+Home Decoration Game,FAMILY,4.0,17543,19M,5000000,Free,0,Everyone,Casual
+EvAk Smart Home,LIFESTYLE,4.1,14,Varies with device,500,Free,0,Everyone,Lifestyle
+PokeType - Dex,FAMILY,4.6,36813,33M,500000,Free,0,Everyone,Entertainment
+Home Security Camera WardenCam - reuse old phones,HOUSE_AND_HOME,4.3,43847,Varies with device,1000000,Free,0,Everyone,House & Home
+Survival Forest : Survivor Home Builder,FAMILY,3.6,9389,64M,1000000,Free,0,Teen,Simulation
+Room Creator Interior Design,HOUSE_AND_HOME,3.9,59660,72M,1000000,Free,0,Everyone,House & Home
+Doll House Design & Decoration 2: Girls House Game,FAMILY,3.9,2338,45M,100000,Free,0,Everyone,Simulation
+Lux Home Decorating Room Games,FAMILY,4.0,1518,Varies with device,100000,Free,0,Everyone,Casual
+eCooltra: scooter sharing. Share electric scooters,TRAVEL_AND_LOCAL,4.2,2822,27M,100000,Free,0,Everyone,Travel & Local
+Design Home,FAMILY,4.4,539931,69M,10000000,Free,0,Everyone,Simulation
+E.W. James & Sons,SHOPPING,4.3,2,4.9M,500,Free,0,Everyone,Shopping
+EW Manager,BUSINESS,4.1,0,4.4M,10,Free,0,Everyone,Business
+PeopleTV - Watch Celebrity News,FAMILY,4.3,2223,8.6M,100000,Free,0,Teen,Entertainment
+ew-Magazin,NEWS_AND_MAGAZINES,4.1,2,13M,100,Free,0,Everyone,News & Magazines
+EW PDF,BOOKS_AND_REFERENCE,4.3,0,8.7M,5,Free,0,Everyone,Books & Reference
+EW Gate,BUSINESS,4.1,0,12M,50,Free,0,Everyone,Business
+E W Bookkeeping & Accountancy,FINANCE,4.1,1,29M,100,Free,0,Everyone,Finance
+News 5 Cleveland,NEWS_AND_MAGAZINES,3.7,1032,Varies with device,100000,Free,0,Everyone,News & Magazines
+EW Login,BUSINESS,4.1,0,5.8M,10,Free,0,Everyone,Business
+Water Surfer Racing In Moto,GAME,4.3,2233,36M,1000000,Free,0,Everyone,Racing
+EW Handbook,BUSINESS,4.1,1,17M,100,Free,0,Everyone,Business
+Mee-EW,TOOLS,4.0,0,17M,5,Free,0,Everyone,Tools
+EW Widgets for Zooper,TOOLS,3.4,5,1.9M,100,Free,0,Everyone,Tools
+"Ew, the small alien",GAME,4.3,5,Varies with device,10,Free,0,Everyone,Adventure
+The List,NEWS_AND_MAGAZINES,3.5,66,12M,10000,Free,0,Everyone,News & Magazines
+EW MOTION THERAPY,HEALTH_AND_FITNESS,4.3,0,7.1M,10,Free,0,Everyone,Health & Fitness
+European War 6: 1804,FAMILY,4.2,1330,96M,10000,Paid,$0.99,Teen,Strategy
+XCOM®: Enemy Within,FAMILY,4.2,13752,21M,100000,Paid,$9.99,Mature 17+,Strategy
+EW Neuron Scan,TOOLS,4.0,1,6.5M,10,Free,0,Everyone,Tools
+ABC15 Arizona,NEWS_AND_MAGAZINES,3.6,1820,Varies with device,100000,Free,0,Everyone,News & Magazines
+NATIVE ENTERTAINMENT MAGAZINE - ISSUE # 1,NEWS_AND_MAGAZINES,4.1,0,62M,10,Free,0,Mature 17+,News & Magazines
+Mobile Strike,FAMILY,3.9,903392,Varies with device,50000000,Free,0,Everyone 10+,Strategy
+European War 5:Empire,FAMILY,3.8,9513,82M,100000,Free,0,Everyone 10+,Strategy
+KMTV 3 News Now,NEWS_AND_MAGAZINES,3.8,265,Varies with device,10000,Free,0,Everyone 10+,News & Magazines
+Rescue Robots Survival Games,GAME,4.0,27557,69M,5000000,Free,0,Teen,Action
+Raytheon F-16 EW 360 VR,FAMILY,4.5,6,22M,500,Free,0,Everyone,Entertainment
+Pregnant Emergency Surgery,FAMILY,3.8,127229,34M,10000000,Free,0,Everyone,Casual
+Eddsworld Amino,SOCIAL,4.9,3071,63M,10000,Free,0,Teen,Social
+TMJ4.com - WTMJ-TV Milwaukee,NEWS_AND_MAGAZINES,3.8,728,Varies with device,50000,Free,0,Everyone 10+,News & Magazines
+Food Network,FAMILY,4.1,7823,Varies with device,500000,Free,0,Teen,Entertainment
+Storm Shield,WEATHER,3.5,2000,14M,100000,Free,0,Everyone,Weather
+EdiRange,TOOLS,3.0,736,1.8M,100000,Free,0,Everyone,Tools
+TRANSFORMERS: Earth Wars,FAMILY,4.5,256219,95M,10000000,Free,0,Everyone,Strategy
+Beard Live Camera Photo Editor,BEAUTY,4.7,900,30M,5000,Free,0,Everyone,Beauty
+WPTV 5 West Palm Beach,NEWS_AND_MAGAZINES,3.8,1093,Varies with device,100000,Free,0,Everyone 10+,News & Magazines
+No Pimple - Fun games,FAMILY,3.3,24091,16M,5000000,Free,0,Teen,Casual
+WKBW 7 Eyewitness News,NEWS_AND_MAGAZINES,4.0,509,Varies with device,50000,Free,0,Everyone,News & Magazines
+Web Browser for Android,COMMUNICATION,4.1,55110,4.3M,1000000,Free,0,Everyone,Communication
+OMG Gross Zit - Date Nightmare,FAMILY,3.7,70105,67M,10000000,Free,0,Everyone,Casual
+Garden Fever - Free!,FAMILY,3.9,13253,12M,1000000,Free,0,Everyone,Puzzle
+GO SMS PRO EMOJI PLUGIN,PERSONALIZATION,3.5,84779,8.5M,5000000,Free,0,Everyone,Personalization
+Bike Race - Bike Blast Rush,GAME,4.4,83891,48M,10000000,Free,0,Everyone,Action
+Subway Simulator 3D,FAMILY,4.0,25489,62M,1000000,Free,0,Everyone,Simulation
+XCOM: TBG,FAMILY,4.0,2294,95M,100000,Free,0,Everyone,Entertainment
+ETERNITY WARRIORS 2,GAME,4.6,568391,5.2M,5000000,Free,0,Teen,Action
+XE Currency,TRAVEL_AND_LOCAL,4.4,77585,Varies with device,10000000,Free,0,Everyone,Travel & Local
+Deus Ex GO,FAMILY,4.5,9699,23M,100000,Paid,$0.99,Teen,Puzzle
+ADWLauncher 1 EX,PERSONALIZATION,4.3,28728,2.8M,500000,Paid,$2.49,Everyone,Personalization
+XE Currency Pro,TRAVEL_AND_LOCAL,4.4,1090,Varies with device,10000,Paid,$1.99,Everyone,Travel & Local
+GO Launcher EX UI5.0 theme,PERSONALIZATION,4.3,111634,13M,5000000,Free,0,Everyone,Personalization
+Device Info Ex Live Wallpaper,PERSONALIZATION,4.1,2645,1.1M,50000,Paid,$0.99,Everyone,Personalization
+GO Weather EX Theme White,WEATHER,4.2,8723,4.6M,500000,Free,0,Everyone,Weather
+Advanced EX for HYUNDAI,TOOLS,2.7,168,170k,5000,Paid,$4.99,Everyone,Tools
+MIUI Style GO Weather EX,WEATHER,4.2,2115,1.1M,500000,Free,0,Everyone,Weather
+Remote EX for NISSAN,COMMUNICATION,2.3,223,1.0M,5000,Paid,$1.49,Everyone,Communication
+Ex Explorer : Dual view exproler / file manager,TOOLS,3.9,361,Varies with device,50000,Free,0,Everyone,Tools
+Get Over Your Ex,DATING,4.1,10,11M,5000,Free,0,Everyone,Dating
+Advanced EX for MITSUBISHI,TOOLS,2.9,33,141k,1000,Paid,$4.99,Everyone,Tools
+Advanced EX for KIA,TOOLS,3.3,257,160k,5000,Paid,$4.99,Everyone,Tools
+Money Manager Ex for Android,FINANCE,4.2,2695,Varies with device,100000,Free,0,Everyone,Finance
+Airway Ex - Intubate. Anesthetize. Train.,MEDICAL,4.3,123,86M,10000,Free,0,Everyone,Medical
+Advanced EX for NISSAN,TOOLS,2.9,164,144k,5000,Paid,$4.99,Everyone,Tools
+Advanced EX for FIAT,TOOLS,3.5,138,141k,5000,Paid,$4.99,Everyone,Tools
+Advanced EX for RENAULT,TOOLS,2.8,130,143k,5000,Paid,$4.99,Everyone,Tools
+EX File Explorer File Manage Pro,PRODUCTIVITY,4.2,1,6.3M,50,Paid,$1.99,Everyone,Productivity
+Aurum Blade EX,FAMILY,4.3,28151,17M,1000000,Free,0,Everyone 10+,Role Playing
+SCI-Ex,HEALTH_AND_FITNESS,3.5,8,7.9M,1000,Free,0,Everyone,Health & Fitness
+Papyrus Ex,TOOLS,4.6,1092,190k,100000,Free,0,Everyone,Tools
+GLASS GO Launcher EX Theme,PERSONALIZATION,4.2,18280,6.0M,1000000,Free,0,Everyone,Personalization
+Moonlight GO Weather EX,WEATHER,4.2,11510,3.5M,1000000,Free,0,Everyone,Weather
+My Ex Girlfriend Comes Back,FAMILY,3.7,3258,26M,500000,Free,0,Everyone,Casual
+An Elite Warrior Ex,GAME,4.7,15,93M,100,Paid,$0.99,Everyone,Adventure
+Gods Wars Ex : Vampire,FAMILY,3.9,1550,21M,100000,Free,0,Teen,Role Playing
+BakaReader EX,BOOKS_AND_REFERENCE,4.3,8894,2.3M,100000,Free,0,Everyone,Books & Reference
+Snes9x EX+,GAME,4.4,70351,Varies with device,5000000,Free,0,Everyone,Arcade
+X your Ex - Break Up Treatment,HEALTH_AND_FITNESS,4.0,32,64M,5000,Free,0,Everyone,Health & Fitness
+Ex Quotes,LIFESTYLE,4.4,129,8.1M,50000,Free,0,Everyone 10+,Lifestyle
+GO Contacts EX Black & Grey,PERSONALIZATION,3.7,21,376k,500,Paid,$0.99,Everyone,Personalization
+CYANOGEN GO Launcher EX Theme,PERSONALIZATION,4.3,60298,13M,5000000,Free,0,Everyone,Personalization
+Ex Service Taxis,BUSINESS,3.5,15,8.0M,1000,Free,0,Everyone,Business
+Rejoin Your Ex,SOCIAL,4.3,0,29M,100,Free,0,Everyone,Social
+S.O.L : Stone of Life EX,FAMILY,4.3,171220,42M,5000000,Free,0,Everyone 10+,Role Playing
+How To Get Your Ex Back Fast,LIFESTYLE,4.0,22,19M,5000,Free,0,Everyone,Lifestyle
+ExDialer PRO Key,COMMUNICATION,4.5,5474,17k,100000,Paid,$3.99,Everyone,Communication
+Volume Control Ex,TOOLS,4.2,5,2.5M,100,Paid,$1.49,Everyone,Tools
+Virtual Dice EX,GAME,4.3,40,3.6M,5000,Free,0,Everyone,Board
+Black Theme Go Launcher EX,PERSONALIZATION,4.1,285,3.9M,50000,Free,0,Teen,Personalization
+EY Events,BUSINESS,2.5,31,54M,10000,Free,0,Everyone,Business
+EY GlobalOne,BUSINESS,2.7,11,6.8M,1000,Free,0,Everyone,Business
+EY Team Connect,PRODUCTIVITY,4.2,0,38M,50,Free,0,Everyone,Productivity
+EY eMentor,FAMILY,4.2,5,44M,500,Free,0,Everyone,Education
+EY Conferences,BUSINESS,4.1,1,30M,1000,Free,0,Everyone,Business
+EY Africa,BUSINESS,4.1,0,8.4M,100,Free,0,Everyone,Business
+EY TaxChat,FINANCE,1.2,44,27M,1000,Free,0,Everyone,Finance
+EY Expenses,FINANCE,4.1,0,10M,1000,Free,0,Everyone,Finance
+EY Tax Briefing,BUSINESS,4.1,3,15M,100,Free,0,Everyone,Business
+EY Digital Direct,BUSINESS,4.1,0,27M,5,Free,0,Everyone,Business
+EY India Tax Insights,BUSINESS,4.7,87,5.1M,10000,Free,0,Everyone,Business
+EY Forensics,FINANCE,4.9,7,3.4M,1000,Free,0,Everyone,Finance
+EY India CFO Insights,BUSINESS,4.7,37,10M,5000,Free,0,Everyone,Business
+EY Digital Tax AR,BUSINESS,4.1,2,19M,100,Free,0,Everyone,Business
+EY Divest,BUSINESS,4.1,0,54M,5,Free,0,Everyone,Business
+EY ATL Fuel Calculator,PRODUCTIVITY,4.4,15,3.1M,500,Free,0,Everyone,Productivity
+Fuel Calculator for EY,TOOLS,4.7,32,2.7M,1000,Free,0,Everyone,Tools
+EY Digi India Personal Tax,BUSINESS,4.0,2,1.7M,100,Free,0,Everyone,Business
+EY Catalyst Reader,BUSINESS,4.1,1,8.4M,5,Free,0,Everyone,Business
+Pink Guy - Ey B0ss,FAMILY,4.7,13,1.2M,500,Free,0,Everyone,Entertainment
+EY Staff ENTERTAINER,LIFESTYLE,4.3,218,19M,10000,Free,0,Everyone,Lifestyle
+EY EMEIA Diversity & Inclusion,BUSINESS,4.1,4,12M,500,Free,0,Everyone,Business
+Ey Sey Storytime រឿងនិទានតាឥសី,FAMILY,4.7,1327,44M,10000,Free,0,Everyone,Education;Education
+EY Football,SPORTS,4.2,0,26M,10,Free,0,Everyone,Sports
+Eyes - The Scary Horror Game Adventure,GAME,4.4,499483,99M,10000000,Free,0,Teen,Adventure
+Amleen Ey,SOCIAL,4.3,0,19M,1,Free,0,Everyone,Social
+EY Events Switzerland,PRODUCTIVITY,4.2,1,18M,500,Free,0,Teen,Productivity
+EY TaxLaw NL,BUSINESS,4.1,9,3.3M,100,Free,0,Everyone,Business
+EY-Parthenon,BUSINESS,4.1,1,30M,5,Free,0,Everyone,Business
+EY Belgium Inhouse Day 2018,EVENTS,4.4,0,24M,10,Free,0,Everyone,Events
+Tenh Ey,SHOPPING,4.3,0,4.5M,10,Free,0,Everyone,Shopping
+EY Oil & Gas,BUSINESS,4.6,20,15M,1000,Free,0,Everyone,Business
+Coupe Adhémar EY 2017,SOCIAL,4.3,6,10M,50,Free,0,Teen,Social
+哈哈姆特不EY,COMMUNICATION,4.2,239,18M,10000,Free,0,Everyone,Communication
+Adhenarcos - Coupe Adhemar EY 2018,FAMILY,4.2,0,13M,100,Free,0,Teen,Entertainment
+Third Eye,TOOLS,4.4,19877,4.5M,1000000,Free,0,Everyone,Tools
+Sudoku Master,GAME,4.4,58387,3.3M,1000000,Free,0,Everyone,Word
+Jungle Monkey Run,GAME,4.4,54082,21M,10000000,Free,0,Everyone,Adventure
+Hey That's Pretty Good!,TOOLS,4.6,222,10M,10000,Free,0,Everyone,Tools
+Everbridge,COMMUNICATION,3.1,497,36M,100000,Free,0,Everyone,Communication
+I am Dentist - Save my Teeth,FAMILY,4.3,7443,33M,100000,Free,0,Everyone,Casual
+Best Auto Call Recorder Free,COMMUNICATION,3.7,7,4.3M,500,Free,0,Everyone,Communication
+FilterGrid - Cam&Photo Editor,PHOTOGRAPHY,4.6,126338,9.6M,1000000,Free,0,Everyone,Photography
+EyPools,HOUSE_AND_HOME,4.2,2,656k,100,Free,0,Everyone,House & Home
+Etihad Airways,TRAVEL_AND_LOCAL,4.1,3674,61M,500000,Free,0,Everyone,Travel & Local
+Beach Volleyball 3D,SPORTS,4.2,43191,14M,5000000,Free,0,Everyone,Sports
+Organizer,PRODUCTIVITY,4.4,936,5.4M,50000,Paid,$2.99,Everyone,Productivity
+EZ Video Download for Facebook,SOCIAL,4.1,34079,1.3M,1000000,Free,0,Teen,Social
+EZCast – Cast Media to TV,VIDEO_PLAYERS,3.6,32112,Varies with device,1000000,Free,0,Everyone,Video Players & Editors
+EZ Cleaner - Booster Optimizer,TOOLS,4.4,6801,2.8M,500000,Free,0,Everyone,Tools
+EZ PZ RPG,FAMILY,3.8,70903,47M,1000000,Free,0,Everyone 10+,Role Playing
+EZ Receipts,FINANCE,4.0,2187,Varies with device,100000,Free,0,Everyone,Finance
+EZ Thanks,BUSINESS,3.2,116,Varies with device,10000,Free,0,Everyone,Business
+EZ Inspections,PRODUCTIVITY,2.8,160,7.6M,10000,Free,0,Everyone,Productivity
+EZ-ELD Update,AUTO_AND_VEHICLES,3.1,14,4.6M,1000,Free,0,Everyone,Auto & Vehicles
+EZ Display,PRODUCTIVITY,2.9,280,10.0M,50000,Free,0,Everyone,Productivity
+EZ Web Video Cast | Chromecast,VIDEO_PLAYERS,4.1,1276,4.6M,100000,Free,0,Everyone,Video Players & Editors
+ez Share Android app,PHOTOGRAPHY,3.3,1461,13M,100000,Free,0,Everyone,Photography
+EZ File Manager(Root Explorer),PRODUCTIVITY,3.5,626,1.2M,100000,Free,0,Everyone,Productivity
+EZ Launcher,PERSONALIZATION,4.2,18926,2.9M,1000000,Free,0,Everyone,Personalization
+EZ-SEE,VIDEO_PLAYERS,2.8,71,10M,10000,Free,0,Everyone,Video Players & Editors
+EZ-ELD Driver App (Free),AUTO_AND_VEHICLES,2.1,83,4.8M,5000,Free,0,Everyone,Auto & Vehicles
+Ez Mirror Match,GAME,4.4,3344,36M,500000,Free,0,Everyone,Arcade
+EZ Notes Lite,PRODUCTIVITY,4.4,69,3.5M,1000,Free,0,Everyone,Productivity
+EZ Bluetooth,TOOLS,4.2,789,Varies with device,50000,Free,0,Everyone,Tools
+Dream EZ,HEALTH_AND_FITNESS,4.1,107,50M,10000,Free,0,Everyone,Health & Fitness
+Ez Texting,BUSINESS,3.3,49,51k,10000,Free,0,Everyone,Business
+EZ TV Player,VIDEO_PLAYERS,3.5,51,11M,10000,Free,0,Everyone,Video Players & Editors
+EZ-GUI Ground Station,TOOLS,4.7,3696,29M,50000,Free,0,Everyone,Tools
+Ez iCam,PHOTOGRAPHY,3.1,7300,46M,1000000,Free,0,Teen,Photography
+E-Z App™ Train Control,TOOLS,4.3,33,46M,1000,Free,0,Everyone,Tools
+EZ App Installer,TOOLS,4.1,533,1.4M,100000,Free,0,Everyone,Tools
+EZ Clock & Weather Widget,WEATHER,4.2,6849,1.2M,1000000,Free,0,Everyone,Weather
+EZ Pass,TOOLS,2.5,15,228k,5000,Free,0,Everyone,Tools
+EZ Usenet for Easynews®,VIDEO_PLAYERS,3.9,244,Varies with device,10000,Free,0,Everyone,Video Players & Editors
+EZ View,BUSINESS,3.0,287,9.8M,50000,Free,0,Everyone,Business
+EZ TAG Express,TRAVEL_AND_LOCAL,3.2,86,39M,10000,Free,0,Everyone,Travel & Local
+EZ Wifi Notification,COMMUNICATION,4.3,260,193k,10000,Free,0,Everyone,Communication
+EZ-VPNGate,TOOLS,4.3,36,12M,5000,Free,0,Everyone,Tools
+EZ Switch Widget,PRODUCTIVITY,4.2,2412,192k,100000,Free,0,Everyone,Productivity
+EZ-Builder Mobile,FAMILY,4.3,51,57M,5000,Free,0,Everyone,Education
+EZ LED,TOOLS,2.2,19,2.1M,1000,Free,0,Everyone,Tools
+F&M Bank - EZ Banking,FINANCE,3.9,49,3.9M,10000,Free,0,Everyone,Finance
+My EZ-Link Mobile,LIFESTYLE,2.8,3187,11M,100000,Free,0,Everyone,Lifestyle
+EZ Financial Calculator,FINANCE,4.4,32,2.3M,1000,Free,0,Everyone,Finance
+EZ Quran,BOOKS_AND_REFERENCE,4.6,595,8.5M,50000,Free,0,Everyone,Books & Reference
+EZ Screenshot,TOOLS,4.4,55,1.4M,5000,Free,0,Everyone,Tools
+EZ Utilities Extension,TOOLS,3.9,33,473k,5000,Free,0,Everyone,Tools
+EZ-Placard - Free Placard Calculator,TOOLS,2.9,7,2.4M,1000,Free,0,Everyone,Tools
+EZ game screen recorder with audio 1080P,VIDEO_PLAYERS,4.1,40,3.9M,1000,Free,0,Everyone,Video Players & Editors
+FA Player Essentials,SPORTS,5.0,7,68M,100,Free,0,Everyone,Sports
+HTC Sense Input - FA,TOOLS,4.6,1420,1.6M,100000,Free,0,Everyone,Tools
+"FEABIE: Feedees, BBW, BHM & FA",DATING,3.7,1212,Varies with device,100000,Free,0,Mature 17+,Dating
+Test Server SMS FA,COMMUNICATION,4.2,0,1.8M,5,Free,0,Everyone,Communication
+"Messages, Text and Video Chat for Messenger",SOCIAL,4.4,49580,4.0M,10000000,Free,0,Everyone,Social
+All Social Networks,SOCIAL,4.2,22650,1.5M,1000000,Free,0,Everyone,Social
+Facebook Face to Face Events,BUSINESS,4.4,4518,26M,1000000,Free,0,Everyone,Business
+FA Part 1 & 2 Past Papers Solved Free – Offline,BOOKS_AND_REFERENCE,3.9,46,3.0M,5000,Free,0,Everyone,Books & Reference
+CNY Slots : Gong Xi Fa Cai 发财机,GAME,3.6,33,71M,5000,Free,0,Teen,Casino
+Il Coccodrillo Come Fa,FAMILY,3.4,17,246k,1000,Free,0,Everyone,Entertainment
+Hertfordshire FA,SPORTS,4.2,0,3.6M,500,Free,0,Everyone,Sports
+Farsi Keyboard,TOOLS,4.3,9716,1.3M,1000000,Free,0,Everyone,Tools
+Premier League - Official App,SPORTS,4.3,63782,24M,5000000,Free,0,Everyone,Sports
+Golden HoYeah Slots - Real Casino Slots,GAME,4.4,201537,68M,5000000,Free,0,Teen,Casino
+Dio Fa Cose,FAMILY,4.2,35,1.3M,1000,Free,0,Everyone,Entertainment
+FaFaFa™ Gold Casino: Free slot machines,GAME,4.3,11051,44M,1000000,Free,0,Teen,Casino
+Messenger Messenger,SOCIAL,4.3,38826,7.0M,10000000,Free,0,Everyone,Social
+F.A Sumon songs,FAMILY,4.2,6,5.4M,1000,Free,0,Everyone,Entertainment
+NCLEX-RN Q&A FLASH CARDS - FA Davis,MEDICAL,4.2,2,7.6M,1000,Free,0,Everyone,Medical
+LEADS FA,FINANCE,4.1,31,14M,1000,Free,0,Everyone,Finance
+Farm Heroes Saga,FAMILY,4.4,7615646,71M,100000000,Free,0,Everyone,Casual
+All AJK Board Matric Fa Fsc Results,FAMILY,4.2,0,2.6M,10,Free,0,Everyone,Education
+ESPN Fantasy Sports,SPORTS,4.0,176487,10M,5000000,Free,0,Everyone,Sports
+Heart of Vegas™ Slots – Free Slot Casino Games,GAME,4.5,264282,48M,10000000,Free,0,Teen,Casino
+Fallout Shelter,FAMILY,4.6,2721923,25M,10000000,Free,0,Teen,Simulation
+Authy 2-Factor Authentication,TOOLS,4.3,15070,6.3M,1000000,Free,0,Everyone,Tools
+Facejjang,PHOTOGRAPHY,4.1,100179,96M,10000000,Free,0,Everyone,Photography
+Block Puzzle - Wood Legend,FAMILY,4.4,318867,10M,10000000,Free,0,Everyone,Puzzle
+Soccer 2018,SPORTS,3.5,172373,47M,10000000,Free,0,Everyone,Sports
+Flash Light on Call & SMS,TOOLS,4.1,25438,3.2M,1000000,Free,0,Everyone,Tools
+Fart sound pranks,FAMILY,3.8,283823,Varies with device,50000000,Free,0,Everyone 10+,Casual
+Facebook Creator,SOCIAL,4.2,3895,Varies with device,1000000,Free,0,Teen,Social
+Swift for Facebook Lite,SOCIAL,4.3,9562,5.8M,500000,Free,0,Teen,Social
+Friendly for Facebook,SOCIAL,4.5,42621,23M,1000000,Free,0,Teen,Social
+Facebook Pages Manager,BUSINESS,4.0,1279800,Varies with device,50000000,Free,0,Everyone,Business
+Mini for fb lite,TOOLS,4.0,710,1.1M,100000,Free,0,Everyone,Tools
+Faster for Facebook Lite,SOCIAL,4.3,24456,4.6M,1000000,Free,0,Teen,Social
+Facebook Ads Manager,BUSINESS,4.1,19051,Varies with device,1000000,Free,0,Everyone,Business
+Who Viewed My FB Profile,FAMILY,3.4,121,6.3M,10000,Free,0,Everyone,Entertainment
+Puffin for Facebook,SOCIAL,4.0,10743,Varies with device,500000,Free,0,Teen,Social
+Lite for Facebook Messenger,COMMUNICATION,4.3,76498,4.3M,1000000,Free,0,Teen,Communication
+Profile Tracker - Who Viewed My Facebook Profile,SOCIAL,4.7,37090,4.8M,500000,Free,0,Teen,Social
+Who viewed my fb profile pro★★,FAMILY,4.5,6396,4.2M,100000,Free,0,Everyone,Entertainment
+Video Downloader For FB: Save FB Videos 2018,TOOLS,4.3,434,3.6M,50000,Free,0,Everyone,Tools
+Pink Color for Facebook,SOCIAL,4.1,5285,4.0M,500000,Free,0,Everyone,Social
+Messenger,SOCIAL,4.1,68025,3.9M,10000000,Free,0,Everyone,Social
+"Stickers for Imo, fb, whatsapp",SOCIAL,4.4,214,8.7M,10000,Free,0,Teen,Social
+Who Viewed My Facebook Profile - Stalkers Visitors,SOCIAL,4.6,273244,9.9M,5000000,Free,0,Everyone,Social
+Downloader plus for FB,SOCIAL,4.3,4,5.1M,500,Free,0,Everyone,Social
+Cover Camera for FB,PHOTOGRAPHY,3.8,742,1.8M,100000,Free,0,Everyone,Photography
+MB Notifications for FB (Free),SOCIAL,3.9,3047,1.5M,100000,Free,0,Teen,Social
+MultiMessage for FB Messenger,PRODUCTIVITY,4.2,182,7.0M,50000,Free,0,Everyone,Productivity
+Messenger Kids – Safer Messaging and Video Chat,FAMILY,4.2,3478,Varies with device,500000,Free,0,Everyone,Communication;Creativity
+FB Live,BUSINESS,3.7,27,18M,5000,Free,0,Everyone,Business
+Phoenix - Facebook & Messenger,SOCIAL,4.3,9606,3.4M,100000,Free,0,Teen,Social
+Faster Social for Facebook,SOCIAL,4.2,1236,3.3M,100000,Free,0,Teen,Social
+Check Your Visitors on FB ?,SOCIAL,3.6,40,1.5M,5000,Free,0,Everyone,Social
+Videos downloader for Facebook:fast fb video saver,VIDEO_PLAYERS,4.3,20,5.1M,5000,Free,0,Everyone,Video Players & Editors
+Stickers for Facebook,SOCIAL,4.3,11066,10M,1000000,Free,0,Everyone,Social
+Video Download For FB,TOOLS,4.3,444,1.6M,100000,Free,0,Everyone,Tools
+Video Downloader for FB : Video Download with Link,VIDEO_PLAYERS,4.5,1060,3.2M,100000,Free,0,Everyone,Video Players & Editors
+Video Downloader for FB,TOOLS,4.3,53,3.0M,5000,Free,0,Everyone,Tools
+FB Photographie,PHOTOGRAPHY,4.7,37,10M,1000,Free,0,Everyone,Photography
+Lite Messenger for Facebook Lite,SOCIAL,3.8,108,2.8M,10000,Free,0,Teen,Social
+Download Facebook Photo Albums,TOOLS,4.0,3840,2.5M,100000,Free,0,Everyone,Tools
+Mini for Facebook lite,SOCIAL,4.1,260,1.3M,10000,Free,0,Teen,Social
+FB Advanced Search,SOCIAL,4.3,2,11M,50,Free,0,Teen,Social
+funny Image Comments for FB,SOCIAL,3.9,19,15M,5000,Free,0,Teen,Social
+IDM for Facebook ★ Downloader,PRODUCTIVITY,4.3,1905,3.1M,100000,Free,0,Everyone,Productivity
+"Unlimited Group Links - Whatsapp, FB, Telegram",SOCIAL,3.4,44,2.8M,10000,Free,0,Mature 17+,Social
+EasyLive - FB Live Helper,BUSINESS,4.1,6,3.7M,500,Free,0,Teen,Business
+HD VideoDownlaoder For Fb : XXVideo Downloader,VIDEO_PLAYERS,4.2,61,6.1M,10000,Free,0,Everyone,Video Players & Editors
+Barca News - app for Barcelona FC Fans,SPORTS,4.5,207,4.5M,10000,Free,0,Everyone,Sports
+FC Barcelona Fantasy Manager: Real football mobile,SPORTS,4.4,15221,30M,1000000,Free,0,Everyone,Sports
+Classic FC 64 IN 1,FAMILY,4.2,1749,6.2M,100000,Free,0,Everyone,Casual
+FC Barcelona Official Keyboard,SPORTS,4.7,5229,20M,500000,Free,0,Everyone,Sports
+Barcelona Live 2018—Goals & News for Barca FC Fans,SPORTS,4.6,342,38M,10000,Free,0,Everyone,Sports
+Barcelona News - Sportfusion,SPORTS,4.4,382,20M,10000,Free,0,Everyone,Sports
+Barcelona Calendar,SPORTS,4.4,670,3.1M,10000,Free,0,Everyone,Sports
+"Barca News - FC Barcelona, World Foot & Transfers",SPORTS,4.8,160,6.4M,10000,Free,0,Everyone,Sports
+FC Bayern Munich,SPORTS,4.6,37140,71M,1000000,Free,0,Everyone,Sports
+FC BARCELONA EVENTS,SPORTS,4.3,6,11M,100,Free,0,Everyone,Sports
+Cambridge English FC,FAMILY,4.4,761,11M,50000,Free,0,Everyone,Education
+Barcelona Live - Goal Score & News for Barca Fans,SPORTS,4.4,38,2.6M,10000,Free,0,Everyone,Sports
+Seattle Sounders FC,SPORTS,3.3,974,33M,10000,Free,0,Everyone,Sports
+FCB Connect - FC Barcelona,SOCIAL,4.5,795,21M,50000,Free,0,Teen,Social
+1. FC Köln App,SPORTS,4.6,2019,41M,100000,Free,0,Everyone,Sports
+File Commander - File Manager/Explorer,BUSINESS,4.3,758590,12M,100000000,Free,0,Everyone,Business
+FC Porto,SPORTS,4.9,15883,21M,100000,Free,0,Everyone,Sports
+Fulham FC,SPORTS,4.3,401,2.8M,10000,Free,0,Everyone,Sports
+Barcelona FC Noticias Live,NEWS_AND_MAGAZINES,4.1,2,3.6M,500,Free,0,Everyone,News & Magazines
+Chelsea FC Official Keyboard,PRODUCTIVITY,4.5,91397,14M,1000000,Free,0,Everyone,Productivity
+Burnley FC,SPORTS,4.9,195,29M,5000,Free,0,Everyone,Sports
+Atlanta United FC,SPORTS,3.7,215,76M,10000,Free,0,Everyone,Sports
+Barcelona Wallpaper HD,PERSONALIZATION,4.5,93,5.7M,10000,Free,0,Everyone,Personalization
+Sydney FC Official App,SPORTS,4.6,57,17M,5000,Free,0,Everyone,Sports
+Birmingham City FC,SPORTS,4.5,191,28M,10000,Free,0,Everyone,Sports
+FC Browser - Focus Privacy Browser,COMMUNICATION,4.1,26,4.6M,1000,Free,0,Everyone,Communication
+My AEK - Official ΑΕΚ FC app,SPORTS,4.8,3346,Varies with device,50000,Free,0,Everyone,Sports
+FC Parking,MAPS_AND_NAVIGATION,4.1,0,19M,500,Free,0,Everyone,Maps & Navigation
+Noticias FC Barcelona,NEWS_AND_MAGAZINES,5.0,4,3.1M,100,Free,0,Everyone,News & Magazines
+Toronto FC,SPORTS,3.4,144,79M,10000,Free,0,Teen,Sports
+Middlesbrough FC Official,SPORTS,4.5,152,36M,10000,Free,0,Everyone,Sports
+The 5th Stand,SPORTS,4.8,1697,17M,100000,Free,0,Everyone,Sports
+Galaxian(FC),GAME,4.5,2,7.8M,100,Paid,$1.99,Everyone,Arcade
+FC Red Bull Salzburg App,SPORTS,4.5,1526,89M,50000,Free,0,Everyone,Sports
+FC Zenit official Android app,SPORTS,4.5,5675,49M,100000,Free,0,Everyone,Sports
+Fan App for Portsmouth FC,SPORTS,4.5,53,12M,1000,Free,0,Teen,Sports
+Latest Barcelona News 24h,NEWS_AND_MAGAZINES,4.5,104,3.0M,10000,Free,0,Everyone,News & Magazines
+Mobile FC,SPORTS,4.1,5015,57M,100000,Free,0,Everyone,Sports
+"FirstCry Baby & Kids Shopping, Fashion & Parenting",SHOPPING,4.1,41074,16M,5000000,Free,0,Everyone,Shopping
+Fan App for Reading FC,SPORTS,3.6,9,13M,500,Free,0,Teen,Sports
+Deportivo Toluca FC,SPORTS,4.7,2317,5.9M,50000,Free,0,Everyone,Sports
+Underdog FC,SPORTS,4.6,216,40M,10000,Free,0,Everyone,Sports
+Las Vegas Lights FC,SPORTS,4.9,10,14M,500,Free,0,Everyone,Sports
+APOEL FC,SPORTS,4.6,688,Varies with device,10000,Free,0,Everyone,Sports
+FD Shift Calendar Widget,TOOLS,4.1,981,73k,100000,Free,0,Everyone,Tools
+Bank FD Interest Calculator,FINANCE,4.5,166,3.5M,10000,Free,0,Everyone,Finance
+FD VR Video Player - (Stored),FAMILY,3.9,751,17M,100000,Free,0,Everyone,Entertainment
+FD Mobile,FAMILY,3.9,53,7.9M,5000,Free,0,Everyone,Entertainment
+Formula DRIFT,SPORTS,4.6,169,19M,10000,Free,0,Everyone,Sports
+FD VR - Virtual 3D Web Browser,FAMILY,3.8,729,30M,100000,Free,0,Everyone,Entertainment
+FD Community FCU Mobile,FINANCE,4.7,175,12M,1000,Free,0,Everyone,Finance
+Female Daily,BEAUTY,3.9,4354,42M,100000,Free,0,Teen,Beauty
+FD VR - Virtual App Launcher,LIBRARIES_AND_DEMO,4.1,1463,7.4M,100000,Free,0,Everyone,Libraries & Demo
+FD VR Player - for 360 Youtube,FAMILY,3.9,100,9.1M,10000,Free,0,Everyone,Entertainment
+FD VR Store -VR Games and Apps,FAMILY,4.0,105,7.5M,10000,Free,0,Everyone,Simulation
+Policy And FD Manager,FINANCE,4.3,20,4.8M,500,Free,0,Everyone,Finance
+FD VR - Virtual Reality Camera,FAMILY,4.0,1007,7.4M,100000,Free,0,Everyone,Entertainment
+Sports Lite,SPORTS,4.4,16,4.9M,1000,Free,0,Everyone,Sports
+FD VR Theater - for Youtube VR,FAMILY,4.1,4585,9.1M,1000000,Free,0,Everyone,Entertainment
+Story Time FD,FAMILY,5.0,2,4.2M,10,Free,0,Everyone 10+,Simulation
+FD Calculator | Term Deposit | Fixed Deposit,FINANCE,4.8,12,2.7M,1000,Free,0,Everyone,Finance
+FD CANNECT,TOOLS,4.0,1,75M,1,Free,0,Everyone,Tools
+Financial Calculator India,FINANCE,4.6,13819,3.9M,1000000,Free,0,Everyone,Finance
+"FD Calculator (EMI, SIP, RD & Loan Eligilibility)",FINANCE,5.0,104,2.3M,1000,Free,0,Everyone,Finance
+FD VR Cardboard Featured 360 Videos,FAMILY,4.2,76,35M,10000,Free,0,Everyone,Entertainment
+"EMI, FD, RD - Bank Calculator",FINANCE,4.7,42,3.5M,5000,Free,0,Everyone,Finance
+FD VR Player - for Youtube 3D,FAMILY,4.0,2378,9.1M,500000,Free,0,Everyone,Entertainment
+RD/FD Calculator,FINANCE,4.4,92,1.5M,10000,Free,0,Everyone,Finance
+FD VR Music Videos - MTV Pop and Rap in 360,FAMILY,4.9,15,26M,1000,Free,0,Everyone,Entertainment
+FD VR - Virtual Photo Gallery,FAMILY,3.5,179,7.4M,10000,Free,0,Everyone,Entertainment
+Fix Deposit Calculator (FD),FINANCE,4.1,7,2.1M,1000,Free,0,Everyone,Finance
+FD Interest Calculator,FINANCE,4.2,17,4.7M,5000,Free,0,Everyone,Finance
+Deposit Calculator FD & RD,FINANCE,4.4,18,3.4M,10000,Free,0,Everyone,Finance
+FD Fotografia,PHOTOGRAPHY,4.2,2,4.2M,100,Free,0,Everyone,Photography
+Banking Calculator,FINANCE,4.5,3704,4.6M,100000,Free,0,Everyone,Finance
+FD e-paper,NEWS_AND_MAGAZINES,3.1,183,7.1M,10000,Free,0,Everyone,News & Magazines
+FD Fitness,HEALTH_AND_FITNESS,4.3,3,21M,50,Free,0,Everyone,Health & Fitness
+EMI/FD/RD/PV/IRR/BEP/EOQ Calc,FINANCE,4.5,58,2.7M,10000,Free,0,Everyone,Finance
+EMI Calculator | FD Calculator | RD calculator,FINANCE,4.6,106,4.4M,10000,Free,0,Everyone,Finance
+LineStar for FanDuel,SPORTS,4.3,1539,14M,50000,Free,0,Teen,Sports
+HD Video Download for Facebook,VIDEO_PLAYERS,4.4,20755,17M,1000000,Free,0,Everyone,Video Players & Editors
+Fire Emblem Heroes,FAMILY,4.6,407694,Varies with device,5000000,Free,0,Teen,Simulation
+Santa Fe FCU Mobile Banking,FINANCE,4.3,12,9.0M,1000,Free,0,Everyone,Finance
+FE Connect,TOOLS,4.8,24,4.5M,5000,Free,0,Everyone,Tools
+FE Civil Engineering Exam Prep,FAMILY,2.8,9,21M,1000,Free,0,Everyone,Education
+FE CREDIT - TET VUI,FINANCE,4.1,125,15M,50000,Free,0,Everyone,Finance
+FE Mechanical Engineering Prep,FAMILY,1.0,2,21M,1000,Free,0,Everyone,Education
+FE Mobile,BUSINESS,3.0,2,8.0M,10,Free,0,Everyone,Business
+Comunidad De Fe Minitries,LIFESTYLE,5.0,19,11M,500,Free,0,Everyone,Lifestyle
+Garena Free Fire,GAME,4.5,5534114,53M,100000000,Free,0,Teen,Action
+FE Other Disciplines Engineering Exam Prep,FAMILY,4.2,0,21M,100,Free,0,Everyone,Education
+FE EN ACCIÓN RADIO,FAMILY,4.2,1,2.9M,10,Free,0,Everyone,Entertainment
+FE Electric & Comp Engineering,FAMILY,4.2,2,20M,500,Free,0,Everyone,Education
+Caprock Santa Fe Credit Union,FINANCE,4.1,0,2.9M,100,Free,0,Everyone,Finance
+FE Chemical Engineering Exam Prep,FAMILY,4.2,2,20M,100,Free,0,Everyone,Education
+Santa Fe Map and Walks,TRAVEL_AND_LOCAL,4.1,2,47M,1000,Free,0,Everyone,Travel & Local
+FE IP,TOOLS,4.0,3,12M,1000,Free,0,Everyone,Tools
+Safe Santa Fe,FAMILY,5.0,2,12M,1000,Free,0,Everyone,Education
+Santa Fe New Mexican e-Edition,NEWS_AND_MAGAZINES,4.1,25,17M,1000,Free,0,Everyone,News & Magazines
+L!FE Premium Training,HEALTH_AND_FITNESS,4.3,2,10M,100,Free,0,Everyone,Health & Fitness
+Theme for Galaxy Note FE Launcher | Live Wallpaper,PERSONALIZATION,4.3,2,26M,100,Free,0,Everyone,Personalization
+Theme for Galaxy Note FE,PERSONALIZATION,4.3,3,9.2M,100,Free,0,Everyone,Personalization
+Note FE Theme And Launcher For Samsung Galaxy,PERSONALIZATION,4.4,7,9.8M,1000,Free,0,Everyone,Personalization
+FE CPS,FINANCE,3.0,62,17M,10000,Free,0,Everyone,Finance
+La Fe de Jesus,BOOKS_AND_REFERENCE,4.3,8,658k,1000,Free,0,Everyone,Books & Reference
+Santa Fe Indian Market,FAMILY,3.8,4,30M,500,Free,0,Everyone,Entertainment
+FE Connect Fhoton,TOOLS,4.0,0,1.8M,100,Free,0,Everyone,Tools
+Repair Hyundai Santa Fe,AUTO_AND_VEHICLES,3.9,22,97M,1000,Free,0,Everyone,Auto & Vehicles
+La Fe de Jesús,BOOKS_AND_REFERENCE,4.3,10,2.9M,500,Free,0,Everyone,Books & Reference
+Santa Fe Espresso & News,FOOD_AND_DRINK,4.2,0,15M,10,Free,0,Everyone,Food & Drink
+Santa Fe Sentry,HOUSE_AND_HOME,4.2,0,5.3M,100,Free,0,Everyone,House & Home
+Santa Fe Thrive,HEALTH_AND_FITNESS,5.0,2,8.3M,50,Free,0,Everyone,Health & Fitness
+FE Connect Drive-Tech,BUSINESS,4.1,0,20M,100,Free,0,Everyone,Business
+FE Mix - Jokes - Status - Wallpaper,FAMILY,4.2,3,3.0M,1000,Free,0,Everyone,Entertainment
+Frases Cristianas de Esperanza y Fe,SOCIAL,4.3,2,5.6M,100,Free,0,Everyone,Social
+Theme for Samsung Galaxy Note FE,PERSONALIZATION,4.5,52,7.9M,10000,Free,0,Everyone,Personalization
+Santa Fe VIP Tours,TRAVEL_AND_LOCAL,4.1,1,22M,100,Free,0,Everyone,Travel & Local
+Santa Fe App,SPORTS,4.2,196,5.0M,5000,Free,0,Everyone,Sports
+Curso Básico y Avanzado la Fe de Jesús Audio-Texto,FAMILY,4.2,0,11M,10,Free,0,Everyone 10+,Education
+Ríos de Fe,LIFESTYLE,5.0,141,15M,1000,Free,0,Everyone,Lifestyle
+Theme For Galaxy Note FE,PERSONALIZATION,4.3,0,7.5M,100,Free,0,Everyone,Personalization
+Le Fe de Jesus,BOOKS_AND_REFERENCE,4.3,3,4.1M,500,Free,0,Everyone,Books & Reference
+FG Mobile,FAMILY,3.3,130,13M,5000,Free,0,Everyone,Education
+FG Wallet,FINANCE,4.1,9,12M,1000,Free,0,Everyone,Finance
+Burn Your Fat With Me! FG,HEALTH_AND_FITNESS,4.5,38487,60M,1000000,Free,0,Teen,Health & Fitness
+FG On-The-Go,TOOLS,4.9,55,25M,1000,Free,0,Everyone,Tools
+FG Autumn Photo Puzzle,FAMILY,4.2,0,4.6M,10,Free,0,Everyone,Puzzle
+Radio FG Paris Underground,FAMILY,4.2,3,1.7M,100,Free,0,Teen,Entertainment
+FG Radio - Radios de France,FAMILY,4.2,0,6.5M,10,Free,0,Everyone,Entertainment
+FG SPINNER,GAME,4.3,2,36M,10,Free,0,Everyone,Board
+FG Finder,TOOLS,4.0,154,17M,10000,Free,0,Everyone,Tools
+FG. Chic - House Lounge Musique - Radios de France,FAMILY,4.2,1,6.5M,50,Free,0,Everyone,Entertainment
+BROTHER IN WARS: GUNNER CITY WARLORDS,GAME,4.3,8649,39M,1000000,Free,0,Teen,Action
+Angry Birds Space HD,GAME,4.5,43645,46M,5000000,Free,0,Everyone,Arcade
+Survival Prison Escape v2: Free Action Game,FAMILY,4.1,44027,52M,5000000,Free,0,Mature 17+,Strategy
+FG VOC,BUSINESS,4.8,6,7.7M,1000,Free,0,Everyone,Business
+Police Car Driver,GAME,3.8,83671,30M,10000000,Free,0,Everyone 10+,Racing
+Modern Sniper Strike: Best Commando Action 2k18,GAME,4.1,164,17M,10000,Free,0,Everyone,Action
+Moto Fighter 3D,GAME,3.9,85410,39M,10000000,Free,0,Everyone 10+,Racing
+FG Rockstar,FAMILY,4.2,1,30M,10,Free,0,Everyone,Education
+BMX Boy,GAME,4.2,839206,12M,50000000,Free,0,Everyone,Racing
+Crazy Bike attack Racing New: motorcycle racing,GAME,4.2,20364,45M,5000000,Free,0,Everyone,Racing
+POLARIS 2MFG,FAMILY,4.8,1228,29M,10000,Free,0,Everyone,Education
+Gun Disassembly 2,FAMILY,4.1,26347,48M,1000000,Free,0,Everyone 10+,Entertainment
+Fields of Battle,GAME,4.1,71476,50M,1000000,Free,0,Everyone 10+,Action
+Family Guy The Quest for Stuff,GAME,4.0,995002,Varies with device,10000000,Free,0,Mature 17+,Adventure
+Ambulance Simulator 3D,FAMILY,3.9,29415,66M,1000000,Free,0,Mature 17+,Simulation
+Leghe Fantagazzetta,SPORTS,4.1,79464,27M,1000000,Free,0,Everyone,Sports
+Police Car Driving Sim,FAMILY,4.1,72522,51M,10000000,Free,0,Everyone,Simulation
+Toy Attack,GAME,4.2,3878,69M,500000,Free,0,Everyone,Action
+Field Goal Tournament,SPORTS,3.7,2980,21M,100000,Free,0,Everyone,Sports
+Ghost In Photo,PHOTOGRAPHY,3.9,28429,14M,5000000,Free,0,Teen,Photography
+Disney Princess Palace Pets,FAMILY,3.9,60097,19M,1000000,Free,0,Everyone,Entertainment;Pretend Play
+Police VAZ LADA Simulator,FAMILY,3.6,3502,61M,500000,Free,0,Teen,Simulation
+Scary Video Maker,FAMILY,3.7,9296,28M,500000,Free,0,Teen,Entertainment
+SnowMobile Parking Adventure,GAME,3.6,12257,49M,1000000,Free,0,Everyone,Racing
+PBS KIDS Games,FAMILY,4.3,12919,94M,1000000,Free,0,Everyone,Educational;Education
+Zombie Sniper 3D III,GAME,3.9,8122,23M,500000,Free,0,Mature 17+,Action
+Family Guy- Another Freakin' Mobile Game,FAMILY,4.5,221691,94M,5000000,Free,0,Teen,Puzzle
+FH WiFiCam,PHOTOGRAPHY,2.6,201,2.5M,10000,Free,0,Everyone,Photography
+HD Themes Volvo FH Trucks,PERSONALIZATION,4.4,40,13M,5000,Free,0,Teen,Personalization
+Familial Hypercholesterolaemia,MEDICAL,4.2,0,34M,10,Free,0,Everyone,Medical
+Familial Hypercholesterolaemia Handbook,MEDICAL,1.0,2,33M,100,Free,0,Everyone,Medical
+Themes Volvo FH 16 Trucks,PERSONALIZATION,4.3,38,16M,10000,Free,0,Teen,Personalization
+FH Calculator,HEALTH_AND_FITNESS,4.3,9,992k,500,Free,0,Everyone,Health & Fitness
+Top Themes Volvo FH Trucks,PERSONALIZATION,4.3,9,18M,1000,Free,0,Teen,Personalization
+Top Puzzles Volvo FH Trucks,FAMILY,4.2,4,8.1M,500,Free,0,Teen,Puzzle
+Wallpapers Volvo FH 16 Trucks,PERSONALIZATION,4.2,13,15M,1000,Free,0,Teen,Personalization
+Puzzles Volvo FH 16 Trucks,FAMILY,4.8,10,8.2M,1000,Free,0,Teen,Puzzle
+Jigsaw Volvo FH 16 Trucks,FAMILY,5.0,5,8.1M,1000,Free,0,Teen,Puzzle
+Shoot Hunter-Gun Killer,GAME,4.3,320334,27M,50000000,Free,0,Teen,Action
+studentsLife by FH Kärnten,FAMILY,4.4,108,Varies with device,5000,Free,0,Everyone,Education
+FH® Cost Lookup / FH® CCSalud,MEDICAL,4.5,30,4.1M,1000,Free,0,Everyone,Medical
+FH Kufstein App,FAMILY,4.2,9,20M,500,Free,0,Everyone,Education
+FH App,BUSINESS,4.9,27,6.0M,100,Free,0,Everyone,Business
+HD Wallpapers Volvo FH Trucks,PERSONALIZATION,4.3,4,17M,500,Free,0,Teen,Personalization
+Jigsaw Puzzles Volvo FH Truck Game,FAMILY,4.2,4,4.7M,100,Free,0,Teen,Puzzle
+Themes Volvo FH Trucks,PERSONALIZATION,4.3,14,14M,1000,Free,0,Teen,Personalization
+FH School,FAMILY,5.0,4,5.8M,100,Free,0,Everyone,Education
+FH Wallet,FINANCE,4.1,0,9.9M,1,Free,0,Everyone,Finance
+FH Dortmund FB4,FAMILY,4.2,40,9.9M,1000,Free,0,Everyone,Education
+Fast Motorcycle Driver 2016,GAME,4.2,28151,49M,1000000,Free,0,Everyone 10+,Racing
+Wallpapers Volvo FH Truck,PERSONALIZATION,4.2,4,14M,100,Free,0,Teen,Personalization
+HD Jigsaw Volvo FH Trucks,FAMILY,4.2,2,7.6M,500,Free,0,Teen,Puzzle
+Jigsaw Puzzles Volvo FH Trucks,FAMILY,4.2,3,7.8M,1000,Free,0,Teen,Puzzle
+Angry Shark 2016,FAMILY,4.0,73185,46M,5000000,Free,0,Teen,Simulation
+First Hawaiian Bank Mobile,FINANCE,2.1,232,29M,10000,Free,0,Everyone,Finance
+FH CODE,TOOLS,4.0,13,3.6M,100,Free,0,Everyone,Tools
+Strike! Ten Pin Bowling,SPORTS,4.2,18584,49M,5000000,Free,0,Everyone,Sports
+IKORO FH App Rosenheim,FAMILY,4.2,22,29M,1000,Free,0,Everyone,Education
+My Truck,TOOLS,2.5,247,8.2M,10000,Free,0,Everyone,Tools
+Talking Tom Bubble Shooter,FAMILY,4.4,687136,54M,50000000,Free,0,Everyone,Casual
+Forgotten Hill: Fall,GAME,4.4,1063,18M,50000,Free,0,Teen,Adventure
+Forgotten Hill Mementoes,GAME,4.6,2027,56M,100000,Free,0,Teen,Adventure
+EHiN-FH conferenceapp,COMMUNICATION,4.2,5,26M,100,Free,0,Everyone,Communication
+BTK-FH Online Campus,FAMILY,4.2,1,3.3M,500,Free,0,Everyone,Education
+Talking Husky Dog,FAMILY,4.4,26545,40M,1000000,Free,0,Everyone,Casual
+Bubble Bird Rescue,FAMILY,4.2,70753,14M,5000000,Free,0,Everyone,Puzzle
+Forgotten Hill: Surgery,GAME,4.5,2431,24M,100000,Free,0,Teen,Adventure
+Real Airplane Flight Simulator: Pilot Games,FAMILY,3.3,21735,37M,1000000,Free,0,Everyone,Simulation
+Dolphin and fish coloring book,FAMILY,3.9,2249,Varies with device,500000,Free,0,Everyone,Art & Design;Creativity
+Carpooling FH Hagenberg,COMMUNICATION,4.2,0,Varies with device,100,Free,0,Everyone,Communication
+Forgotten Hill: Puppeteer,GAME,4.5,2917,22M,100000,Free,0,Teen,Adventure
+Airplane Fly Hawaii,FAMILY,4.1,83427,16M,1000000,Free,0,Everyone,Simulation
+FiSwitch,TOOLS,4.8,615,2.0M,10000,Paid,$1.99,Everyone,Tools
+Signal Info,TOOLS,4.6,424,3.5M,10000,Free,0,Everyone,Tools
+Signal Spy - Monitor Signal Strength & Data Usage,TOOLS,4.4,875,8.5M,100000,Free,0,Everyone,Tools
+Wi-Fi Auto-connect,COMMUNICATION,3.8,15036,253k,1000000,Free,0,Everyone,Communication
+Smart Wi-Fi Hotspot PRO,COMMUNICATION,3.7,197,957k,10000,Paid,$2.99,Everyone,Communication
+"Talkie - Wi-Fi Calling, Chats, File Sharing",COMMUNICATION,4.2,4838,Varies with device,500000,Free,0,Everyone,Communication
+Portable Wi-Fi hotspot Premium,COMMUNICATION,3.7,481,420k,10000,Paid,$0.99,Everyone,Communication
+Avast Wi-Fi Finder,PRODUCTIVITY,4.3,37277,13M,1000000,Free,0,Everyone,Productivity
+Police Field Interview FI Card,PRODUCTIVITY,4.5,112,2.4M,1000,Paid,$7.99,Everyone,Productivity
+LG Hi-Fi Plus Manager,TOOLS,3.5,154,3.4M,10000,Free,0,Everyone,Tools
+WeFi - Free Fast WiFi Connect & Find Wi-Fi Map,COMMUNICATION,4.0,13469,5.1M,1000000,Free,0,Everyone,Communication
+"Talkie Pro - Wi-Fi Calling, Chats, File Sharing",COMMUNICATION,4.5,201,Varies with device,1000,Paid,$2.99,Everyone,Communication
+Safe Wi-Fi,PRODUCTIVITY,2.9,32,9.7M,1000,Free,0,Everyone,Productivity
+[root] Pry-Fi,TOOLS,3.9,6736,72k,500000,Free,0,Everyone,Tools
+Sat-Fi,COMMUNICATION,3.6,97,Varies with device,5000,Free,0,Everyone,Communication
+WiFi Monitor Pro - analyzer of Wi-Fi networks,TOOLS,4.6,85,2.4M,1000,Paid,$2.99,Everyone,Tools
+Candy simply-Fi,LIFESTYLE,2.1,2390,35M,100000,Free,0,Everyone,Lifestyle
+SCI-FI UI,FAMILY,4.7,15,3.9M,100,Paid,$1.99,Everyone,Entertainment
+Wi-Fi Rabbit Unlock Key,TOOLS,4.5,142,26k,5000,Paid,$1.00,Everyone,Tools
+Wi-Fi settings shortcut,TOOLS,4.1,479,29k,50000,Free,0,Everyone,Tools
+Wi-Fi Master,TOOLS,4.5,3673,5.8M,500000,Free,0,Everyone,Tools
+Micro Fi,FAMILY,3.7,39,2.8M,5000,Free,0,Everyone,Education
+fi,FAMILY,2.9,691,5.8M,100000,Free,0,Everyone,Strategy
+Portable Wi-Fi hotspot Free,COMMUNICATION,4.0,1711,2.1M,100000,Free,0,Everyone,Communication
+Wi-Fi Networks,PRODUCTIVITY,4.2,115,1.4M,10000,Free,0,Everyone,Productivity
+FI CFL,FINANCE,3.7,112,3.9M,10000,Free,0,Everyone,Finance
+Tassa.fi Finland,LIFESTYLE,3.6,346,7.5M,50000,Free,0,Everyone,Lifestyle
+TownWiFi | Wi-Fi Everywhere,COMMUNICATION,3.9,2372,58M,500000,Free,0,Everyone,Communication
+Jazz Wi-Fi,COMMUNICATION,3.4,49,4.0M,10000,Free,0,Everyone,Communication
+Xposed Wi-Fi-Pwd,PERSONALIZATION,3.5,1042,404k,100000,Free,0,Everyone,Personalization
+osmino Wi-Fi: free WiFi,TOOLS,4.2,134203,4.1M,10000000,Free,0,Everyone,Tools
+Sat-Fi Voice,COMMUNICATION,3.4,37,14M,1000,Free,0,Everyone,Communication
+Wi-Fi Visualizer,TOOLS,3.9,132,2.6M,50000,Free,0,Everyone,Tools
+Lennox iComfort Wi-Fi,LIFESTYLE,3.0,552,7.6M,50000,Free,0,Everyone,Lifestyle
+Sci-Fi Sounds and Ringtones,PERSONALIZATION,3.6,128,11M,10000,Free,0,Everyone,Personalization
+Sci Fi Sounds,FAMILY,3.2,4,8.0M,1000,Free,0,Everyone,Entertainment
+Free Wi-fi HotspoT,COMMUNICATION,4.1,382,2.3M,50000,Free,0,Everyone,Communication
+FJ 4x4 Cruiser Offroad Driving,FAMILY,4.1,3543,49M,500000,Free,0,Everyone,Simulation
+FJ 4x4 Cruiser Snow Driving,FAMILY,4.2,1619,43M,500000,Free,0,Everyone,Simulation
+Wallpapers Toyota FJ Cruiser,PERSONALIZATION,4.2,78,10M,10000,Free,0,Everyone,Personalization
+New Wallpapers Toyota FJ Cruiser Theme,PERSONALIZATION,4.3,1,16M,100,Free,0,Teen,Personalization
+"FJ Final Join , Circles Game",GAME,4.7,32,24M,1000,Free,0,Teen,Arcade
+HD Wallpaper - Toyota FJ Cruiser,TOOLS,4.0,2,6.2M,100,Free,0,Everyone,Tools
+FJ Drive: Mercedes-Benz Lease,AUTO_AND_VEHICLES,4.6,107,27M,10000,Free,0,Everyone,Auto & Vehicles
+Driving n Parking School 2017,FAMILY,4.5,15,46M,1000,Free,0,Everyone,Simulation
+FJ WiFi HDD,TOOLS,4.0,40,2.4M,5000,Free,0,Everyone,Tools
+Offroad Cruiser,FAMILY,4.3,42432,36M,1000000,Free,0,Everyone,Simulation
+HD Themes Toyota Cruiser 70,PERSONALIZATION,4.5,86,17M,10000,Free,0,Teen,Personalization
+Toyota Cruisers & Trucks Mag,TRAVEL_AND_LOCAL,4.5,10,8.0M,500,Free,0,Everyone,Travel & Local
+4 x4 Offroad SUV 3D Truck Simulator Driving 2017,FAMILY,4.4,32,37M,1000,Free,0,Everyone,Simulation
+Cake Shop - Kids Cooking,FAMILY,4.3,30668,33M,5000000,Free,0,Everyone,Casual;Pretend Play
+HD Themes Toyota Cruiser 60,PERSONALIZATION,4.3,0,15M,100,Free,0,Teen,Personalization
+HD Themes Toyota Cruiser70,PERSONALIZATION,4.3,0,15M,100,Free,0,Teen,Personalization
+HD Themes Toyota Cruiser 80,PERSONALIZATION,4.3,2,13M,100,Free,0,Teen,Personalization
+HD Themes Toyota Cruiser 50,PERSONALIZATION,4.3,1,11M,50,Free,0,Teen,Personalization
+OFF-ROAD SIMULATOR 4x4 : REAL,FAMILY,4.2,109,25M,10000,Free,0,Everyone,Simulation
+HD Themes Toyota Cruiser 100VX,PERSONALIZATION,4.3,2,16M,100,Free,0,Teen,Personalization
+HD Themes Toyota Cruiser 200,PERSONALIZATION,3.7,3,15M,100,Free,0,Teen,Personalization
+HD Themes Toyota Cruiser 40,PERSONALIZATION,4.3,2,15M,100,Free,0,Teen,Personalization
+Fun Kid Racing - Motocross,FAMILY,4.1,59768,Varies with device,10000000,Free,0,Everyone,Racing;Action & Adventure
+Offroad 4x4 Car Driving,FAMILY,4.3,26224,43M,1000000,Free,0,Everyone,Simulation
+Motocross Beach Jumping 3D,FAMILY,4.0,105954,43M,10000000,Free,0,Teen,Simulation
+Offroad drive : 4x4 driving game,GAME,3.5,2071,36M,100000,Free,0,Everyone,Racing
+Hair saloon - Spa salon,FAMILY,4.2,38473,23M,10000000,Free,0,Everyone,Casual;Pretend Play
+Rope Hero: Vice Town,GAME,4.4,452589,99M,10000000,Free,0,Mature 17+,Action
+Drive 4x4 Luxury SUV Jeep,GAME,4.2,2183,46M,500000,Free,0,Everyone,Racing
+PIP Selfie Camera Photo Editor,PHOTOGRAPHY,4.4,156322,Varies with device,10000000,Free,0,Everyone,Photography
+FJ-link,TOOLS,4.0,1,20M,10,Free,0,Everyone,Tools
+Motocross Mayhem,GAME,3.8,35171,45M,1000000,Free,0,Everyone,Racing
+Funny Jokes,FAMILY,3.9,2505,2.9M,100000,Free,0,Mature 17+,Entertainment
+Flight Simulator: Fly Plane 3D,FAMILY,4.0,660613,21M,50000000,Free,0,Everyone,Simulation
+Motocross Fun Simulator,FAMILY,3.8,22570,35M,1000000,Free,0,Everyone,Simulation
+Dino Defends king 3 – Dinosaur T rex Hunter Games,GAME,3.6,182,41M,50000,Free,0,Teen,Adventure
+Fast Notes FJ,PRODUCTIVITY,4.2,12,2.2M,500,Free,0,Everyone,Productivity
+FJ Toolkit,TOOLS,4.0,1,2.5M,100,Paid,$1.49,Everyone,Tools
+Block Gun 3D: Haunted Hollow,GAME,3.8,16282,35M,1000000,Free,0,Teen,Action
+Art of F J Taylor,VIDEO_PLAYERS,4.1,2,1.5M,10,Free,0,Everyone,Video Players & Editors
+Driving Suv Toyota Car Simulator,FAMILY,3.7,187,54M,10000,Free,0,Everyone,Simulation
+Navy Gunner Shoot War 3D,GAME,4.0,103199,44M,10000000,Free,0,Teen,Action
+Drift Legends,GAME,4.2,33788,27M,1000000,Free,0,Everyone,Racing
+FK,MEDICAL,4.4,1517,8.5M,100000,Free,0,Everyone,Medical
+FK (FlightKid),GAME,4.3,2,22M,10,Free,0,Everyone,Action
+FK Sūduva Marijampolė,SPORTS,4.2,2,26M,10,Free,0,Everyone,Sports
+Fairy Kingdom: World of Magic and Farming,FAMILY,4.4,129542,63M,1000000,Free,0,Everyone,Strategy;Creativity
+FK Željezničar,SPORTS,4.9,1420,20M,10000,Free,0,Everyone,Sports
+FK Oleksandria,SPORTS,4.2,0,26M,10,Free,0,Everyone,Sports
+FK CLASSIC FOR YOU,BUSINESS,5.0,1,3.5M,10,Free,0,Everyone,Business
+FK Sileks,SPORTS,4.2,0,26M,1,Free,0,Everyone,Sports
+Kernel Manager for Franco Kernel ✨,TOOLS,4.8,12700,10M,100000,Paid,$3.49,Everyone,Tools
+Qarabağ FK,SPORTS,4.2,9,5.5M,100,Free,0,Everyone,Sports
+FK Sloboda Tuzla,SPORTS,4.2,0,26M,10,Free,0,Everyone,Sports
+FK Jelgava,SPORTS,4.2,0,26M,5,Free,0,Everyone,Sports
+FK Vojvodina,SPORTS,4.2,5,26M,50,Free,0,Everyone,Sports
+FK Liepaja,SPORTS,4.2,4,26M,100,Free,0,Everyone,Sports
+FK Teplice,SPORTS,4.2,2,26M,50,Free,0,Everyone,Sports
+FK Sarajevo,SPORTS,4.2,6,26M,100,Free,0,Everyone,Sports
+FK Vardar,SPORTS,4.2,2,26M,10,Free,0,Everyone,Sports
+Ray Financial Calculator Pro,FINANCE,4.0,67,2.4M,10000,Paid,$2.99,Everyone,Finance
+FK Bregalnica Štip,SPORTS,4.2,0,26M,1,Free,0,Everyone,Sports
+FK Mladost Lucani,SPORTS,4.2,0,26M,5,Free,0,Everyone,Sports
+FK Radnicki Nis,SPORTS,4.2,1,26M,50,Free,0,Everyone,Sports
+FK Dukla Prague,SPORTS,4.2,0,26M,10,Free,0,Everyone,Sports
+FK Rad,SPORTS,4.2,1,26M,10,Free,0,Everyone,Sports
+FK Jablonec,SPORTS,4.2,2,26M,50,Free,0,Everyone,Sports
+FK Senica,SPORTS,4.2,0,13M,10,Free,0,Everyone,Sports
+FK Vozdovac,SPORTS,4.2,1,26M,10,Free,0,Everyone,Sports
+Toy Truck Rally 3D,GAME,4.0,301895,25M,50000000,Free,0,Everyone,Racing
+FK Mladá Boleslav,SPORTS,4.2,0,26M,10,Free,0,Everyone,Sports
+FK Macva Sabac,SPORTS,4.2,3,26M,10,Free,0,Everyone,Sports
+FK Crvena zvezda,SPORTS,4.9,1211,15M,10000,Free,0,Everyone,Sports
+FK Events,PRODUCTIVITY,4.2,0,18M,5,Free,0,Teen,Productivity
+PRO MX MOTOCROSS 2,GAME,3.8,25275,21M,5000000,Free,0,Everyone,Racing
+FK Jonava,SPORTS,4.2,1,26M,5,Free,0,Everyone,Sports
+FK Željezničar Izzy,FAMILY,4.9,119,17M,1000,Free,0,Everyone,Entertainment
+FK Čukarički,SPORTS,4.2,0,26M,10,Free,0,Everyone,Sports
+Austria Wien FK - Fussball - Inoffizielle App,SPORTS,4.2,2,12M,100,Free,0,Everyone,Sports
+FK Železiarne Podbrezová,SPORTS,4.2,0,26M,5,Free,0,Everyone,Sports
+FK Viktoria Žižkov,SPORTS,4.2,0,26M,10,Free,0,Everyone,Sports
+FK Zemun,SPORTS,4.2,3,26M,10,Free,0,Everyone,Sports
+FK Atlantas,SPORTS,1.5,2,26M,5,Free,0,Everyone,Sports
+FK Spartak Subotica,SPORTS,4.2,0,26M,10,Free,0,Everyone,Sports
+FK Dedinje BGD,SPORTS,5.0,36,2.6M,100,Free,0,Everyone,Sports
+FK Fotbal Třinec,SPORTS,4.2,0,27M,10,Free,0,Everyone,Sports
+FK Crvena Zvezda Izzy,TOOLS,4.8,1456,15M,50000,Free,0,Everyone,Tools
+FK Utenis Utena,SPORTS,4.2,0,26M,5,Free,0,Everyone,Sports
+Crazy Freekick,SPORTS,3.9,47688,17M,5000000,Free,0,Everyone,Sports
+FL State Parks Guide,TRAVEL_AND_LOCAL,3.7,871,45M,100000,Free,0,Everyone,Travel & Local
+FL SW Fishing Regulations,SPORTS,4.6,60,24M,1000,Paid,$1.99,Everyone,Sports
+Permit Test FL Florida DHSMV,FAMILY,4.7,246,11M,10000,Free,0,Everyone,Education
+FL Lottery Results,FAMILY,4.6,1481,3.1M,50000,Free,0,Teen,Entertainment
+Florida DMV Permit Test -Fl,FAMILY,4.3,87,30M,10000,Free,0,Everyone,Education
+Lottery Results: Florida,FAMILY,4.2,582,3.2M,100000,Free,0,Teen,Entertainment
+Scratch-Off Guide for FL Lotto,FAMILY,4.6,25,5.6M,5000,Free,0,Everyone,Entertainment
+"Charlotte County, FL",PRODUCTIVITY,4.7,10,7.1M,1000,Free,0,Everyone,Productivity
+Results for FL Lottery,NEWS_AND_MAGAZINES,4.6,146,7.1M,10000,Free,0,Everyone,News & Magazines
+Check Lottery Tickets - Florida,FAMILY,2.0,27,31M,5000,Free,0,Teen,Entertainment
+Fish|Hunt FL,LIFESTYLE,3.6,853,34M,100000,Free,0,Everyone,Lifestyle
+Florida 511,TOOLS,3.2,148,9.2M,50000,Free,0,Everyone,Tools
+Florida Storms,WEATHER,3.8,116,36M,10000,Free,0,Everyone,Weather
+FL Racing Manager 2018 Lite,SPORTS,4.0,1338,15M,100000,Free,0,Everyone,Sports
+Florida Tides & Weather,WEATHER,3.8,30,2.0M,1000,Paid,$6.99,Everyone,Weather
+FL Tax-Verify,BUSINESS,3.8,17,6.1M,5000,Free,0,Everyone,Business
+FL House,PRODUCTIVITY,4.4,29,Varies with device,1000,Free,0,Everyone,Productivity
+FL Racing Manager 2015 Pro,SPORTS,4.4,656,22M,5000,Paid,$0.99,Everyone,Sports
+Lottery Driver- Florida Result,FAMILY,4.4,70,4.4M,5000,Free,0,Teen,Entertainment
+Florida Travel Guide,TRAVEL_AND_LOCAL,3.8,11,86M,1000,Free,0,Everyone,Travel & Local
+The Florida Trail Guide,TRAVEL_AND_LOCAL,4.3,100,13M,5000,Free,0,Everyone,Travel & Local
+Florida - Pocket Brainbook,BOOKS_AND_REFERENCE,4.6,7,12M,1000,Free,0,Everyone,Books & Reference
+Lottery Ticket Checker - Florida Results & Lotto,TOOLS,1.0,3,41M,500,Free,0,Everyone,Tools
+Florida Statutes (FL Code),BOOKS_AND_REFERENCE,3.2,5,8.2M,1000,Free,0,Everyone,Books & Reference
+Discovery Church Florida,LIFESTYLE,4.7,40,8.0M,1000,Free,0,Teen,Lifestyle
+FL Racing Manager 2018 Pro,SPORTS,4.3,340,15M,5000,Paid,$1.99,Everyone,Sports
+Florida Driver License Test,FAMILY,4.5,65,470k,5000,Free,0,Everyone,Education
+Free Florida DMV Test 2018,FAMILY,4.1,665,5.3M,50000,Free,0,Everyone,Education
+Canvas FL,FAMILY,4.9,36,9.4M,1000,Free,0,Teen,Education
+Florida Lottery Results,NEWS_AND_MAGAZINES,4.1,763,2.2M,100000,Free,0,Everyone,News & Magazines
+Florida Cooling Supply HVAC,PRODUCTIVITY,4.2,6,43M,500,Free,0,Everyone,Productivity
+Restaurant Inspections - FL,HEALTH_AND_FITNESS,3.5,143,226k,10000,Free,0,Everyone,Health & Fitness
+Florida Keys,TRAVEL_AND_LOCAL,4.2,92,20M,10000,Free,0,Everyone,Travel & Local
+South Florida AA Meetings,LIFESTYLE,5.0,10,21M,1000,Free,0,Everyone,Lifestyle
+Florida Travel Guide - TOURIAS,TRAVEL_AND_LOCAL,3.8,80,37M,10000,Free,0,Everyone,Travel & Local
+Florida State Gameday,SPORTS,4.7,1566,26M,50000,Free,0,Everyone,Sports
+FL Bankers,EVENTS,4.4,0,3.4M,10,Free,0,Everyone,Events
+Fort Myers FL,PRODUCTIVITY,4.2,0,22M,100,Free,0,Everyone,Productivity
+"News-Journal-Daytona Beach, FL",NEWS_AND_MAGAZINES,4.5,76,7.8M,5000,Free,0,Everyone,News & Magazines
+Florida map,TRAVEL_AND_LOCAL,4.1,11,3.4M,5000,Free,0,Everyone,Travel & Local
+"Trinity Church Deltona, FL",LIFESTYLE,5.0,33,28M,500,Free,0,Everyone,Lifestyle
+FL Drone 2,PHOTOGRAPHY,3.3,41,7.8M,5000,Free,0,Everyone,Photography
+"Beacon Baptist Jupiter, FL",LIFESTYLE,5.0,14,2.6M,100,Free,0,Everyone,Lifestyle
+"Clearwater, FL - weather and more",WEATHER,4.2,0,3.9M,10,Free,0,Everyone,Weather
+University of Florida,FAMILY,4.0,168,7.6M,10000,Free,0,Everyone,Education
+"Ocala Star Banner, FL",NEWS_AND_MAGAZINES,4.5,75,8.1M,5000,Free,0,Everyone,News & Magazines
+Alachua County Sheriff FL,LIFESTYLE,3.2,5,9.5M,100,Free,0,Everyone,Lifestyle
+Lotto Results - Mega Millions Powerball Lottery US,NEWS_AND_MAGAZINES,4.5,14221,1.8M,1000000,Free,0,Teen,News & Magazines
+Jax Sheriff (FL),LIFESTYLE,4.2,53,16M,5000,Free,0,Everyone,Lifestyle
+Results for FL Lottery (Florida),FAMILY,4.2,1,3.2M,100,Free,0,Mature 17+,Entertainment
+Hidden Object Florida Vacation Adventure Fun Game,FAMILY,3.7,126,45M,10000,Free,0,Everyone,Casual
+WFLA News Channel 8 - Tampa FL,NEWS_AND_MAGAZINES,3.8,133,14M,10000,Free,0,Everyone,News & Magazines
+Florida Beach Wallpapers HD,TRAVEL_AND_LOCAL,5.0,3,12M,100,Free,0,Everyone,Travel & Local
+MY GULFPORT FL,PRODUCTIVITY,4.2,0,49M,50,Free,0,Everyone,Productivity
+My MLS App,LIFESTYLE,4.1,1213,13M,100000,Free,0,Everyone,Lifestyle
+Employ Florida Mobile,BUSINESS,2.9,97,9.9M,10000,Free,0,Everyone,Business
+"St. Petersburg, FL - weather and more",WEATHER,4.2,0,3.9M,10,Free,0,Everyone,Weather
+LifePoint Church - FL,LIFESTYLE,4.1,1,7.6M,50,Free,0,Everyone,Lifestyle
+WSVN • South Florida's Source for Weather,WEATHER,4.2,7,28M,1000,Free,0,Everyone,Weather
+PriorityONE Credit Union of Fl,FINANCE,4.7,178,12M,1000,Free,0,Everyone,Finance
+Florida Wildflowers,FAMILY,5.0,5,69M,1000,Free,0,Everyone,Education
+Florida Blue,HEALTH_AND_FITNESS,3.2,499,34M,100000,Free,0,Everyone,Health & Fitness
+ORLANDO FLORIDA MAP,TRAVEL_AND_LOCAL,4.1,3,9.2M,1000,Free,0,Everyone,Travel & Local
+Florida Tech Mobile,FAMILY,3.8,87,5.4M,5000,Free,0,Everyone,Education
+Florida Offline Road Map,TRAVEL_AND_LOCAL,3.8,144,8.7M,10000,Free,0,Everyone,Travel & Local
+Florida Map offline,TRAVEL_AND_LOCAL,4.6,8,18M,1000,Free,0,Everyone,Travel & Local
+"The Ledger - Lakeland, Florida",NEWS_AND_MAGAZINES,4.6,89,5.7M,5000,Free,0,Everyone,News & Magazines
+FRONTLINE COMMANDO,GAME,4.4,1351833,12M,10000000,Free,0,Teen,Action
+Gainesville Florida Police Department,LIFESTYLE,4.8,4,15M,500,Free,0,Everyone,Lifestyle
+Gainesville Bus Tracker,MAPS_AND_NAVIGATION,4.2,63,1.6M,10000,Free,0,Everyone,Maps & Navigation
+Florida Today,NEWS_AND_MAGAZINES,3.3,202,38M,10000,Free,0,Everyone 10+,News & Magazines
+Florida HSMV Driver License,FAMILY,3.9,14,11M,1000,Free,0,Everyone,Education
+WSVN - 7 News Miami,NEWS_AND_MAGAZINES,4.5,3320,14M,100000,Free,0,Everyone,News & Magazines
+WICShopper,SHOPPING,3.9,3023,Varies with device,500000,Free,0,Everyone,Shopping
+First Federal Bank of Florida,FINANCE,4.3,133,30M,10000,Free,0,Everyone,Finance
+South Florida MLS,LIFESTYLE,4.4,133,13M,10000,Free,0,Everyone,Lifestyle
+Football Manager Mobile 2018,SPORTS,3.9,11460,Varies with device,100000,Paid,$8.99,Everyone,Sports
+Podcast App: Free & Offline Podcasts by Player FM,NEWS_AND_MAGAZINES,4.6,66407,19M,1000000,Free,0,Teen,News & Magazines
+Motorola FM Radio,VIDEO_PLAYERS,3.9,54815,Varies with device,100000000,Free,0,Everyone,Video Players & Editors
+FN Cam,PHOTOGRAPHY,3.4,181,10M,10000,Free,0,Everyone,Photography
+How it Works: FN SCAR assault rifle,FAMILY,4.6,44,45M,10000,Free,0,Everyone,Casual
+FN pistol Model 1906 explained,BOOKS_AND_REFERENCE,4.3,1,5.3M,10,Paid,$5.49,Everyone,Books & Reference
+FN pistol model 1903 explained,BOOKS_AND_REFERENCE,4.3,1,19M,10,Paid,$6.49,Everyone,Books & Reference
+FutureNet your social app,SOCIAL,4.2,2093,7.0M,100000,Free,0,Teen,Social
+Jigsaw Puzzles FN FAL Light Automatic Rifle,FAMILY,4.2,0,5.6M,50,Free,0,Teen,Puzzle
+Wallpapers FN Herstal FNP 9,PERSONALIZATION,4.3,0,11M,1,Free,0,Teen,Personalization
+Ninja FN Button,FAMILY,4.8,12,12M,1000,Free,0,Teen,Entertainment
+Wallpapers FN SCAR H,PERSONALIZATION,5.0,4,9.2M,100,Free,0,Teen,Personalization
+Wallpapers FN F2000,PERSONALIZATION,4.3,0,11M,5,Free,0,Teen,Personalization
+Wallpapers FN Five seven,PERSONALIZATION,4.3,0,13M,10,Free,0,Teen,Personalization
+FN,BUSINESS,5.0,14,3.3M,50,Free,0,Everyone,Business
+Wallpapers FN FAL Light Automatic Rifle,PERSONALIZATION,4.3,0,14M,10,Free,0,Teen,Personalization
+"The FN ""Baby"" pistol explained",BOOKS_AND_REFERENCE,4.3,1,8.8M,10,Paid,$5.99,Everyone,Books & Reference
+FN FAL rifle explained,BOOKS_AND_REFERENCE,4.3,1,7.3M,10,Paid,$6.49,Everyone,Books & Reference
+F N Bail Bonds,LIFESTYLE,3.8,4,14M,500,Free,0,Everyone,Lifestyle
+The FN HP pistol explained,BOOKS_AND_REFERENCE,4.3,1,8.5M,10,Paid,$6.49,Everyone,Books & Reference
+SB · FN 1870 Mobile Banking,FINANCE,2.9,139,3.3M,10000,Free,0,Everyone,Finance
+PIP-Camera FN Photo Effect,PHOTOGRAPHY,4.6,8,9.0M,1000,Free,0,Everyone,Photography
+Bullet - FN Theme,PERSONALIZATION,3.8,143,240k,5000,Free,0,Everyone,Personalization
+FN model 1900 pistol explained,BOOKS_AND_REFERENCE,4.3,0,8.2M,10,Paid,$6.49,Everyone,Books & Reference
+Pistolet FN GP35 expliqué,BOOKS_AND_REFERENCE,4.3,2,7.9M,5,Paid,$5.99,Everyone,Books & Reference
+FN Web Radio,COMMUNICATION,4.2,0,1.6M,10,Free,0,Everyone,Communication
+Gun Builder ELITE,GAME,4.1,88941,34M,1000000,Free,0,Teen,Action
+FNH Payment Info,COMMUNICATION,4.2,0,2.1M,10,Free,0,Everyone,Communication
+Magnum 3.0 Gun Custom SImulator,GAME,4.5,16815,59M,1000000,Free,0,Teen,Action
+Pistolet FN 1906 expliqué,BOOKS_AND_REFERENCE,4.3,0,5.2M,10,Paid,$5.49,Everyone,Books & Reference
+Circle Colors Pack-FN Theme,PERSONALIZATION,4.2,6,89k,50,Paid,$0.99,Everyone,Personalization
+Calculator Fn,TOOLS,4.0,9,3.6M,500,Free,0,Everyone,Tools
+Pint - FN Theme,PERSONALIZATION,2.5,6,234k,100,Free,0,Everyone,Personalization
+HAL-9000 - FN Theme,PERSONALIZATION,3.5,159,257k,10000,Free,0,Everyone,Personalization
+Solitaire+,GAME,4.6,11235,Varies with device,100000,Paid,$2.99,Everyone,Card
+Fresh News,NEWS_AND_MAGAZINES,4.4,2207,9.8M,100000,Free,0,Everyone,News & Magazines
+Future Cloud,PRODUCTIVITY,4.6,1075,Varies with device,100000,Free,0,Everyone,Productivity
+Fruit Ninja Classic,GAME,4.3,85468,36M,1000000,Paid,$0.99,Everyone,Arcade
+Hunting Safari 3D,SPORTS,4.2,36183,20M,5000000,Free,0,Teen,Sports
+Gun Club Armory,GAME,4.2,55014,28M,1000000,Free,0,Teen,Action
+Ethical Hacking,FAMILY,4.1,128,3.2M,10000,Free,0,Everyone,Education
+Armed Cam Gun Pack,GAME,4.2,1012,50M,10000,Free,0,Teen,Action
+Zombie Defense,FAMILY,4.3,275048,41M,10000000,Free,0,Teen,Strategy
+Fo File Manager,TOOLS,4.5,1916,364k,100000,Free,0,Everyone,Tools
+Alarm.fo – choose your info,SOCIAL,4.4,19,3.1M,1000,Free,0,Everyone,Social
+FO Bixby,PERSONALIZATION,5.0,5,861k,100,Paid,$0.99,Everyone,Personalization
+Pin-fo,FAMILY,4.6,19,1.6M,500,Free,0,Everyone,Entertainment
+MARKET FO,COMMUNICATION,4.2,0,15M,100,Free,0,Everyone,Communication
+FO OP St-Nazaire,COMMUNICATION,4.2,1,17M,100,Free,0,Everyone,Communication
+FO SODEXO,COMMUNICATION,4.2,0,16M,100,Free,0,Everyone,Communication
+FO RCBT,COMMUNICATION,4.2,5,15M,100,Free,0,Everyone,Communication
+FO Interim,COMMUNICATION,4.2,1,11M,100,Free,0,Everyone,Communication
+Mu.F.O.,GAME,5.0,2,16M,1,Paid,$0.99,Everyone,Arcade
+FO PSA Sept-Fons,COMMUNICATION,4.2,2,15M,100,Free,0,Everyone,Communication
+FO BOULANGER,FINANCE,4.1,10,19M,50,Free,0,Everyone,Finance
+FO AIRBUS TLSE,COMMUNICATION,4.2,4,16M,1000,Free,0,Everyone,Communication
+F-O-Meter,FAMILY,4.2,0,2.8M,1,Free,0,Mature 17+,Entertainment
+Theme fo Oppo A30 Wallpaper & Icon,BUSINESS,4.1,7,1.3M,500,Free,0,Everyone,Business
+Fo Fo Fish,GAME,3.4,5,21M,50,Free,0,Everyone,Arcade
+FO STELIA Méaulte,COMMUNICATION,4.2,2,18M,100,Free,0,Everyone,Communication
+RRIMS FO,BUSINESS,4.1,2,5.2M,100,Free,0,Everyone,Business
+Neon Blue Gaming Wallpaper&Theme fo Lenovo K8 Note,BUSINESS,4.6,7,2.0M,500,Free,0,Everyone,Business
+Photo Editor Collage Maker Pro,PHOTOGRAPHY,4.5,1519671,Varies with device,100000000,Free,0,Everyone,Photography
+Custos F.O.,BUSINESS,4.1,0,9.7M,1,Free,0,Everyone,Business
+FO AIRBUS Nantes,COMMUNICATION,4.2,0,17M,100,Free,0,Everyone,Communication
+Stylish Fonts,PERSONALIZATION,3.8,153176,4.3M,10000000,Free,0,Everyone,Personalization
+4x4 Jeep Racer,GAME,4.1,7279,54M,1000000,Free,0,Everyone,Racing
+Lalafo Pulsuz Elanlar,SHOPPING,4.4,61392,Varies with device,1000000,Free,0,Everyone,Shopping
+My Earthquake Alerts - US & Worldwide Earthquakes,WEATHER,4.4,3471,Varies with device,100000,Free,0,Everyone,Weather
+FunForMobile Ringtones & Chat,SOCIAL,4.4,68358,7.2M,5000000,Free,0,Mature 17+,Social
+FarmersOnly Dating,DATING,3.0,1145,1.4M,100000,Free,0,Mature 17+,Dating
+Free Slideshow Maker & Video Editor,PHOTOGRAPHY,4.2,162564,11M,10000000,Free,0,Everyone,Photography
+Frontline Terrorist Battle Shoot: Free FPS Shooter,GAME,4.2,9183,49M,1000000,Free,0,Mature 17+,Action
+BankNordik,FINANCE,3.9,28,15M,5000,Free,0,Everyone,Finance
+Sona - Nær við allastaðni,LIFESTYLE,4.2,31,25M,1000,Free,0,Everyone,Lifestyle
+Firefox Focus: The privacy browser,COMMUNICATION,4.4,36981,4.0M,1000000,Free,0,Everyone,Communication
+Mad Dash Fo' Cash,GAME,5.0,14,16M,100,Free,0,Everyone,Arcade
+Launcher Theme for LG K10 2018,PERSONALIZATION,4.0,649,11M,100000,Free,0,Everyone,Personalization
+Mobile Kick,SPORTS,4.3,111809,40M,10000000,Free,0,Everyone,Sports
+English To Shona Dictionary,BOOKS_AND_REFERENCE,4.6,60,3.7M,10000,Free,0,Everyone,Books & Reference
+Posta App,MAPS_AND_NAVIGATION,3.6,8,Varies with device,1000,Free,0,Everyone,Maps & Navigation
+Thumbnail Maker,PHOTOGRAPHY,4.4,26252,24M,1000000,Free,0,Everyone,Photography
+Fon WiFi App – WiFi Connect,TOOLS,4.1,222,16M,50000,Free,0,Everyone,Tools
+MOD-MASTER for Minecraft PE (Pocket Edition) Free,TOOLS,4.2,271908,8.1M,10000000,Free,0,Everyone,Tools
+MX Player Codec (ARMv7),LIBRARIES_AND_DEMO,4.3,332083,6.3M,10000000,Free,0,Everyone,Libraries & Demo
+FP Notebook,MEDICAL,4.5,410,60M,50000,Free,0,Everyone,Medical
+FeaturePoints: Free Gift Cards,FAMILY,3.9,121321,46M,5000000,Free,0,Everyone,Entertainment
+Draw with FP sDraw,TOOLS,4.3,3268,467k,100000,Free,0,Everyone,Tools
+FP Click sound changer,PERSONALIZATION,3.5,178,1.4M,10000,Free,0,Everyone,Personalization
+FP Connect,COMMUNICATION,4.2,0,22M,100,Free,0,Teen,Communication
+FP VoiceBot,FAMILY,4.2,17,157k,100,Paid,$0.99,Mature 17+,Entertainment
+FP-safe,BUSINESS,4.1,0,2.6M,100,Free,0,Everyone,Business
+FP Legacy,MAPS_AND_NAVIGATION,4.0,3,44M,1000,Free,0,Everyone,Maps & Navigation
+Race Manager FP,GAME,3.8,196,11M,5000,Free,0,Everyone,Racing
+FreedomPop Messaging Phone/SIM,COMMUNICATION,3.6,9894,39M,500000,Free,0,Everyone,Communication
+PhotoFunia,PHOTOGRAPHY,4.3,316378,4.4M,10000000,Free,0,Everyone,Photography
+Fingerprint Quick Action,TOOLS,4.2,8484,1.7M,1000000,Free,0,Everyone,Tools
+GKPB FP Online Church,LIFESTYLE,5.0,32,7.9M,1000,Free,0,Everyone,Lifestyle
+FP BW LCD View,FAMILY,3.4,16,1.2M,500,Free,0,Everyone,Entertainment
+FP Markets,FINANCE,4.1,1,2.0M,100,Free,0,Everyone,Finance
+FP Boss,FINANCE,4.1,1,5.8M,1,Free,0,Everyone,Finance
+FP Opgaver,TOOLS,4.0,9,61M,1000,Free,0,Everyone,Tools
+FP Charging Daydream,PERSONALIZATION,3.5,96,3.8M,5000,Free,0,Everyone,Personalization
+FP Live,COMMUNICATION,4.2,0,3.3M,10,Free,0,Teen,Communication
+FP Runner,GAME,3.7,38,29M,1000,Free,0,Everyone,Arcade
+Finger Scanner Gestures,TOOLS,4.2,2531,3.3M,100000,Free,0,Everyone,Tools
+FP Market,FAMILY,4.2,24,44k,1000,Free,0,Everyone,Education
+FP FCU,FINANCE,3.6,48,26M,5000,Free,0,Everyone,Finance
+Slickdeals: Coupons & Shopping,SHOPPING,4.5,33599,12M,1000000,Free,0,Everyone,Shopping
+SCM FPS Status,BUSINESS,4.2,123,3.3M,10000,Free,0,Everyone,Business
+Hondata Mobile,MAPS_AND_NAVIGATION,4.3,334,676k,10000,Free,0,Everyone,Maps & Navigation
+FreedomPop Friends for Free Data,TOOLS,4.4,58,2.5M,5000,Free,0,Everyone,Tools
+Fisher-Price® Smart Connect™,TOOLS,2.7,422,72M,50000,Free,0,Everyone,Tools
+Fingerprint Lock Screen Prank,TOOLS,4.1,10786,4.3M,1000000,Free,0,Everyone,Tools
+FP NFC Rewrite,TOOLS,4.0,17,67k,1000,Free,0,Everyone,Tools
+Fast Tract Diet,HEALTH_AND_FITNESS,4.4,35,2.4M,1000,Paid,$7.99,Everyone,Health & Fitness
+Greek Bible FP (Audio),BOOKS_AND_REFERENCE,4.3,5,8.0M,1000,Free,0,Everyone,Books & Reference
+The FP Shield,NEWS_AND_MAGAZINES,4.1,0,11M,10,Free,0,Everyone,News & Magazines
+FP Разбитый дисплей,FAMILY,4.5,922,552k,50000,Free,0,Everyone,Entertainment
+FP Transportation,AUTO_AND_VEHICLES,4.2,1,885k,1,Free,0,Everyone,Auto & Vehicles
+Chat For Strangers - Video Chat,SOCIAL,3.4,622,Varies with device,100000,Free,0,Mature 17+,Social
+FreedomPop Diagnostics,TOOLS,2.9,452,7.0M,100000,Free,0,Everyone,Tools
+NFP 2018,EVENTS,4.8,8,16M,500,Free,0,Everyone,Events
+AAFP,MEDICAL,3.8,63,24M,10000,Free,0,Everyone,Medical
+FQ Magazine,LIFESTYLE,4.1,1,12M,100,Free,0,Everyone,Lifestyle
+Modern Counter Terrorist FPS Shoot,GAME,4.0,795,41M,100000,Free,0,Teen,Action
+FQ METER,PRODUCTIVITY,3.9,17,2.4M,1000,Free,0,Everyone,Productivity
+FQ Load Board for Transporters,BUSINESS,4.1,0,3.9M,100,Free,0,Everyone,Business
+FQ India,LIFESTYLE,4.1,0,8.9M,10,Free,0,Everyone,Lifestyle
+Miss FQ,NEWS_AND_MAGAZINES,4.1,0,36M,10,Free,0,Everyone,News & Magazines
+FQ - Football Quiz,SPORTS,4.2,1,9.0M,1,Free,0,Everyone,Sports
+Monster Ride Pro,GAME,5.0,1,24M,10,Free,0,Everyone,Racing
+BEBONCOOL GAMEPAD V1.0,GAME,3.9,404,2.2M,100000,Free,0,Everyone,Arcade
+Union League,FAMILY,4.0,939,38M,10000,Free,0,Everyone,Role Playing
+Fortune Quest: Savior,FAMILY,3.6,135,75M,10000,Free,0,Everyone 10+,Role Playing
+Modern Counter 3: FPS Multiplayers battlegro 3,FAMILY,4.1,17,50M,1000,Free,0,Everyone,Strategy
+Modern Strike Online,GAME,4.3,834117,44M,10000000,Free,0,Teen,Action
+Trine 2: Complete Story,GAME,3.8,252,11M,10000,Paid,$16.99,Teen,Action
+Modern Counter Terror Attack – Shooting Game,GAME,4.2,340,72M,50000,Free,0,Mature 17+,Action
+Big Hunter,GAME,4.3,245455,84M,10000000,Free,0,Everyone 10+,Action
+"sugar, sugar",FAMILY,4.2,1405,9.5M,10000,Paid,$1.20,Everyone,Puzzle
+ChopAssistant,TOOLS,4.2,455,2.8M,50000,Free,0,Everyone,Tools
+Modern Counter Global Strike 3D,GAME,4.1,297,48M,50000,Free,0,Teen,Action
+Fountain Live Wallpaper HD – Dubai Wallpaper 3D,PERSONALIZATION,4.3,1,20M,500,Free,0,Everyone,Personalization
+Modern Counter Global Strike 3D V2,GAME,4.0,368,48M,50000,Free,0,Everyone 10+,Action
+HipChat - beta version,COMMUNICATION,4.1,1035,20M,50000,Free,0,Everyone,Communication
+Winter Wonderland,GAME,4.0,1287,38M,50000,Free,0,Everyone,Word
+Soccer Clubs Logo Quiz,GAME,4.2,21661,16M,1000000,Free,0,Everyone,Trivia
+Sid Story,GAME,4.4,28510,78M,500000,Free,0,Teen,Card
+PopStar,FAMILY,4.2,13,5.7M,1000,Free,0,Everyone,Casual
+Reindeer VPN - Proxy VPN,TOOLS,4.2,7339,4.0M,100000,Free,0,Everyone,Tools
+Inf VPN - Global Proxy & Unlimited Free WIFI VPN,TOOLS,4.7,61445,7.8M,1000000,Free,0,Everyone,Tools
+Fuel Rewards® program,LIFESTYLE,4.6,32433,46M,1000000,Free,0,Everyone,Lifestyle
+Word Search Tab 1 FR,FAMILY,4.2,0,1020k,50,Paid,$1.04,Everyone,Puzzle
+Fr Daoud Lamei,SOCIAL,4.7,2036,6.8M,100000,Free,0,Everyone,Social
+FR Roster,TOOLS,4.1,174,12M,5000,Free,0,Everyone,Tools
+Fr Ignacio Outreach,FAMILY,4.9,52,19M,1000,Free,0,Everyone,Education
+FR: My Famous Lover,FAMILY,4.0,185,28M,10000,Free,0,Teen,Entertainment
+Fatal Raid - No.1 Mobile FPS,GAME,4.3,56496,81M,1000000,Free,0,Teen,Action
+Poker Pro.Fr,GAME,4.2,5442,17M,100000,Free,0,Teen,Card
+Scoreboard FR,LIFESTYLE,4.3,3,15M,100,Free,0,Everyone,Lifestyle
+SnakeBite911 FR,MEDICAL,4.2,1,42M,500,Free,0,Everyone,Medical
+My FR App,TOOLS,4.0,2,4.2M,100,Free,0,Everyone,Tools
+lesparticuliers.fr,LIFESTYLE,4.1,96,1.0M,50000,Free,0,Everyone,Lifestyle
+Castle Clash: RPG War and Strategy FR,FAMILY,4.7,376223,24M,1000000,Free,0,Everyone,Strategy
+Fr Lupupa Sermons,BUSINESS,4.8,19,21M,100,Free,0,Everyone,Business
+FR Plus 1.6,AUTO_AND_VEHICLES,4.2,4,3.9M,100,Free,0,Everyone,Auto & Vehicles
+Fr Agnel Pune,FAMILY,4.1,80,13M,1000,Free,0,Everyone,Education
+DICT.fr Mobile,BUSINESS,4.1,20,2.7M,10000,Free,0,Everyone,Business
+FR: My Secret Pets! ,FAMILY,4.0,785,31M,50000,Free,0,Teen,Entertainment
+Golden Dictionary (FR-AR),BOOKS_AND_REFERENCE,4.2,5775,4.9M,500000,Free,0,Everyone,Books & Reference
+FieldBi FR Offline,BUSINESS,4.1,2,6.8M,100,Free,0,Everyone,Business
+HTC Sense Input - FR,TOOLS,4.0,885,8.0M,100000,Free,0,Everyone,Tools
+Gold Quote - Gold.fr,FINANCE,4.1,96,1.5M,10000,Free,0,Everyone,Finance
+Fanfic-FR,BOOKS_AND_REFERENCE,3.3,52,3.6M,5000,Free,0,Teen,Books & Reference
+Fr. Daoud Lamei,FAMILY,5.0,22,8.6M,1000,Free,0,Teen,Education
+Poop FR,FAMILY,4.2,6,2.5M,50,Free,0,Everyone,Entertainment
+PLMGSS FR,PRODUCTIVITY,4.2,0,3.1M,10,Free,0,Everyone,Productivity
+List iptv FR,VIDEO_PLAYERS,4.1,1,2.9M,100,Free,0,Everyone,Video Players & Editors
+Cardio-FR,MEDICAL,4.2,67,82M,10000,Free,0,Everyone,Medical
+Naruto & Boruto FR,SOCIAL,4.3,7,7.7M,100,Free,0,Teen,Social
+Frim: get new friends on local chat rooms,SOCIAL,4.0,88486,Varies with device,5000000,Free,0,Mature 17+,Social
+Fr Agnel Ambarnath,FAMILY,4.2,117,13M,5000,Free,0,Everyone,Education
+Manga-FR - Anime Vostfr,COMICS,3.4,291,13M,10000,Free,0,Everyone,Comics
+Bulgarian French Dictionary Fr,BOOKS_AND_REFERENCE,4.6,603,7.4M,10000,Free,0,Everyone,Books & Reference
+News Minecraft.fr,NEWS_AND_MAGAZINES,3.8,881,2.3M,100000,Free,0,Everyone,News & Magazines
+payermonstationnement.fr,MAPS_AND_NAVIGATION,4.1,38,9.8M,5000,Free,0,Everyone,Maps & Navigation
+FR Tides,WEATHER,3.8,1195,582k,100000,Free,0,Everyone,Weather
+Chemin (fr),BOOKS_AND_REFERENCE,4.8,44,619k,1000,Free,0,Everyone,Books & Reference
+FR Calculator,FAMILY,4.0,7,2.6M,500,Free,0,Everyone,Education
+FR Forms,BUSINESS,4.1,0,9.6M,10,Free,0,Everyone,Business
+Sya9a Maroc - FR,FAMILY,4.5,38,53M,5000,Free,0,Everyone,Education
+Fr. Mike Schmitz Audio Teachings,FAMILY,5.0,4,3.6M,100,Free,0,Everyone,Education
+Parkinson Exercices FR,MEDICAL,4.2,3,9.5M,1000,Free,0,Everyone,Medical
+The SCP Foundation DB fr nn5n,BOOKS_AND_REFERENCE,4.5,114,Varies with device,1000,Free,0,Mature 17+,Books & Reference
+iHoroscope - 2018 Daily Horoscope & Astrology,LIFESTYLE,4.5,398307,19M,10000000,Free,0,Everyone,Lifestyle

--- a/src/preprocess_data/preprocess_data.py
+++ b/src/preprocess_data/preprocess_data.py
@@ -1,0 +1,84 @@
+import pandas as pd
+import os
+
+def clean_and_save_data():
+    """
+    Clean the Google Play Store dataset by applying necessary transformations 
+    and saving the cleaned data to a CSV file.
+
+    This function:
+    - Reads the raw dataset from the specified path.
+    - Removes rows with ratings greater than 5.
+    - Fills missing ratings with the mean of their respective categories.
+    - Drops the columns 'Current Ver', 'Last Updated', and 'Android Ver'.
+    - Imputes missing values in the 'Type' column based on the 'Price' column.
+    - Converts the 'Installs' column to a numeric format (removing commas and plus signs).
+    - Rounds the 'Rating' column to 1 decimal place.
+    - Saves the cleaned dataset to a CSV file in the 'preprocessed' directory.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    FileNotFoundError
+        If the input raw data file does not exist at the specified path.
+    
+    FileExistsError
+        If the output directory cannot be created.
+
+    Notes
+    -----
+    The cleaned data is saved as "clean_data.csv" in the relative path:
+    "../../data/preprocessed". The 'preprocessed' directory will be created
+    if it does not already exist.
+
+    Example
+    -------
+    To clean the data and save it:
+    
+    >>> clean_and_save_data()
+    Cleaned data saved to ../../data/preprocessed/clean_data.csv
+    """
+    
+    try:
+        df = pd.read_csv("../../data/raw/googleplaystore.csv")
+
+        df.drop(df[df['Rating'] > 5].index, inplace=True)
+        df.reset_index(drop=True, inplace=True)
+
+        category_means = df.groupby('Category')['Rating'].transform(lambda x: x.fillna(x.mean()))
+        df['Rating'] = df['Rating'].fillna(category_means)
+
+        df.drop(['Current Ver', 'Last Updated', 'Android Ver'], axis=1, inplace=True)
+
+        df['Type'] = df.apply(lambda row: 'Free' if row['Price'] == 0 else 'Paid' if pd.isna(row['Type']) else row['Type'], axis=1)
+
+        df['Installs'] = df['Installs'].str.replace(',', '').str.replace('+', '').astype(int)
+
+        df['Reviews'] = df['Reviews'].astype(int)
+
+        df['Rating'] = df['Rating'].round(1)
+
+        output_dir = "../../data/preprocessed"
+        os.makedirs(output_dir, exist_ok=True)
+
+        cleaned_file_path = os.path.join(output_dir, "clean_data.csv")
+        df.to_csv(cleaned_file_path, index=False)
+
+        print(f"Cleaned data saved to {cleaned_file_path}")
+
+    except FileNotFoundError:
+        print("Error: Raw data file not found at the specified path.")
+    except FileExistsError:
+        print("Error: Unable to create the output directory.")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+if __name__ == "__main__":
+    clean_and_save_data()


### PR DESCRIPTION
Cleaned the googleplaystore.csv data so that it can be used for visualization.
Did the following things:
- Removed rows with ratings greater than 5. (Only had a single row)
- Filled missing ratings with the mean of their respective categories.
- Dropped the columns 'Current Ver', 'Last Updated', and 'Android Ver'.
- Imputed missing values in the 'Type' column based on the 'Price' column.
- Converts the 'Installs' column to a numeric format (removing commas and plus signs).
- Rounds the 'Rating' column to 1 decimal place.

This pull request closes #13 issue.